### PR TITLE
Fix intel thermals

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/util/ThermalsWatcher.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/ThermalsWatcher.kt
@@ -67,6 +67,7 @@ internal class IntelThermalsParser(val thermalsFileProvider: () -> File) : Therm
   private var process: Process? = null
   private var thermalsFile: File? = null
   private val started = AtomicBoolean(false)
+
   override fun start() {
     check(!started.getAndSet(true)) { "Already started" }
     thermalsFile = thermalsFileProvider()
@@ -86,13 +87,14 @@ internal class IntelThermalsParser(val thermalsFileProvider: () -> File) : Therm
   }
 
   override fun stop(): Thermals {
-    check(started.getAndSet(false)) { "Not started" }
+    check(started.get()) { "Not started" }
     val thermals =
       try {
         peek()
       } finally {
         process?.destroyForcibly()?.waitFor()
       }
+    started.set(false)
     process = null
     thermalsFile = null
     return thermals


### PR DESCRIPTION
Because we `peek()` to get the current value in the intel watcher, we need to defer setting `started()` to false until after we peek