### PR TITLE
Implement compose() feature DSL in SlackExtension

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
@@ -46,7 +46,9 @@ internal class SlackBasePlugin : Plugin<Project> {
     val slackProperties = SlackProperties(target)
 
     if (!target.isRootProject) {
-      StandardProjectConfigurations().applyTo(target)
+      val versionCatalog =
+        target.getVersionsCatalogOrNull() ?: error("SGP requires use of version catalogs!")
+      StandardProjectConfigurations(slackProperties, versionCatalog).applyTo(target)
       target.configureTests(slackProperties)
 
       // Configure Gradle's test-retry plugin for insights on build scans on CI only

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -679,6 +679,7 @@ constructor(
         "ComposeHandler must be configured with an Android extension before it can be enabled. Did you apply the Android gradle plugin?"
       }
     enabled.set(true)
+    enabled.disallowChanges()
     extension.apply {
       buildFeatures { compose = true }
       composeOptions { kotlinCompilerExtensionVersion = composeCompilerVersion }

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
@@ -214,18 +214,13 @@ internal fun Project.jvmTargetVersion(): Int {
   return SlackProperties(this).jvmTarget
 }
 
-internal fun Project.getVersionsCatalog(
-  properties: SlackProperties = SlackProperties(this)
-): VersionCatalog {
-  return getVersionsCatalogOrNull(properties) ?: error("No versions catalog found!")
+internal fun Project.getVersionsCatalog(): VersionCatalog {
+  return getVersionsCatalogOrNull() ?: error("No versions catalog found!")
 }
 
-internal fun Project.getVersionsCatalogOrNull(
-  properties: SlackProperties = SlackProperties(this)
-): VersionCatalog? {
-  val name = properties.versionCatalogName
+internal fun Project.getVersionsCatalogOrNull(): VersionCatalog? {
   return try {
-    project.extensions.getByType<VersionCatalogsExtension>().named(name)
+    project.extensions.getByType<VersionCatalogsExtension>().named("libs")
   } catch (ignored: Exception) {
     null
   }

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -52,7 +52,7 @@ public class SlackProperties private constructor(private val project: Project) {
 
   internal val versions: SlackVersions by lazy {
     project.rootProject.getOrCreateExtra("slack-versions") {
-      SlackVersions(project.rootProject.getVersionsCatalog(this))
+      SlackVersions(project.rootProject.getVersionsCatalog())
     }
   }
 
@@ -120,12 +120,12 @@ public class SlackProperties private constructor(private val project: Project) {
   public val versionsJson: File?
     get() = fileProperty("slack.versionsJson")
 
-  /** Toggle for enabling Jetpack Compose in Android subprojects. */
-  public val enableCompose: Boolean
-    get() =
-      booleanProperty(
-        "slack.enableCompose",
-      )
+  /**
+   * An alias name to a libs.versions.toml bundle for common Android Compose dependencies that
+   * should be added to android projects with compose enabled
+   */
+  public val defaultComposeAndroidBundleAlias: String?
+    get() = optionalStringProperty("slack.compose.android.defaultBundleAlias")
 
   /**
    * When this property is present, the "internalRelease" build variant will have an application id
@@ -365,10 +365,6 @@ public class SlackProperties private constructor(private val project: Project) {
   /** Specific toggle for validating the presence of `.kt` files in Kotlin projects. */
   public val strictValidateKtFilePresence: Boolean
     get() = booleanProperty("slack.strict.validateKtFiles", defaultValue = true)
-
-  /** Specified the name of the versions catalog to use for bom management. */
-  public val versionCatalogName: String
-    get() = stringProperty("slack.catalog", defaultValue = "libs")
 
   internal fun requireAndroidSdkProperties(): AndroidSdkProperties {
     val compileSdk = compileSdkVersion ?: error("slack.compileSdkVersion not set")

--- a/slack-plugin/src/main/kotlin/slack/gradle/dependencies/SlackDependencies.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/dependencies/SlackDependencies.kt
@@ -15,7 +15,6 @@
  */
 package slack.gradle.dependencies
 
-import slack.gradle.SlackProperties
 import slack.gradle.dependencies.SlackDependencies.artifact
 
 /**
@@ -78,16 +77,7 @@ import slack.gradle.dependencies.SlackDependencies.artifact
 @Suppress("MemberNameEqualsClassName") // Detekt is being silly here
 internal object SlackDependencies : DependencySet() {
 
-  val clikt: Any by artifact("com.github.ajalt.clikt")
   internal val javaxInject: Any by artifact("javax.inject", "javax.inject")
-  object Androidx : DependencySet() {
-    /** NOTE: You must enable the [SlackProperties.enableCompose] property to use these. */
-    object Compose : DependencyGroup("androidx.compose", "compose") {
-      val compiler: Any by
-        artifact(groupOverride = "androidx.compose.compiler", gradleProperty = "compose-compiler")
-      val runtime: Any by artifact(groupOverride = "androidx.compose.runtime")
-    }
-  }
 
   object Anvil : DependencyGroup("com.squareup.anvil", "anvil") {
     internal val annotations by artifact()


### PR DESCRIPTION
This moves compose support to a new DSL configuration instead.

```kotlin
slack {
  android {
    features {
      compose()
    }
  }
}
```

Currently there is no extra configuration beyond the above in the DSL, but we could add more in the future. This also adds a new `defaultComposeAndroidBundleAlias` property that can be used to identify a default `libs.bundle.*` alias to include in any projects that enable compose. This is, in this case, just focused on adding _core_ compose deps (runtime, ui, etc).

One implementation note is that due to AGP using regular kotlin properties still, we have to make enabling compose a synchronous action that directly sets them on the underlying AGP property under the hood. If they ever convert them into lazy gradle properties, we could look at chaining these instead.