### PR TITLE
Build upon defaults for detekt

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -740,6 +740,7 @@ internal class StandardProjectConfigurations {
     pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
       // Configuration examples https://arturbosch.github.io/detekt/kotlindsl.html
       configure<DetektExtension> {
+        buildUponDefaultConfig = true
         toolVersion =
           slackProperties.versions.detekt ?: error("missing 'detekt' version in version catalog")
         rootProject.file("config/detekt/detekt.yml")


### PR DESCRIPTION
We currently maintain a fork of the default rules that we have to manually update every time, let's just define our changes from the defaults instead.