### PR TITLE
Use a custom `ValueSource` to avoid unnecessary configuration cache invalidations

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/ProcessExtensions.kt
+++ b/slack-plugin/src/main/kotlin/slack/ProcessExtensions.kt
@@ -63,7 +63,7 @@ internal fun executeWithResult(
   arguments: List<String>,
   isRelevantToConfigurationCache: Boolean
 ): Provider<String> {
-  if (isRelevantToConfigurationCache) {
+  if (!isRelevantToConfigurationCache) {
     return providers
       .of(ExecSource::class.java) {
         parameters.workingDir.set(inputWorkingDir)

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
@@ -69,7 +69,8 @@ public fun Project.gitBranch(): Provider<String> {
       executeWithResult(
           project.providers,
           rootProject.rootDir,
-          listOf("git", "rev-parse", "--abbrev-ref", "HEAD")
+          listOf("git", "rev-parse", "--abbrev-ref", "HEAD"),
+          isRelevantToConfigurationCache = false
         )
         .map { it.lines()[0].trim() }
   }
@@ -157,7 +158,12 @@ public enum class SupportedLanguagesEnum {
 
 public val Project.fullGitSha: Provider<String>
   get() {
-    return executeWithResult(providers, rootProject.rootDir, listOf("git", "rev-parse", "HEAD"))
+    return executeWithResult(
+      providers,
+      rootProject.rootDir,
+      listOf("git", "rev-parse", "HEAD"),
+      isRelevantToConfigurationCache = true
+    )
   }
 
 public val Project.gitSha: Provider<String>
@@ -165,7 +171,8 @@ public val Project.gitSha: Provider<String>
     return executeWithResult(
       providers,
       rootProject.rootDir,
-      listOf("git", "rev-parse", "--short", "HEAD")
+      listOf("git", "rev-parse", "--short", "HEAD"),
+      isRelevantToConfigurationCache = true
     )
   }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -322,12 +322,21 @@ internal class SlackRootPlugin : Plugin<Project> {
     if (!isCi) {
       slackProperties.gitHooksFile?.let { hooksPath ->
         // Configure hooks
-        "git config core.hooksPath $hooksPath".executeBlocking(project.providers, rootDir)
+        "git config core.hooksPath $hooksPath".executeBlocking(
+          project.providers,
+          rootDir,
+          isRelevantToConfigurationCache = false
+        )
       }
 
       val revsFile = slackProperties.gitIgnoreRevsFile ?: return
       // "git version 2.24.1"
-      val gitVersion = "git --version".executeBlockingWithResult(project.providers, rootDir)
+      val gitVersion =
+        "git --version".executeBlockingWithResult(
+          project.providers,
+          rootDir,
+          isRelevantToConfigurationCache = false
+        )
       val versionNumber = parseGitVersion(gitVersion)
       @Suppress(
         "ReplaceCallWithBinaryOperator"
@@ -349,7 +358,8 @@ internal class SlackRootPlugin : Plugin<Project> {
           logger.debug("Configuring blame.ignoreRevsFile")
           "git config blame.ignoreRevsFile ${file(revsFile)}".executeBlocking(
             project.providers,
-            rootDir
+            rootDir,
+            isRelevantToConfigurationCache = false
           )
         }
       }

--- a/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
@@ -131,16 +131,24 @@ private fun ScanApi.addGitMetadata(project: Project) {
       executeBlockingWithResult(
         providers,
         projectDir,
-        listOf("git", "rev-parse", "--short=8", "--verify", "HEAD")
+        listOf("git", "rev-parse", "--short=8", "--verify", "HEAD"),
+        isRelevantToConfigurationCache = false
       )
     val gitBranchName =
       executeBlockingWithResult(
         providers,
         projectDir,
-        listOf("git", "rev-parse", "--abbrev-ref", "HEAD")
+        listOf("git", "rev-parse", "--abbrev-ref", "HEAD"),
+        isRelevantToConfigurationCache = false
       )
+
     val gitStatus =
-      executeBlockingWithResult(providers, projectDir, listOf("git", "status", "--porcelain"))
+      executeBlockingWithResult(
+        providers,
+        projectDir,
+        listOf("git", "status", "--porcelain"),
+        isRelevantToConfigurationCache = false
+      )
 
     if (gitCommitId != null) {
       val gitCommitIdLabel = "Git commit id"
@@ -154,7 +162,8 @@ private fun ScanApi.addGitMetadata(project: Project) {
         executeBlockingWithResult(
           providers,
           projectDir,
-          listOf("git", "config", "--get", "remote.origin.url")
+          listOf("git", "config", "--get", "remote.origin.url"),
+          isRelevantToConfigurationCache = false
         )
       if (originUrl != null) {
         if ("github.com/" in originUrl || "github.com:" in originUrl) {
@@ -217,7 +226,7 @@ private fun urlEncode(url: String): String {
 
 private fun isGitInstalled(providers: ProviderFactory, workingDir: File): Boolean {
   return try {
-    "git --version".executeBlocking(providers, workingDir)
+    "git --version".executeBlocking(providers, workingDir, isRelevantToConfigurationCache = false)
     true
   } catch (ignored: IOException) {
     false


### PR DESCRIPTION
Resolves #30, using a custom `ValueSource` per https://docs.gradle.org/7.5-rc-1/release-notes.html#configuration-cache-improvements. The API is a little ugly and explicit but didn't see an easier way to do this.
