### PR TITLE
Unify thermals watching API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,18 @@ it to all projects in the consuming repo and reduce dependency version stratific
 
 ### Thermal throttling capture
 
-Macbooks can suffer thermal throttling and result in poor build performance. We built
+MacBooks can suffer thermal throttling and result in poor build performance. We built
 instrumentation for this to capture these and include them in our build scans to better understand
 their impact. We support both Intel and Apple Silicon macs now and contain this implementation in
-`ThermalsParser.kt`. This also includes helpful charting APIs for visualizing the data (courtesy
+`ThermalsWatcher.kt`. This also includes helpful charting APIs for visualizing the data (courtesy
 of our friends at Square).
 
 ### Better Properties
 
-Gradle's built-in property support is limited and has surprising behavior, so we have our own 
-system on top of it that has consistent precedence, `local.properties` support, local project 
-properties, and configuration caching support. Check out `safeProperty()` in `PropertyUtil.kt`.
+Gradle's built-in property support is limited and has surprising behavior, so we have our own
+system on top of it that has consistent precedence, `local.properties` support, project-local
+`gradle.properties`, and configuration caching support. Check out `safeProperty()` in
+`PropertyUtil.kt`.
 
 ### Dependency Rake
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
@@ -98,11 +98,12 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
   override fun close() {
     // Close thermals process and save off its current value
     thermalsAtClose = thermalsWatcher?.stop()
-    if (!parameters.offline.get()) {
-      thermalsAtClose?.let { thermalsReporter?.reportThermals(it) }
-    }
-    try {} catch (t: Throwable) {
-      logger.error("Failed to parse thermals", t)
+    try {
+      if (!parameters.offline.get()) {
+        thermalsAtClose?.let { thermalsReporter?.reportThermals(it) }
+      }
+    } catch (t: Throwable) {
+      logger.error("Failed to report thermals", t)
     } finally {
       if (okHttpClient.isInitialized()) {
         with(okHttpClient.value) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
@@ -68,6 +68,10 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
       return thermalsAtClose ?: peekThermals()
     }
 
+  init {
+    thermalsWatcher?.start()
+  }
+
   public fun registerExtension(extension: SlackToolsExtension) {
     val dependencies =
       object : SlackToolsDependencies {

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
@@ -15,13 +15,8 @@
  */
 package slack.gradle
 
-import io.reactivex.rxjava3.core.Observable
-import io.reactivex.rxjava3.disposables.Disposable
-import io.reactivex.rxjava3.subjects.BehaviorSubject
 import java.io.File
-import java.time.LocalDateTime
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit.SECONDS
 import javax.inject.Inject
 import kotlin.reflect.KClass
 import okhttp3.OkHttpClient
@@ -36,21 +31,11 @@ import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.services.BuildServiceRegistration
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.registerIfAbsent
-import slack.cli.AppleSiliconCompat
-import slack.cli.AppleSiliconCompat.Arch.ARM64
-import slack.cli.AppleSiliconCompat.Arch.X86_64
 import slack.gradle.SlackTools.Companion.SERVICE_NAME
 import slack.gradle.SlackTools.Parameters
 import slack.gradle.agp.AgpHandler
-import slack.gradle.util.AppleSiliconThermals
-import slack.gradle.util.AppleSiliconThermals.ThermalState.CRITICAL
-import slack.gradle.util.AppleSiliconThermals.ThermalState.FAIR
-import slack.gradle.util.AppleSiliconThermals.ThermalState.NOMINAL
-import slack.gradle.util.AppleSiliconThermals.ThermalState.SERIOUS
-import slack.gradle.util.ThermLog
 import slack.gradle.util.Thermals
-import slack.gradle.util.ThermalsData
-import slack.gradle.util.ThermalsParser
+import slack.gradle.util.ThermalsWatcher
 import slack.gradle.util.mapToBoolean
 
 /** Misc tools for Slack Gradle projects, usable in tasks as a [BuildService] too. */
@@ -64,16 +49,24 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
   // work for BuildService parameters
   public lateinit var globalConfig: GlobalConfig
 
-  public var thermalsReporter: ThermalsReporter? = null
-
   private val logger = Logging.getLogger("SlackTools")
   private val extensions = ConcurrentHashMap<KClass<out SlackToolsExtension>, SlackToolsExtension>()
 
   public lateinit var okHttpClient: Lazy<OkHttpClient>
 
+  private var thermalsReporter: ThermalsReporter? = null
   private val logThermals =
     OperatingSystem.current().isMacOsX &&
       providers.gradleProperty(SlackProperties.LOG_THERMALS).mapToBoolean().getOrElse(false)
+
+  private val thermalsWatcher = if (logThermals) ThermalsWatcher(::thermalsFile) else null
+  private var thermalsAtClose: Thermals? = null
+
+  /** Returns the current or latest captured thermals log. */
+  public val thermals: Thermals?
+    get() {
+      return thermalsAtClose ?: peekThermals()
+    }
 
   public fun registerExtension(extension: SlackToolsExtension) {
     val dependencies =
@@ -98,91 +91,19 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
     }
   }
 
-  private val thermalsLogProcess: Process? =
-    if (logThermals && AppleSiliconCompat.Arch.get() == X86_64) {
-      ProcessBuilder("pmset", "-g", "thermlog").redirectOutput(thermalsFile()).start()
-    } else {
-      null
-    }
-
-  // TODO unify this API with the other thermals logging?
-  private val appleSiliconThermals: BehaviorSubject<Thermals> = BehaviorSubject.create()
-  @Suppress("UNCHECKED_CAST")
-  private val appleSiliconThermalsHeartbeat: Disposable =
-    if (logThermals && AppleSiliconCompat.Arch.get() == ARM64) {
-      Observable.interval(5, SECONDS)
-        .map {
-          ThermLog(
-            timestamp = LocalDateTime.now(),
-            schedulerLimit = 0,
-            availableCpus = 0,
-            // These aren't entirely true numbers but best effort for now
-            speedLimit =
-              when (AppleSiliconThermals.getThermals()) {
-                NOMINAL -> 100
-                FAIR -> 75
-                SERIOUS -> 50
-                CRITICAL -> 25
-                null -> -1
-              },
-          )
-        }
-        .filter { it.speedLimit != -1 }
-        .map {
-          thermalsFile().appendText("\n${it.timestamp} - ${it.speedLimit}")
-          it
-        }
-        .scanWith<Thermals>({ Thermals.Empty }) { acc, next ->
-          when (acc) {
-            is Thermals.Empty -> ThermalsData(listOf(next))
-            is ThermalsData -> ThermalsData(acc.logs + next)
-          }
-        }
-        .subscribe { appleSiliconThermals.onNext(it) }
-    } else {
-      Disposable.empty()
-    }
-
-  private var thermalsAtClose: Thermals? = null
-
-  /** Returns the current or latest captured thermals log. */
-  public val thermals: Thermals?
-    get() {
-      return thermalsAtClose ?: readThermalsResult()
-    }
-
-  @Synchronized
-  private fun readThermalsResult(): Thermals? {
-    return if (logThermals) {
-      if (AppleSiliconCompat.Arch.get() == ARM64) {
-        appleSiliconThermals.value
-      } else {
-        val file = parameters.thermalsOutputFile.asFile.get()
-        // File may no longer exist if they were running `clean`
-        if (file.exists()) {
-          val thermalsLog = file.readText()
-          ThermalsParser.parse(thermalsLog)
-        } else {
-          Thermals.Empty
-        }
-      }
-    } else {
-      null
-    }
+  private fun peekThermals(): Thermals? {
+    return thermalsWatcher?.peek()
   }
 
   override fun close() {
-    appleSiliconThermalsHeartbeat.dispose()
-    try {
-      // Close thermals process and save off its current value
-      thermalsAtClose = readThermalsResult()
-      if (!parameters.offline.get()) {
-        thermalsAtClose?.let { thermalsReporter?.reportThermals(it) }
-      }
-    } catch (t: Throwable) {
+    // Close thermals process and save off its current value
+    thermalsAtClose = thermalsWatcher?.stop()
+    if (!parameters.offline.get()) {
+      thermalsAtClose?.let { thermalsReporter?.reportThermals(it) }
+    }
+    try {} catch (t: Throwable) {
       logger.error("Failed to parse thermals", t)
     } finally {
-      thermalsLogProcess?.destroyForcibly()?.waitFor()
       if (okHttpClient.isInitialized()) {
         with(okHttpClient.value) {
           dispatcher.executorService.shutdown()

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
@@ -42,11 +42,11 @@ import slack.cli.AppleSiliconCompat.Arch.X86_64
 import slack.gradle.SlackTools.Companion.SERVICE_NAME
 import slack.gradle.SlackTools.Parameters
 import slack.gradle.agp.AgpHandler
-import slack.gradle.util.M1ThermalParser
-import slack.gradle.util.M1ThermalParser.ThermalState.CRITICAL
-import slack.gradle.util.M1ThermalParser.ThermalState.FAIR
-import slack.gradle.util.M1ThermalParser.ThermalState.NOMINAL
-import slack.gradle.util.M1ThermalParser.ThermalState.SERIOUS
+import slack.gradle.util.AppleSiliconThermals
+import slack.gradle.util.AppleSiliconThermals.ThermalState.CRITICAL
+import slack.gradle.util.AppleSiliconThermals.ThermalState.FAIR
+import slack.gradle.util.AppleSiliconThermals.ThermalState.NOMINAL
+import slack.gradle.util.AppleSiliconThermals.ThermalState.SERIOUS
 import slack.gradle.util.ThermLog
 import slack.gradle.util.Thermals
 import slack.gradle.util.ThermalsData
@@ -118,7 +118,7 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
             availableCpus = 0,
             // These aren't entirely true numbers but best effort for now
             speedLimit =
-              when (M1ThermalParser.getThermals()) {
+              when (AppleSiliconThermals.getThermals()) {
                 NOMINAL -> 100
                 FAIR -> 75
                 SERIOUS -> 50

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
@@ -106,9 +106,9 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
     }
 
   // TODO unify this API with the other thermals logging?
-  private val m1Thermals: BehaviorSubject<Thermals> = BehaviorSubject.create()
+  private val appleSiliconThermals: BehaviorSubject<Thermals> = BehaviorSubject.create()
   @Suppress("UNCHECKED_CAST")
-  private val m1ThermalsHeartbeat: Disposable =
+  private val appleSiliconThermalsHeartbeat: Disposable =
     if (logThermals && AppleSiliconCompat.Arch.get() == ARM64) {
       Observable.interval(5, SECONDS)
         .map {
@@ -138,7 +138,7 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
             is ThermalsData -> ThermalsData(acc.logs + next)
           }
         }
-        .subscribe { m1Thermals.onNext(it) }
+        .subscribe { appleSiliconThermals.onNext(it) }
     } else {
       Disposable.empty()
     }
@@ -155,7 +155,7 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
   private fun readThermalsResult(): Thermals? {
     return if (logThermals) {
       if (AppleSiliconCompat.Arch.get() == ARM64) {
-        m1Thermals.value
+        appleSiliconThermals.value
       } else {
         val file = parameters.thermalsOutputFile.asFile.get()
         // File may no longer exist if they were running `clean`
@@ -172,7 +172,7 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
   }
 
   override fun close() {
-    m1ThermalsHeartbeat.dispose()
+    appleSiliconThermalsHeartbeat.dispose()
     try {
       // Close thermals process and save off its current value
       thermalsAtClose = readThermalsResult()

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/ThermalsParser.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/ThermalsParser.kt
@@ -185,7 +185,7 @@ public data class ThermLog(
   val isThrottled: Boolean = speedLimit != -1 && speedLimit < 100
 }
 
-internal object M1ThermalParser {
+internal object AppleSiliconThermals {
   fun getThermals(): ThermalState? {
     val rawValue = JnaThermalState.INSTANCE.thermal_state()
     // Raw value in this case is 0-4, which we use as the ordinal of our enums for convenience

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/ThermalsWatcher.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/ThermalsWatcher.kt
@@ -17,15 +17,90 @@ package slack.gradle.util
 
 import com.sun.jna.Library
 import com.sun.jna.Native
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.subjects.BehaviorSubject
+import java.io.File
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.jvm.Throws
+import slack.cli.AppleSiliconCompat.Arch
+import slack.cli.AppleSiliconCompat.Arch.ARM64
+import slack.cli.AppleSiliconCompat.Arch.X86_64
+import slack.gradle.util.AppleSiliconThermals.ThermalState.CRITICAL
+import slack.gradle.util.AppleSiliconThermals.ThermalState.FAIR
+import slack.gradle.util.AppleSiliconThermals.ThermalState.NOMINAL
+import slack.gradle.util.AppleSiliconThermals.ThermalState.SERIOUS
 import slack.gradle.util.charting.ChartCreator
 
+/**
+ * Simple interface for recording thermals data during the course of a build. The watcher should be
+ * [started][start] when the build is started and [stopped][stop] when the build is complete.
+ *
+ * Current thermals data can be [peeked][peek] at at any time.
+ */
+// Can't be a sealed interface because Gradle hasn't figured out Kotlin 1.5 yet.
+internal interface ThermalsWatcher {
+  fun start()
+
+  fun peek(): Thermals
+
+  fun stop(): Thermals
+
+  companion object {
+    operator fun invoke(thermalsFileProvider: () -> File): ThermalsWatcher {
+      return when (val arch = Arch.get()) {
+        ARM64 -> AppleSiliconThermals(thermalsFileProvider)
+        X86_64 -> IntelThermalsParser(thermalsFileProvider)
+        else -> throw IllegalStateException("Unsupported architecture: $arch")
+      }
+    }
+  }
+}
+
+internal class IntelThermalsParser(val thermalsFileProvider: () -> File) : ThermalsWatcher {
+
+  private var process: Process? = null
+  private var thermalsFile: File? = null
+  private val started = AtomicBoolean(false)
+  override fun start() {
+    check(!started.getAndSet(true)) { "Already started" }
+    thermalsFile = thermalsFileProvider()
+    process = ProcessBuilder("pmset", "-g", "thermlog").redirectOutput(thermalsFile).start()
+  }
+
+  override fun peek(): Thermals {
+    check(started.get()) { "Not started" }
+    val file = thermalsFile ?: return Thermals.Empty
+    // File may no longer exist if they were running `clean`
+    return if (file.exists()) {
+      val thermalsLog = file.readText()
+      ThermlogParser.parse(thermalsLog)
+    } else {
+      Thermals.Empty
+    }
+  }
+
+  override fun stop(): Thermals {
+    check(started.getAndSet(false)) { "Not started" }
+    val thermals =
+      try {
+        peek()
+      } finally {
+        process?.destroyForcibly()?.waitFor()
+      }
+    process = null
+    thermalsFile = null
+    return thermals
+  }
+}
+
 /** Utility for parsing thermals as reported by `pmset -g thermlog`. */
-internal object ThermalsParser {
+internal object ThermlogParser {
   internal val TIMESTAMP_PATTERN = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z")
 
   internal fun parse(log: String): Thermals {
@@ -185,8 +260,63 @@ public data class ThermLog(
   val isThrottled: Boolean = speedLimit != -1 && speedLimit < 100
 }
 
-internal object AppleSiliconThermals {
-  fun getThermals(): ThermalState? {
+internal class AppleSiliconThermals(
+  private val thermalsFileProvider: () -> File,
+) : ThermalsWatcher {
+
+  private var emissions: BehaviorSubject<Thermals> = BehaviorSubject.create()
+  private var heartbeat: Disposable? = null
+  private var thermalsFile: File? = null
+  private val started = AtomicBoolean(false)
+
+  override fun start() {
+    check(!started.getAndSet(true)) { "Already started." }
+    thermalsFile = thermalsFileProvider()
+    heartbeat =
+      Observable.interval(5, SECONDS)
+        .map {
+          ThermLog(
+            timestamp = LocalDateTime.now(),
+            schedulerLimit = 0,
+            availableCpus = 0,
+            // These aren't entirely true numbers but best effort for now
+            speedLimit =
+              when (getThermalState()) {
+                NOMINAL -> 100
+                FAIR -> 75
+                SERIOUS -> 50
+                CRITICAL -> 25
+                null -> -1
+              },
+          )
+        }
+        .filter { it.speedLimit != -1 }
+        .doOnNext { thermalsFile?.appendText("\n${it.timestamp} - ${it.speedLimit}") }
+        .scanWith<Thermals>({ Thermals.Empty }) { acc, next ->
+          when (acc) {
+            is Thermals.Empty -> ThermalsData(listOf(next))
+            is ThermalsData -> ThermalsData(acc.logs + next)
+          }
+        }
+        .subscribe { emissions.onNext(it) }
+  }
+
+  override fun peek(): Thermals {
+    check(started.get()) { "Not started." }
+    return emissions.value ?: Thermals.Empty
+  }
+
+  override fun stop(): Thermals {
+    check(started.getAndSet(false)) { "Not started." }
+    heartbeat?.dispose()
+    heartbeat = null
+    thermalsFile = null
+    val thermals = emissions.value ?: Thermals.Empty
+    emissions = BehaviorSubject.create()
+    return thermals
+  }
+
+  private fun getThermalState(): ThermalState? {
     val rawValue = JnaThermalState.INSTANCE.thermal_state()
     // Raw value in this case is 0-4, which we use as the ordinal of our enums for convenience
     return if (rawValue in 0..ThermalState.values().size) {

--- a/slack-plugin/src/test/kotlin/slack/gradle/util/ThermlogParserTest.kt
+++ b/slack-plugin/src/test/kotlin/slack/gradle/util/ThermlogParserTest.kt
@@ -20,11 +20,11 @@ import java.time.LocalDateTime
 import org.junit.Assert.fail
 import org.junit.Test
 
-class ThermalsParserTest {
+class ThermlogParserTest {
 
   @Test
   fun happyPath() {
-    val log = ThermalsParser.parse(UNTHROTTLED_EXAMPLE)
+    val log = ThermlogParser.parse(UNTHROTTLED_EXAMPLE)
     check(log is ThermalsData)
     assertThat(log.wasThrottled).isFalse()
     assertThat(log.logs)
@@ -37,14 +37,14 @@ class ThermalsParserTest {
 
   @Test
   fun emptyLogs() {
-    val log = ThermalsParser.parse("")
+    val log = ThermlogParser.parse("")
     check(log is Thermals.Empty)
     assertThat(log.wasThrottled).isFalse()
   }
 
   @Test
   fun throttled() {
-    val log = ThermalsParser.parse(THROTTLED_EXAMPLE)
+    val log = ThermlogParser.parse(THROTTLED_EXAMPLE)
     check(log is ThermalsData)
     assertThat(log.wasThrottled).isTrue()
     assertThat(log.logs)
@@ -57,7 +57,7 @@ class ThermalsParserTest {
 
   @Test
   fun incompleteDataIsSkipped() {
-    val log = ThermalsParser.parse(INCOMPLETE_EXAMPLE)
+    val log = ThermlogParser.parse(INCOMPLETE_EXAMPLE)
     check(log is ThermalsData)
     assertThat(log.wasThrottled).isFalse()
     assertThat(log.logs)
@@ -103,7 +103,7 @@ class ThermalsParserTest {
 
   @Test
   fun garbageDataIsGracefullySkipped() {
-    val log = checkNotNull(ThermalsParser.parse(GARBAGE_DATA))
+    val log = checkNotNull(ThermlogParser.parse(GARBAGE_DATA))
     check(log is ThermalsData)
     assertThat(log.logs).hasSize(2)
     assertThat(log.logs[0].speedLimit).isEqualTo(90)
@@ -117,7 +117,7 @@ class ThermalsParserTest {
     cpuLimit: Int
   ): ThermLog {
     return ThermLog(
-      LocalDateTime.parse(rawString, ThermalsParser.TIMESTAMP_PATTERN),
+      LocalDateTime.parse(rawString, ThermlogParser.TIMESTAMP_PATTERN),
       schedulerLimit,
       availableCpus,
       cpuLimit


### PR DESCRIPTION
This unifies our two thermals logging APIs behind a common `ThermalsWatcher` that can be simply started/stopped in `SlackTools`. This makes it fairly simple to work with and possibly easy to ~copy into other projects~ release as a separate project some day :).

Now all the core logic lives in `ThermalsWatcher.kt`. Would like to some day move the polling logic to coroutines too. 

Opportunistically cleaned up the README doc around properties too per @seankim-android's previous PR comment