### PR TITLE
Remove gradle enterprise `configureBuildTags.kt#addTestSystemProperties`

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
@@ -106,7 +106,6 @@ internal class SlackBasePlugin : Plugin<Project> {
     val scanApi = ScanApi(target)
     if (scanApi.isAvailable) {
       scanApi.addTestParallelization(target)
-      scanApi.addTestSystemProperties(target)
     }
   }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
@@ -18,7 +18,6 @@ package slack.gradle
 import java.io.File
 import java.io.IOException
 import java.net.URLEncoder
-import java.security.MessageDigest
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.provider.ProviderFactory

--- a/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/configureBuildTags.kt
@@ -48,7 +48,6 @@ internal fun Project.configureBuildScanMetadata(scanApi: ScanApi) {
   }
   scanApi.addGitMetadata(project)
   scanApi.addTestParallelization(project)
-  scanApi.addTestSystemProperties(project)
   scanApi.addGradleEnterpriseVersion()
 }
 
@@ -192,16 +191,6 @@ internal fun ScanApi.addTestParallelization(project: Project) {
   }
 }
 
-internal fun ScanApi.addTestSystemProperties(project: Project) {
-  project.tasks.withType<Test>().configureEach {
-    doFirst {
-      systemProperties.forEach { (key, entryValue) ->
-        hash(entryValue)?.let { hash -> value("$identityPath#sysProps-$key", hash) }
-      }
-    }
-  }
-}
-
 private fun ScanApi.addGradleEnterpriseVersion() {
   javaClass
     .classLoader
@@ -239,26 +228,5 @@ private fun isGitInstalled(providers: ProviderFactory, workingDir: File): Boolea
     true
   } catch (ignored: IOException) {
     false
-  }
-}
-
-private val MESSAGE_DIGEST = MessageDigest.getInstance("SHA-256")
-
-private fun hash(value: Any?): String? {
-  return if (value == null) {
-    null
-  } else {
-    val string = value.toString()
-    val encodedHash = MESSAGE_DIGEST.digest(string.toByteArray(Charsets.UTF_8))
-    buildString {
-      for (i in 0 until encodedHash.size / 4) {
-        val hex = Integer.toHexString(0xff and encodedHash[i].toInt())
-        if (hex.length == 1) {
-          append("0")
-        }
-        append(hex)
-      }
-      append("...")
-    }
   }
 }


### PR DESCRIPTION
###  Summary

This function is resulting in some crashes in CI and is not that useful. Removing it should increase CI reliability. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
