### PR TITLE
Make LocData optional instead

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/stats/LocTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/LocTask.kt
@@ -32,6 +32,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import slack.stats.LocTask.LocData
 
@@ -43,8 +44,7 @@ import slack.stats.LocTask.LocData
  */
 @CacheableTask
 internal abstract class LocTask : DefaultTask() {
-  // Always run this! Not every module has source files but in those cases we want to just write
-  // an empty JSON object for tasks that depend on this task's outputs.
+  @get:SkipWhenEmpty
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputDirectory
   abstract val srcsDir: DirectoryProperty
@@ -216,5 +216,9 @@ internal abstract class LocTask : DefaultTask() {
   data class LocData(
     val srcs: Map<String, LanguageStats>,
     val generatedSrcs: Map<String, LanguageStats>
-  )
+  ) {
+    companion object {
+      val EMPTY = LocData(emptyMap(), emptyMap())
+    }
+  }
 }

--- a/slack-plugin/src/main/kotlin/slack/stats/ModuleStats.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/ModuleStats.kt
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -349,7 +350,10 @@ internal abstract class ModuleStatsCollectorTask : DefaultTask() {
   @get:InputFile
   abstract val buildFileProperty: RegularFileProperty
 
-  @get:PathSensitive(PathSensitivity.NONE) @get:InputFile abstract val locData: RegularFileProperty
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  abstract val locData: RegularFileProperty
 
   @get:OutputFile abstract val outputFile: RegularFileProperty
 
@@ -362,8 +366,12 @@ internal abstract class ModuleStatsCollectorTask : DefaultTask() {
   @TaskAction
   fun dumpStats() {
     val (sources, generatedSources) =
-      locData.asFile.get().source().buffer().use { source ->
-        moshi.adapter<LocTask.LocData>().fromJson(source)!!
+      if (locData.isPresent) {
+        locData.asFile.get().source().buffer().use { source ->
+          moshi.adapter<LocTask.LocData>().fromJson(source)!!
+        }
+      } else {
+        LocTask.LocData.EMPTY
       }
 
     val dependencies = StatsUtils.parseProjectDeps(buildFileProperty.asFile.get())


### PR DESCRIPTION
Apparently having an empty input dir just breaks gradle so we need to keep skipwhenempty and instead just handle it as an optional input elsewhere
