### PR TITLE
Make SGP more reusable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ generated baselines from each subproject into a single global baseline.
 
 There are a _ton_ of miscellaneous tools, utilities, and glue code for Gradle (and various plugins) sprinkled throughout this project.
 
+## Usage requirements
+
+SGP expects there to be a `libs` version catalog.
+
+The following versions are required to be set the above catalog.
+Their docs can be found in `SlackVersions.kt`.
+- `jdk`
+
 License
 --------
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
@@ -132,22 +132,14 @@ internal class SlackBasePlugin : Plugin<Project> {
           val ktlintVersion = slackProperties.versions.ktlint
           if (ktlintVersion != null) {
             val ktlintUserData = mapOf("indent_size" to "2", "continuation_indent_size" to "2")
-            kotlin {
-              ktlint(ktlintVersion).userData(ktlintUserData)
-            }
-            kotlinGradle {
-              ktlint(ktlintVersion).userData(ktlintUserData)
-            }
+            kotlin { ktlint(ktlintVersion).userData(ktlintUserData) }
+            kotlinGradle { ktlint(ktlintVersion).userData(ktlintUserData) }
           }
 
           val ktfmtVersion = slackProperties.versions.ktfmt
           if (ktfmtVersion != null) {
-            kotlin {
-              ktfmt(ktfmtVersion).googleStyle()
-            }
-            kotlinGradle {
-              ktfmt(ktfmtVersion).googleStyle()
-            }
+            kotlin { ktfmt(ktfmtVersion).googleStyle() }
+            kotlinGradle { ktfmt(ktfmtVersion).googleStyle() }
           }
 
           if (ktlintVersion != null || ktfmtVersion != null) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
@@ -190,20 +190,23 @@ internal class SlackBasePlugin : Plugin<Project> {
     // core one with the
     // new one (as cover for transitive users like junit).
     if (hamcrestDepOptional.isPresent && isTestProject || "test" in lowercaseName) {
-      val hamcrestDep = hamcrestDepOptional.get().get().toString()
-      configuration.resolutionStrategy {
-        dependencySubstitution {
-          substitute(module("org.hamcrest:hamcrest-core")).apply {
-            using(module(hamcrestDep))
-            because("hamcrest 2.1 removed the core/integration/library artifacts")
-          }
-          substitute(module("org.hamcrest:hamcrest-integration")).apply {
-            using(module(hamcrestDep))
-            because("hamcrest 2.1 removed the core/integration/library artifacts")
-          }
-          substitute(module("org.hamcrest:hamcrest-library")).apply {
-            using(module(hamcrestDep))
-            because("hamcrest 2.1 removed the core/integration/library artifacts")
+      val hamcrestDepProvider = hamcrestDepOptional.get()
+      if (hamcrestDepProvider.isPresent) {
+        val hamcrestDep = hamcrestDepProvider.get().toString()
+        configuration.resolutionStrategy {
+          dependencySubstitution {
+            substitute(module("org.hamcrest:hamcrest-core")).apply {
+              using(module(hamcrestDep))
+              because("hamcrest 2.1 removed the core/integration/library artifacts")
+            }
+            substitute(module("org.hamcrest:hamcrest-integration")).apply {
+              using(module(hamcrestDep))
+              because("hamcrest 2.1 removed the core/integration/library artifacts")
+            }
+            substitute(module("org.hamcrest:hamcrest-library")).apply {
+              using(module(hamcrestDep))
+              because("hamcrest 2.1 removed the core/integration/library artifacts")
+            }
           }
         }
       }

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -276,12 +276,14 @@ public class SlackProperties private constructor(private val project: Project) {
     get() = project.project(stringProperty("slack.location.robolectric-core"))
 
   /**
-   * Location for slack-platform project to be referenced by projects.
+   * Gradle path to a platform project to be referenced by other projects.
    *
    * Should be `:path:to:slack-platform` format
+   *
+   * @see Platforms
    */
-  public val slackPlatformProject: Project
-    get() = project.project(stringProperty("slack.location.slack-platform"))
+  public val platformProjectPath: String?
+    get() = optionalStringProperty("slack.location.slack-platform")
 
   /**
    * Opt-in path for commit hooks in the consuming repo that should be automatically installed
@@ -356,7 +358,11 @@ public class SlackProperties private constructor(private val project: Project) {
     return AndroidSdkProperties(compileSdk, minSdk, targetSdk)
   }
 
-  internal data class AndroidSdkProperties(val compileSdk: String, val minSdk: Int, val targetSdk: Int)
+  internal data class AndroidSdkProperties(
+    val compileSdk: String,
+    val minSdk: Int,
+    val targetSdk: Int
+  )
 
   public val compileSdkVersion: String?
     get() = optionalStringProperty("slack.compileSdkVersion")

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -315,7 +315,7 @@ public class SlackProperties private constructor(private val project: Project) {
 
   /** The JDK runtime to target for compilations. */
   public val jvmTarget: Int
-    get() = intProperty("slackToolchainsJvmTarget", defaultValue = 8)
+    get() = intProperty("slackToolchainsJvmTarget", defaultValue = 11)
 
   /** Android cache fix plugin. */
   public val enableAndroidCacheFix: Boolean = booleanProperty("slack.plugins.android-cache-fix")

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -311,11 +311,11 @@ public class SlackProperties private constructor(private val project: Project) {
 
   /** The JDK version to use for compilations. */
   public val jdkVersion: Int
-    get() = intProperty("slackToolchainsJdk")
+    get() = versions.jdk
 
   /** The JDK runtime to target for compilations. */
   public val jvmTarget: Int
-    get() = intProperty("slackToolchainsJvmTarget", defaultValue = 11)
+    get() = versions.jvmTarget
 
   /** Android cache fix plugin. */
   public val enableAndroidCacheFix: Boolean = booleanProperty("slack.plugins.android-cache-fix")

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -204,8 +204,8 @@ public class SlackProperties private constructor(private val project: Project) {
    *
    * Latest versions can be found at https://developer.android.com/ndk/downloads
    */
-  public val ndkVersion: String
-    get() = stringProperty("slack.ndkVersion")
+  public val ndkVersion: String?
+    get() = optionalStringProperty("slack.ndkVersion")
 
   /** Flag to enable verbose logging in unit tests. */
   public val testVerboseLogging: Boolean
@@ -349,14 +349,26 @@ public class SlackProperties private constructor(private val project: Project) {
   public val versionCatalogName: String
     get() = stringProperty("slack.catalog", defaultValue = "libs")
 
-  public val compileSdkVersion: String
-    get() = stringProperty("slack.compileSdkVersion")
+  internal fun requireAndroidSdkProperties(): AndroidSdkProperties {
+    val compileSdk = compileSdkVersion ?: error("slack.compileSdkVersion not set")
+    val minSdk = minSdkVersion?.toInt() ?: error("slack.minSdkVersion not set")
+    val targetSdk = targetSdkVersion?.toInt() ?: error("slack.targetSdkVersion not set")
+    return AndroidSdkProperties(compileSdk, minSdk, targetSdk)
+  }
+
+  internal data class AndroidSdkProperties(val compileSdk: String, val minSdk: Int, val targetSdk: Int)
+
+  public val compileSdkVersion: String?
+    get() = optionalStringProperty("slack.compileSdkVersion")
+
   public fun latestCompileSdkWithSources(defaultValue: Int): Int =
     intProperty("slack.latestCompileSdkWithSources", defaultValue = defaultValue)
-  public val minSdkVersion: String
-    get() = stringProperty("slack.minSdkVersion")
-  public val targetSdkVersion: String
-    get() = stringProperty("slack.targetSdkVersion")
+
+  private val minSdkVersion: String?
+    get() = optionalStringProperty("slack.minSdkVersion")
+
+  private val targetSdkVersion: String?
+    get() = optionalStringProperty("slack.targetSdkVersion")
 
   public companion object {
     /**

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -307,7 +307,7 @@ public class SlackProperties private constructor(private val project: Project) {
 
   /** Flag to enable strict JDK mode, forcing some things like JAVA_HOME. */
   public val strictJdk: Boolean
-    get() = booleanProperty("slackToolchainsStrict")
+    get() = booleanProperty("slackToolchainsStrict", defaultValue = true)
 
   /** The JDK version to use for compilations. */
   public val jdkVersion: Int

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -123,21 +123,27 @@ internal class SlackRootPlugin : Plugin<Project> {
     }
 
     // Add ktlint download task
-    project.tasks.register<KtLintDownloadTask>("updateKtLint") {
-      version.set(slackProperties.versions.ktlint)
-      outputFile.set(project.layout.projectDirectory.file("config/bin/ktlint"))
+    slackProperties.versions.ktlint?.let { ktlintVersion ->
+      project.tasks.register<KtLintDownloadTask>("updateKtLint") {
+        version.set(ktlintVersion)
+        outputFile.set(project.layout.projectDirectory.file("config/bin/ktlint"))
+      }
     }
 
     // Add detekt download task
-    project.tasks.register<DetektDownloadTask>("updateDetekt") {
-      version.set(slackProperties.versions.detekt)
-      outputFile.set(project.layout.projectDirectory.file("config/bin/detekt"))
+    slackProperties.versions.detekt?.let { detektVersion ->
+      project.tasks.register<DetektDownloadTask>("updateDetekt") {
+        version.set(detektVersion)
+        outputFile.set(project.layout.projectDirectory.file("config/bin/detekt"))
+      }
     }
 
     // Add GJF download task
-    project.tasks.register<GjfDownloadTask>("updateGjf") {
-      version.set(slackProperties.versions.gjf)
-      outputFile.set(project.layout.projectDirectory.file("config/bin/gjf"))
+    slackProperties.versions.gjf?.let { gjfVersion ->
+      project.tasks.register<GjfDownloadTask>("updateGjf") {
+        version.set(gjfVersion)
+        outputFile.set(project.layout.projectDirectory.file("config/bin/gjf"))
+      }
     }
 
     // Dependency analysis plugin for build health

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -36,6 +36,7 @@ import slack.gradle.tasks.CoreBootstrapTask
 import slack.gradle.tasks.DetektDownloadTask
 import slack.gradle.tasks.GjfDownloadTask
 import slack.gradle.tasks.KtLintDownloadTask
+import slack.gradle.tasks.KtfmtDownloadTask
 import slack.gradle.util.ThermalsData
 import slack.stats.ModuleStatsTasks
 
@@ -143,6 +144,14 @@ internal class SlackRootPlugin : Plugin<Project> {
       project.tasks.register<GjfDownloadTask>("updateGjf") {
         version.set(gjfVersion)
         outputFile.set(project.layout.projectDirectory.file("config/bin/gjf"))
+      }
+    }
+
+    // Add ktfmt download task
+    slackProperties.versions.ktfmt?.let { ktfmtVersion ->
+      project.tasks.register<KtfmtDownloadTask>("updateKtfmt") {
+        version.set(ktfmtVersion)
+        outputFile.set(project.layout.projectDirectory.file("config/bin/ktfmt"))
       }
     }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -90,9 +90,10 @@ internal class SlackRootPlugin : Plugin<Project> {
     }
 
     if (!project.isCi) {
-      val compileSdk = slackProperties.compileSdkVersion.substringAfter("-").toInt()
-      val latestCompileSdkWithSources = slackProperties.latestCompileSdkWithSources(compileSdk)
-      AndroidSourcesConfigurer.patchSdkSources(compileSdk, project, latestCompileSdkWithSources)
+      slackProperties.compileSdkVersion?.substringAfter("-")?.toInt()?.let { compileSdk ->
+        val latestCompileSdkWithSources = slackProperties.latestCompileSdkWithSources(compileSdk)
+        AndroidSourcesConfigurer.patchSdkSources(compileSdk, project, latestCompileSdkWithSources)
+      }
       project.configureGit(slackProperties)
     }
     project.configureSlackRootBuildscript()

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
@@ -19,7 +19,6 @@ import java.util.Optional
 import org.gradle.api.artifacts.ExternalModuleDependencyBundle
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.artifacts.VersionCatalog
-import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.provider.Provider
 
 // TODO generate something to map these in the future? Or with reflection?
@@ -60,14 +59,14 @@ internal class SlackVersions(val catalog: VersionCatalog) {
   }
 
   internal fun getValue(key: String): String {
-    return getOptionalValue(key)
-      .orElseThrow { IllegalStateException("No catalog version found for ${tomlKey(key)}") }
+    return getOptionalValue(key).orElseThrow {
+      IllegalStateException("No catalog version found for ${tomlKey(key)}")
+    }
   }
 
   internal fun getOptionalValue(key: String): Optional<String> {
     val tomlKey = tomlKey(key)
-    return catalog.findVersion(tomlKey)
-      .map { it.toString() }
+    return catalog.findVersion(tomlKey).map { it.toString() }
   }
 
   internal val boms: Set<Provider<MinimalExternalModuleDependency>> by lazy {

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
@@ -24,20 +24,22 @@ import org.gradle.api.provider.Provider
 
 // TODO generate something to map these in the future? Or with reflection?
 internal class SlackVersions(val catalog: VersionCatalog) {
-  val agp: String
-    get() = getValue("agp")
-  val composeCompiler: String
-    get() = getValue("compose-compiler")
-  val detekt: String
-    get() = getValue("detekt")
-  val gjf: String
-    get() = getValue("google-java-format")
-  val gson: String
-    get() = getValue("gson")
-  val ktlint: String
-    get() = getValue("ktlint")
-  val objenesis: String
-    get() = getValue("objenesis")
+  val agp: String?
+    get() = getOptionalValue("agp").orElse(null)
+  val composeCompiler: String?
+    get() = getOptionalValue("compose-compiler").orElse(null)
+  val detekt: String?
+    get() = getOptionalValue("detekt").orElse(null)
+  val gjf: String?
+    get() = getOptionalValue("google-java-format").orElse(null)
+  val gson: String?
+    get() = getOptionalValue("gson").orElse(null)
+  val ktlint: String?
+    get() = getOptionalValue("ktlint").orElse(null)
+  val ktfmt: String?
+    get() = getOptionalValue("ktfmt").orElse(null)
+  val objenesis: String?
+    get() = getOptionalValue("objenesis").orElse(null)
   val jdk: Int
     get() = getValue("jdk").toInt()
   val jvmTarget: Int

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -473,7 +473,8 @@ internal class StandardProjectConfigurations {
     }
 
     val composeCompilerVersion by lazy {
-      slackProperties.versions.composeCompiler ?: error("Missing `compose-compiler` version in catalog")
+      slackProperties.versions.composeCompiler
+        ?: error("Missing `compose-compiler` version in catalog")
     }
 
     pluginManager.withPlugin("com.android.base") {
@@ -817,7 +818,8 @@ internal class StandardProjectConfigurations {
     pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
       // Configuration examples https://arturbosch.github.io/detekt/kotlindsl.html
       configure<DetektExtension> {
-        toolVersion = slackProperties.versions.detekt ?: error("missing 'detekt' version in version catalog")
+        toolVersion =
+          slackProperties.versions.detekt ?: error("missing 'detekt' version in version catalog")
         config.from("$rootDir/config/detekt/detekt.yml")
         config.from("$rootDir/config/detekt/detekt-all.yml")
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -463,14 +463,18 @@ internal class StandardProjectConfigurations {
         if (name.contains("androidTest", ignoreCase = true)) {
           // Cover for https://github.com/Kotlin/kotlinx.coroutines/issues/2023
           exclude("org.jetbrains.kotlinx", "kotlinx-coroutines-debug")
-          // Cover for https://github.com/mockito/mockito/pull/2024, as objenesis 3.x is not
-          // compatible with Android SDK <26
-          resolutionStrategy.force("org.objenesis:objenesis:$objenesis2Version")
+          objenesis2Version?.let {
+            // Cover for https://github.com/mockito/mockito/pull/2024, as objenesis 3.x is not
+            // compatible with Android SDK <26
+            resolutionStrategy.force("org.objenesis:objenesis:$it")
+          }
         }
       }
     }
 
-    val composeCompilerVersion = slackProperties.versions.composeCompiler
+    val composeCompilerVersion by lazy {
+      slackProperties.versions.composeCompiler ?: error("Missing `compose-compiler` version in catalog")
+    }
 
     pluginManager.withPlugin("com.android.base") {
       if (slackProperties.enableCompose) {
@@ -813,7 +817,7 @@ internal class StandardProjectConfigurations {
     pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
       // Configuration examples https://arturbosch.github.io/detekt/kotlindsl.html
       configure<DetektExtension> {
-        toolVersion = slackProperties.versions.detekt
+        toolVersion = slackProperties.versions.detekt ?: error("missing 'detekt' version in version catalog")
         config.from("$rootDir/config/detekt/detekt.yml")
         config.from("$rootDir/config/detekt/detekt-all.yml")
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -382,16 +382,19 @@ internal class StandardProjectConfigurations {
       }
 
     val shouldApplyCacheFixPlugin = slackProperties.enableAndroidCacheFix
+    val sdkVersions by lazy {
+      slackProperties.requireAndroidSdkProperties()
+    }
     val commonBaseExtensionConfig: BaseExtension.() -> Unit = {
       if (shouldApplyCacheFixPlugin) {
         apply(plugin = "org.gradle.android.cache-fix")
       }
 
-      compileSdkVersion(slackProperties.compileSdkVersion)
-      ndkVersion = slackProperties.ndkVersion
+      compileSdkVersion(sdkVersions.compileSdk)
+      slackProperties.ndkVersion?.let { ndkVersion = it }
       defaultConfig {
         // TODO this won't work with SDK previews but will fix in a followup
-        minSdk = slackProperties.minSdkVersion.toInt()
+        minSdk = sdkVersions.minSdk
         vectorDrawables.useSupportLibrary = true
         // Default to the standard android runner, but note this is overridden in :app
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -494,7 +497,7 @@ internal class StandardProjectConfigurations {
         }
         defaultConfig {
           // TODO this won't work with SDK previews but will fix in a followup
-          targetSdk = slackProperties.targetSdkVersion.toInt()
+          targetSdk = sdkVersions.targetSdk
         }
         lint {
           lintConfig = rootProject.layout.projectDirectory.file("config/lint/lint.xml").asFile

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/KtfmtDownloadTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/KtfmtDownloadTask.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.tasks
+
+/**
+ * Downloads the ktfmt binary from maven central.
+ *
+ * Usage:
+ * ```
+ *     ./gradlew updateKtfmt
+ * ```
+ */
+internal abstract class KtfmtDownloadTask :
+  BaseDownloadTask(
+    targetName = "ktfmt",
+    addExecPrefix = true,
+    urlTemplate = { version ->
+      "https://repo1.maven.org/maven2/com/facebook/ktfmt/$version/ktfmt-$version-jar-with-dependencies.jar"
+    }
+  )


### PR DESCRIPTION
This PR cleans up a bunch of places where SGP currently expects properties or version catalog versions to exist but aren't actually required. The goal in this is to make the plugin more resuable so we can use it in projects other than the main android repo. Best reviewed commit-by-commit!

There's likely more spots we want to address, but this at least gets it up and running on our internal lints repo as a starting point 👍 