### PR TITLE
Add support for android test projects

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -19,7 +19,10 @@ package slack.gradle
 
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.dsl.Lint
-import com.android.build.api.variant.*
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.HasAndroidTestBuilder
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -19,13 +19,11 @@ package slack.gradle
 
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.dsl.Lint
-import com.android.build.api.variant.AndroidComponentsExtension
-import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.api.variant.HasAndroidTestBuilder
-import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.*
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.gradle.internal.dsl.BuildType
 import com.autonomousapps.DependencyAnalysisSubExtension
@@ -420,71 +418,75 @@ internal class StandardProjectConfigurations(
 
     val sdkVersions by lazy { slackProperties.requireAndroidSdkProperties() }
     val shouldApplyCacheFixPlugin = slackProperties.enableAndroidCacheFix
-    val commonBaseExtensionConfig: BaseExtension.() -> Unit = {
-      if (shouldApplyCacheFixPlugin) {
-        apply(plugin = "org.gradle.android.cache-fix")
-      }
-
-      compileSdkVersion(sdkVersions.compileSdk)
-      slackProperties.ndkVersion?.let { ndkVersion = it }
-      defaultConfig {
-        // TODO this won't work with SDK previews but will fix in a followup
-        minSdk = sdkVersions.minSdk
-        vectorDrawables.useSupportLibrary = true
-        // Default to the standard android runner, but note this is overridden in :app
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-      }
-
-      compileOptions {
-        sourceCompatibility = javaVersion
-        targetCompatibility = javaVersion
-        isCoreLibraryDesugaringEnabled = true
-      }
-
-      dependencies.add(
-        Configurations.CORE_LIBRARY_DESUGARING,
-        SlackDependencies.Google.coreLibraryDesugaring
-      )
-
-      testOptions {
-        animationsDisabled = true
-
-        if (booleanProperty("orchestrator")) {
-          logger.info(
-            "[android.testOptions]: Configured to run tests with Android Test Orchestrator"
-          )
-          execution = "ANDROIDX_TEST_ORCHESTRATOR"
-        } else {
-          logger.debug(
-            "[android.testOptions]: Configured to run tests without Android Test Orchestrator"
-          )
+    val commonBaseExtensionConfig: BaseExtension.(applyTestOptions: Boolean) -> Unit =
+      { applyTestOptions ->
+        if (shouldApplyCacheFixPlugin) {
+          apply(plugin = "org.gradle.android.cache-fix")
         }
 
-        // Added to avoid unimplemented exceptions in some of the unit tests that have simple
-        // android dependencies like checking whether code is running on main thread.
-        // See https://developer.android.com/training/testing/unit-testing/local-unit-tests
-        // #error-not-mocked for more details
-        unitTests.isReturnDefaultValues = true
-        unitTests.isIncludeAndroidResources = true
+        compileSdkVersion(sdkVersions.compileSdk)
+        slackProperties.ndkVersion?.let { ndkVersion = it }
+        defaultConfig {
+          // TODO this won't work with SDK previews but will fix in a followup
+          minSdk = sdkVersions.minSdk
+          vectorDrawables.useSupportLibrary = true
+          // Default to the standard android runner, but note this is overridden in :app
+          testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        }
 
-        // Configure individual Tests tasks.
-        unitTests.all(
-          typedClosureOf {
-            //
-            // Note that we can't configure this to _just_ be enabled for robolectric projects
-            // based on dependencies unfortunately, as the task graph is already wired by the time
-            // dependencies start getting resolved.
-            //
-            logger.debug("Configuring $name test task to depend on Robolectric jar downloads")
-            dependsOn(globalConfig.updateRobolectricJarsTask)
+        compileOptions {
+          sourceCompatibility = javaVersion
+          targetCompatibility = javaVersion
+          isCoreLibraryDesugaringEnabled = true
+        }
 
-            // Necessary for some OkHttp-using tests to work on JDK 11 in Robolectric
-            // https://github.com/robolectric/robolectric/issues/5115
-            systemProperty("javax.net.ssl.trustStoreType", "JKS")
-          }
+        dependencies.add(
+          Configurations.CORE_LIBRARY_DESUGARING,
+          SlackDependencies.Google.coreLibraryDesugaring
         )
+
+        if (applyTestOptions) {
+          testOptions {
+            animationsDisabled = true
+
+            if (booleanProperty("orchestrator")) {
+              logger.info(
+                "[android.testOptions]: Configured to run tests with Android Test Orchestrator"
+              )
+              execution = "ANDROIDX_TEST_ORCHESTRATOR"
+            } else {
+              logger.debug(
+                "[android.testOptions]: Configured to run tests without Android Test Orchestrator"
+              )
+            }
+
+            // Added to avoid unimplemented exceptions in some of the unit tests that have simple
+            // android dependencies like checking whether code is running on main thread.
+            // See https://developer.android.com/training/testing/unit-testing/local-unit-tests
+            // #error-not-mocked for more details
+            unitTests.isReturnDefaultValues = true
+            unitTests.isIncludeAndroidResources = true
+
+            // Configure individual Tests tasks.
+            unitTests.all(
+              typedClosureOf {
+                //
+                // Note that we can't configure this to _just_ be enabled for robolectric projects
+                // based on dependencies unfortunately, as the task graph is already wired by the
+                // time
+                // dependencies start getting resolved.
+                //
+                logger.debug("Configuring $name test task to depend on Robolectric jar downloads")
+                dependsOn(globalConfig.updateRobolectricJarsTask)
+
+                // Necessary for some OkHttp-using tests to work on JDK 11 in Robolectric
+                // https://github.com/robolectric/robolectric/issues/5115
+                systemProperty("javax.net.ssl.trustStoreType", "JKS")
+              }
+            )
+          }
+        }
       }
-    }
 
     val objenesis2Version = slackProperties.versions.objenesis
     val prepareAndroidTestConfigurations = {
@@ -498,6 +500,15 @@ internal class StandardProjectConfigurations(
             resolutionStrategy.force("org.objenesis:objenesis:$it")
           }
         }
+      }
+    }
+
+    pluginManager.withPlugin("com.android.test") {
+      slackProperties.versions.bundles.commonLint.ifPresent { dependencies.add("lintChecks", it) }
+      configure<TestExtension> {
+        slackExtension.androidHandler.featuresHandler.composeHandler.androidExtension = this
+        commonBaseExtensionConfig(false)
+        defaultConfig { targetSdk = sdkVersions.targetSdk }
       }
     }
 
@@ -530,7 +541,7 @@ internal class StandardProjectConfigurations(
       }
       configure<BaseAppModuleExtension> {
         slackExtension.androidHandler.featuresHandler.composeHandler.androidExtension = this
-        commonBaseExtensionConfig()
+        commonBaseExtensionConfig(true)
         defaultConfig {
           // TODO this won't work with SDK previews but will fix in a followup
           targetSdk = sdkVersions.targetSdk
@@ -692,7 +703,7 @@ internal class StandardProjectConfigurations(
       }
       configure<LibraryExtension> {
         slackExtension.androidHandler.featuresHandler.composeHandler.androidExtension = this
-        commonBaseExtensionConfig()
+        commonBaseExtensionConfig(true)
         lint { configureLint(project, slackProperties, sdkVersions, false) }
         if (isLibraryWithVariants) {
           buildTypes {


### PR DESCRIPTION
This adds basic support for `com.android.test` projects. Nothing too crazy, mostly the `pluginManager` block. The rest are mostly indent changes