### PR TITLE
Fix spotless applications

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -376,7 +376,7 @@ private fun Project.configureSlackRootBuildscript() {
 
 @Suppress("UnstableApiUsage")
 private fun Project.configureMisc(slackProperties: SlackProperties) {
-  tasks.register<Delete>("clean") {
+  tasks.withType<Delete>().matching { it.name == "clean" }.configureEach {
     group = "build"
     delete(rootProject.buildDir)
   }


### PR DESCRIPTION
Formatters need to apparently be decalred in _both_ the subproject and root project, they just must also be the same. Also fixes delete task handling as spotless will apply the base lifecycle plugin for us before-hand now