### PR TITLE
Two quick androidTest allowed variants fixes

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -713,7 +713,7 @@ constructor(
    */
   public fun androidTest(
     excludeFromFladle: Boolean = false,
-    allowedVariants: Set<String>? = null
+    allowedVariants: Iterable<String>? = null
   ) {
     androidTest.set(true)
     androidTestExcludeFromFladle.set(excludeFromFladle)

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -516,6 +516,15 @@ internal class StandardProjectConfigurations(
             if (builder.buildType == "release") {
               builder.enableUnitTest = false
             }
+            // Disable androidTest tasks in libraries unless they opt-in
+            val androidTestEnabled =
+              slackExtension.androidHandler.featuresHandler.androidTest.getOrElse(false)
+            val variantEnabled =
+              androidTestEnabled &&
+                builder.name in
+                  slackExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
+                    .orEmpty()
+            builder.enableAndroidTest = variantEnabled
           }
         }
       }
@@ -661,9 +670,9 @@ internal class StandardProjectConfigurations(
             slackExtension.androidHandler.featuresHandler.androidTest.getOrElse(false)
           val variantEnabled =
             androidTestEnabled &&
-              (slackExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
-                ?.contains(builder.flavorName)
-                ?: true)
+              builder.name in
+                slackExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
+                  .orEmpty()
           builder.enableAndroidTest = variantEnabled
         }
 


### PR DESCRIPTION
- Fix using the wrong name for the flavor name check
- Fix not applying this in application projects too