### PR TITLE
Add robolectric add-opens args

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -28,12 +28,14 @@ import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.domainObjectSet
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 import slack.gradle.agp.PermissionAllowlistConfigurer
 import slack.gradle.dependencies.SlackDependencies
@@ -674,11 +676,19 @@ constructor(
       if (featuresHandler.robolectric.getOrElse(false)) {
         project.dependencies {
           // For projects using robolectric, we want to make sure they include robolectric-core to
-          // ensure robolectric
-          // uses our custom dependency resolver and confg (which just need to be on the classpath).
+          // ensure robolectric uses our custom dependency resolver and config (which just need
+          // to be on the classpath).
           add("testImplementation", SlackDependencies.Testing.Robolectric.annotations)
           add("testImplementation", SlackDependencies.Testing.Robolectric.robolectric)
           add("testImplementation", slackProperties.robolectricCoreProject)
+        }
+        // Robolectric 4.9+ requires these --add-opens options.
+        // https://github.com/robolectric/robolectric/issues/7456
+        project.tasks.withType<Test>().configureEach {
+          jvmArgs(
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+          )
         }
       }
 


### PR DESCRIPTION
Necessary on robolectric 4.9+ due to https://github.com/robolectric/robolectric/issues/7456