### PR TITLE
Update AndroidSourcesConfigurer to allow per-repo overrides + default to compileSdk

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/AndroidSourcesConfigurer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/AndroidSourcesConfigurer.kt
@@ -34,21 +34,15 @@ import org.gradle.api.logging.Logger
  */
 internal object AndroidSourcesConfigurer {
 
-  private const val LATEST = 31
   internal const val MARKER_FILE_NAME = "slack_patched_marker"
 
-  fun patchSdkSources(requestedSdkVersion: Int, rootProject: Project, latest: Int = LATEST) {
+  fun patchSdkSources(requestedSdkVersion: Int, rootProject: Project, latest: Int) {
     val sdkDir = inferAndroidHome(rootProject.projectDir)
     patchSdkSources(requestedSdkVersion, sdkDir, rootProject.logger, latest)
   }
 
   @Suppress("LongMethod")
-  fun patchSdkSources(
-    requestedSdkVersion: Int,
-    sdkDir: File,
-    logger: Logger,
-    latest: Int = LATEST
-  ) {
+  fun patchSdkSources(requestedSdkVersion: Int, sdkDir: File, logger: Logger, latest: Int) {
     if (requestedSdkVersion == latest) {
       // Check for our patched marker. If it exists, delete the directory and let AGP download it
       // again.
@@ -87,7 +81,7 @@ internal object AndroidSourcesConfigurer {
         )
       } else {
         logger.lifecycle(
-          "Patching Android sources from $latest as requested SDK version" + " $requestedSdkVersion"
+          "Patching Android sources from $latest as requested SDK version $requestedSdkVersion"
         )
         measureTimeMillis {
           requestedSources.mkdirs()

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -351,6 +351,8 @@ public class SlackProperties private constructor(private val project: Project) {
 
   public val compileSdkVersion: String
     get() = stringProperty("slack.compileSdkVersion")
+  public fun latestCompileSdkWithSources(defaultValue: Int): Int =
+    intProperty("slack.latestCompileSdkWithSources", defaultValue = defaultValue)
   public val minSdkVersion: String
     get() = stringProperty("slack.minSdkVersion")
   public val targetSdkVersion: String

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -91,7 +91,8 @@ internal class SlackRootPlugin : Plugin<Project> {
 
     if (!project.isCi) {
       val compileSdk = slackProperties.compileSdkVersion.substringAfter("-").toInt()
-      AndroidSourcesConfigurer.patchSdkSources(compileSdk, project)
+      val latestCompileSdkWithSources = slackProperties.latestCompileSdkWithSources(compileSdk)
+      AndroidSourcesConfigurer.patchSdkSources(compileSdk, project, latestCompileSdkWithSources)
       project.configureGit(slackProperties)
     }
     project.configureSlackRootBuildscript()


### PR DESCRIPTION
This allows consuming repos to customize the behavior of this and use a newer version rather than rely on this repo to be the source of truth of the current latest version