### PR TITLE
Only check allowed androidTest variants if any are defined

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -521,9 +521,9 @@ internal class StandardProjectConfigurations(
               slackExtension.androidHandler.featuresHandler.androidTest.getOrElse(false)
             val variantEnabled =
               androidTestEnabled &&
-                builder.name in
-                  slackExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
-                    .orEmpty()
+                slackExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
+                  ?.contains(builder.name)
+                  ?: true
             builder.enableAndroidTest = variantEnabled
           }
         }
@@ -645,9 +645,9 @@ internal class StandardProjectConfigurations(
             slackExtension.androidHandler.featuresHandler.androidTest.getOrElse(false)
           val variantEnabled =
             androidTestEnabled &&
-              builder.name in
-                slackExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
-                  .orEmpty()
+              slackExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
+                ?.contains(builder.name)
+                ?: true
           builder.enableAndroidTest = variantEnabled
         }
 


### PR DESCRIPTION
We initially set this up to default to treating all variants as disabled if none were defined, when we should be doing the opposite.