### PR TITLE
Remove canIDropJetifier

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,6 @@ commonsText = "org.apache.commons:commons-text:1.9"
 detekt = { module = "io.gitlab.arturbosch.detekt:detekt-core", version.ref = "detekt" }
 gradlePlugins-anvil = { module = "com.squareup.anvil:gradle-plugin", version.ref = "anvil" }
 gradlePlugins-bugsnag = { module = "com.bugsnag:bugsnag-android-gradle-plugin", version.ref = "bugsnagGradle" }
-gradlePlugins-canIDropJetifier = "com.github.plnice:canidropjetifier:0.5"
 gradlePlugins-dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysisPlugin" }
 gradlePlugins-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradlePlugins-doctor = "com.osacky.doctor:doctor-plugin:0.8.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -77,7 +77,6 @@ dependencyResolutionManagement {
     exclusiveContent {
       forRepository(::gradlePluginPortal)
       filter {
-        includeModule("com.github.plnice", "canidropjetifier")
         includeModule("com.github.ben-manes", "gradle-versions-plugin")
         includeModule("com.gradle", "gradle-enterprise-gradle-plugin")
         includeModule("org.gradle", "test-retry-gradle-plugin")

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies {
   compileOnly(libs.gradlePlugins.errorProne)
   compileOnly(libs.gradlePlugins.nullaway)
   compileOnly(libs.gradlePlugins.dependencyAnalysis)
-  compileOnly(libs.gradlePlugins.canIDropJetifier)
   compileOnly(libs.gradlePlugins.retry)
   compileOnly(libs.gradlePlugins.anvil)
   compileOnly(libs.gradlePlugins.spotless)

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -17,7 +17,6 @@ package slack.gradle
 
 import com.autonomousapps.DependencyAnalysisExtension
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-import com.github.plnice.canidropjetifier.CanIDropJetifierPluginExtension
 import com.osacky.doctor.DoctorExtension
 import java.util.Locale
 import okhttp3.OkHttpClient
@@ -137,18 +136,6 @@ internal class SlackRootPlugin : Plugin<Project> {
     project.tasks.register<GjfDownloadTask>("updateGjf") {
       version.set(slackProperties.versions.gjf)
       outputFile.set(project.layout.projectDirectory.file("config/bin/gjf"))
-    }
-
-    // Plugin to check for dependencies that impose a Jetifier requirement
-    // Usage: ./gradlew -Pandroid.enableJetifier=false canIDropJetifier
-    project.pluginManager.withPlugin("com.github.plnice.canidropjetifier") {
-      project.configure<CanIDropJetifierPluginExtension> {
-        // To print out the dependency chain that's incurring it!
-        verbose = true
-        // We disable it because some JVM projects may depend on androidx.annotation (which is just
-        // a jar).
-        analyzeOnlyAndroidModules = false
-      }
     }
 
     // Dependency analysis plugin for build health

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -220,8 +220,7 @@ internal class StandardProjectConfigurations {
               throw IllegalArgumentException(
                 "Legacy support library dependencies are no longer " +
                   "supported. To trace this dependency, run './gradlew " +
-                  "-Pandroid.enableJetifier=false -Pslack.gradle.skipAndroidXCheck=true " +
-                  "canIDropJetifier'"
+                  "checkJetifier -Pandroid.enableJetifier=true --no-configuration-cache"
               )
             }
           }


### PR DESCRIPTION
No longer necessary (or maintained) since AGP has a separate check