### PR TITLE
Only enable android test on allowed variants

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
@@ -697,6 +698,7 @@ constructor(
 ) {
   internal abstract val androidTest: Property<Boolean>
   internal abstract val androidTestExcludeFromFladle: Property<Boolean>
+  internal abstract val androidTestAllowedVariants: SetProperty<String>
   internal abstract val robolectric: Property<Boolean>
 
   // Compose features
@@ -707,10 +709,18 @@ constructor(
    * Enables android instrumentation tests for this project.
    *
    * @param excludeFromFladle If true, the test will be excluded from Flank/Fladle tests.
+   * @param allowedVariants If set, the allowed variants to enable android tests for.
    */
-  public fun androidTest(excludeFromFladle: Boolean = false) {
+  public fun androidTest(
+    excludeFromFladle: Boolean = false,
+    allowedVariants: List<String>? = null
+  ) {
     androidTest.set(true)
     androidTestExcludeFromFladle.set(excludeFromFladle)
+    androidTestAllowedVariants.set(allowedVariants)
+    androidTest.disallowChanges()
+    androidTestExcludeFromFladle.disallowChanges()
+    androidTestAllowedVariants.disallowChanges()
   }
 
   /** Enables robolectric for this project. */

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -408,8 +408,7 @@ internal class StandardProjectConfigurations(
               builder.enable = false
               builder.enableUnitTest = false
               if (builder is HasAndroidTestBuilder) {
-                builder.enableAndroidTest =
-                  slackExtension.androidHandler.featuresHandler.androidTest.getOrElse(false)
+                builder.enableAndroidTest = false
               }
             }
           }
@@ -658,8 +657,14 @@ internal class StandardProjectConfigurations(
 
         // Disable androidTest tasks in libraries unless they opt-in
         beforeVariants { builder ->
-          builder.enableAndroidTest =
+          val androidTestEnabled =
             slackExtension.androidHandler.featuresHandler.androidTest.getOrElse(false)
+          val variantEnabled =
+            androidTestEnabled &&
+              (slackExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
+                ?.contains(builder.flavorName)
+                ?: true)
+          builder.enableAndroidTest = variantEnabled
         }
 
         // Contribute these libraries to Fladle if they opt into it


### PR DESCRIPTION
This way we can disable androidTest compilation tasks for variants that don't actually run them