### PR TITLE
Specify kotlin version in compose compatibility check

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
@@ -27,12 +27,16 @@ internal class SlackVersions(val catalog: VersionCatalog) {
     get() = getOptionalValue("agp").orElse(null)
   val composeCompiler: String?
     get() = getOptionalValue("compose-compiler").orElse(null)
+  val composeCompilerKotlinVersion: String?
+    get() = getOptionalValue("compose-compiler-kotlin-version").orElse(null)
   val detekt: String?
     get() = getOptionalValue("detekt").orElse(null)
   val gjf: String?
     get() = getOptionalValue("google-java-format").orElse(null)
   val gson: String?
     get() = getOptionalValue("gson").orElse(null)
+  val kotlin: String
+    get() = getValue("kotlin")
   val ktlint: String?
     get() = getOptionalValue("ktlint").orElse(null)
   val ktfmt: String?

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -793,11 +793,20 @@ internal class StandardProjectConfigurations(
             )
             freeCompilerArgs += "-Xskip-prerelease-check"
             // Flag to disable Compose's kotlin version check because they're often behind
-            freeCompilerArgs +=
-              listOf(
-                "-P",
-                "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true"
-              )
+            // Or ahead
+            // Or if they're the same, do nothing
+            // It's basically just very noisy.
+            val composeCompilerKotlinVersion =
+              slackProperties.versions.composeCompilerKotlinVersion
+                ?: error("missing 'compose-compiler-kotlin-version' version in version catalog")
+            val kotlinVersion = slackProperties.versions.kotlin
+            if (kotlinVersion != composeCompilerKotlinVersion) {
+              freeCompilerArgs +=
+                listOf(
+                  "-P",
+                  "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=$kotlinVersion"
+                )
+            }
           }
 
           // Potentially useful for static analysis or annotation processors

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -798,7 +798,7 @@ internal class StandardProjectConfigurations(
             // It's basically just very noisy.
             val composeCompilerKotlinVersion =
               slackProperties.versions.composeCompilerKotlinVersion
-                ?: error("missing 'compose-compiler-kotlin-version' version in version catalog")
+                ?: error("Missing 'composeCompilerKotlinVersion' version in version catalog")
             val kotlinVersion = slackProperties.versions.kotlin
             if (kotlinVersion != composeCompilerKotlinVersion) {
               freeCompilerArgs +=


### PR DESCRIPTION
This is an annoying new granularity to the compose compiler version checks that we have to handle now.

kotlin 1.7.10, compose expects 1.7.0 => specify

1.7.10 kotlin 1.7.10, compose expects 1.7.10 => omit the arg entirely

https://android-review.googlesource.com/c/platform/frameworks/support/+/2189520