### PR TITLE
Don't skip on empty sources in LocTask

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/stats/LocTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/LocTask.kt
@@ -44,9 +44,10 @@ import slack.stats.LocTask.LocData
  */
 @CacheableTask
 internal abstract class LocTask : DefaultTask() {
+  // Always run this! Not every module has source files but in those cases we want to just write
+  // an empty JSON object for tasks that depend on this task's outputs.
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputDirectory
-  @get:SkipWhenEmpty
   abstract val srcsDir: DirectoryProperty
 
   @get:PathSensitive(PathSensitivity.RELATIVE)

--- a/slack-plugin/src/main/kotlin/slack/stats/LocTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/LocTask.kt
@@ -32,7 +32,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import slack.stats.LocTask.LocData
 


### PR DESCRIPTION
We want to always run this because not every module has source files. In those cases we want to just write an empty JSON object for tasks that depend on this task's outputs. This fixes an issue we would see in resources-only projects
