### PR TITLE
Automatically configure `namespace` property for android library projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ slack {
 
 A major benefit of this is that we can intelligently configure features and avoid applying costly
 plugins like Kapt unless they're actually needed for a specific feature, such as Java injections in
-projects using Dagger. Since this is pure code, we can also propagate deprecated behavior by 
+projects using Dagger. Since this is pure code, we can also propagate deprecated behavior by
 deprecating the corresponding functions in the DSL.
 
 ### Platform plugins

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -689,42 +689,8 @@ public abstract class AndroidFeaturesHandler {
 }
 
 @SlackExtensionMarker
-public abstract class SlackAndroidLibraryExtension @Inject constructor(objects: ObjectFactory) {
-
-  internal val manifestHandler = objects.newInstance<ManifestHandler>()
-
-  public fun manifest(action: Action<ManifestHandler>) {
-    action.execute(manifestHandler)
-  }
-
-  /**
-   * Configures a generated manifest for a library project.
-   *
-   * Example:
-   * ```
-   * slack {
-   *   manifest {
-   *     packageName.set("slack.foo.blah")
-   *   }
-   * }
-   * ```
-   */
-  public abstract class ManifestHandler @Inject constructor(objects: ObjectFactory) {
-
-    internal val packageName = objects.property<String>()
-
-    /**
-     * Manifest package names are generated as an interpolation of the project path, but you can set
-     * this to hardcode one if need be.
-     *
-     * This can also be set via [SlackProperties.generatedManifestPackageName] in gradle.properties.
-     *
-     * Names will be normalized as needed to avoid keywords like "default", etc.
-     */
-    public fun packageName(name: String) {
-      packageName.set(name)
-    }
-  }
+public abstract class SlackAndroidLibraryExtension {
+  // Left as a toe-hold for the future
 }
 
 @SlackExtensionMarker

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
@@ -242,13 +242,13 @@ internal fun VersionCatalog.identifierMap(): Map<String, String> {
  * nesting.
  */
 internal fun tomlKey(key: String): String =
-  key.replace("-", "%").replace(".", "-").replace("%", ".").replace("_", ".").toCamel()
+  key.replace("-", "%").replace(".", "-").replace("%", ".").replace("_", ".").snakeToCamel()
 
-private fun String.toCamel(): String {
+internal fun String.snakeToCamel(upper: Boolean = false): String {
   return buildString {
-    var capNext = false
-    for (c in this@toCamel) {
-      if (c == '.' || c == '_') {
+    var capNext = upper
+    for (c in this@snakeToCamel) {
+      if (c == '_' || c == '-' || c == '.') {
         capNext = true
         continue
       } else {

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -87,10 +87,6 @@ public class SlackProperties private constructor(private val project: Project) {
   public val rakeNoApi: Boolean
     get() = booleanProperty("slack.gradle.config.rake.noapi")
 
-  /** Flag to indicate whether to compute a namespace for the given Android library project. */
-  public val computeAndroidNamespace: Boolean
-    get() = booleanProperty("slack.gradle.config.manifest.computeAndroidNamespace", true)
-
   /**
    * Flag to enable the Gradle Dependency Analysis Plugin, which is disabled by default due to
    * https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/204

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -87,9 +87,9 @@ public class SlackProperties private constructor(private val project: Project) {
   public val rakeNoApi: Boolean
     get() = booleanProperty("slack.gradle.config.rake.noapi")
 
-  /** Flag to indicate a generated manifest package name. */
-  public val generatedManifestPackageName: String?
-    get() = optionalStringProperty("slack.gradle.config.manifest.packageName")
+  /** Flag to indicate whether to compute a namespace for the given Android library project. */
+  public val computeAndroidNamespace: Boolean
+    get() = booleanProperty("slack.gradle.config.manifest.computeAndroidNamespace", true)
 
   /**
    * Flag to enable the Gradle Dependency Analysis Plugin, which is disabled by default due to

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -706,7 +706,8 @@ internal class StandardProjectConfigurations {
                   when (it) {
                     // Skip dashes and underscores. We could camelcase but it looks weird in a
                     // package name
-                    '-', '_' -> null
+                    '-',
+                    '_' -> null
                     // Use the project path as the real dot namespacing
                     ':' -> '.'
                     else -> it

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -701,8 +701,18 @@ internal class StandardProjectConfigurations {
             "slack" +
               project
                 .path
-                .snakeToCamel() // handles dashes and underscores in names
-                .replace(':', '.')
+                .asSequence()
+                .mapNotNull {
+                  when (it) {
+                    // Skip dashes and underscores. We could camelcase but it looks weird in a
+                    // package name
+                    '-', '_' -> null
+                    // Use the project path as the real dot namespacing
+                    ':' -> '.'
+                    else -> it
+                  }
+                }
+                .joinToString("")
         }
       }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -694,14 +694,16 @@ internal class StandardProjectConfigurations {
         }
         // We don't set targetSdkVersion in libraries since this is controlled by the app.
 
-        // Configure generated manifest
-        // TODO disabled because it seems that disabling android resources always results in
-        //  AndroidSourceSet.manifest.srcFile to exist for some reason
-        //        AutoManifest.configure(
-        //          project = project,
-        //          libraryExtension = this@configure,
-        //          handler = slackExtension.androidHandler.libraryHandler.manifestHandler
-        //        )
+        // TODO namespace is unfortunately not a property so we can't chain this. Would be nice if
+        //  it was.
+        if (slackProperties.computeAndroidNamespace) {
+          namespace =
+            "slack" +
+              project
+                .path
+                .snakeToCamel() // handles dashes and underscores in names
+                .replace(':', '.')
+        }
       }
 
       slackExtension.androidHandler.configureFeatures(project, slackProperties)


### PR DESCRIPTION
Should allow us to remove most of our `AndroidManifest.xml` files!