### PR TITLE
Add gradle enterprise version to build scans if present

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
@@ -49,6 +49,14 @@ internal fun Project.configureBuildScanMetadata(scanApi: ScanApi) {
   scanApi.addGitMetadata(project)
   scanApi.addTestParallelization(project)
   scanApi.addTestSystemProperties(project)
+
+  // Add the gradle enterprise plugin version if present
+  ScanApi::class
+    .java
+    .classLoader
+    .getResource("com.gradle.scan.plugin.internal.meta.buildAgentVersion.txt")
+    ?.readText()
+    ?.let { buildAgentVersion -> scanApi.value("GE Gradle plugin version", buildAgentVersion) }
 }
 
 private fun ScanApi.tagOs() {

--- a/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
@@ -49,14 +49,7 @@ internal fun Project.configureBuildScanMetadata(scanApi: ScanApi) {
   scanApi.addGitMetadata(project)
   scanApi.addTestParallelization(project)
   scanApi.addTestSystemProperties(project)
-
-  // Add the gradle enterprise plugin version if present
-  ScanApi::class
-    .java
-    .classLoader
-    .getResource("com.gradle.scan.plugin.internal.meta.buildAgentVersion.txt")
-    ?.readText()
-    ?.let { buildAgentVersion -> scanApi.value("GE Gradle plugin version", buildAgentVersion) }
+  scanApi.addGradleEnterpriseVersion()
 }
 
 private fun ScanApi.tagOs() {
@@ -198,6 +191,14 @@ internal fun ScanApi.addTestSystemProperties(project: Project) {
       }
     }
   }
+}
+
+private fun ScanApi.addGradleEnterpriseVersion() {
+  javaClass
+    .classLoader
+    .getResource("com.gradle.scan.plugin.internal.meta.buildAgentVersion.txt")
+    ?.readText()
+    ?.let { buildAgentVersion -> value("GE Gradle plugin version", buildAgentVersion) }
 }
 
 private fun ScanApi.addCustomLinkWithSearchTerms(title: String, search: Map<String, String>) {


### PR DESCRIPTION
Taken from https://github.com/gradle/gradle-enterprise-build-config-samples/blob/main/build-data-capturing-gradle-samples/capture-ge-plugin-version/gradle-ge-plugin-version.gradle