### PR TITLE
Only enable androidResources in tests if robolectric is requested

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -613,13 +613,7 @@ constructor(
   }
   internal val enabled = objects.property<Boolean>().convention(false)
 
-  /**
-   * This is weird! Due to the non-property nature of the AGP buildFeatures and composeOptions DSLs,
-   * we can't lazily chain their values to our own extension's properties. Because of this, we
-   * lazily set this instance from [StandardProjectConfigurations] during Android extension
-   * evaluation and then make calls to [enable] directly set the values on this instance. Ideally we
-   * could eventually remove this if/when AGP finally makes these properties lazy.
-   */
+  /** @see [AndroidHandler.androidExtension] */
   internal var androidExtension: CommonExtension<*, *, *, *>? = null
 
   internal fun enable() {
@@ -671,6 +665,19 @@ constructor(
       versionCatalog
     )
 
+  /**
+   * This is weird! Due to the non-property nature of the AGP buildFeatures and composeOptions DSLs,
+   * we can't lazily chain their values to our own extension's properties. Because of this, we
+   * lazily set this instance from [StandardProjectConfigurations] during Android extension
+   * evaluation and then make calls to [enable] directly set the values on this instance. Ideally we
+   * could eventually remove this if/when AGP finally makes these properties lazy.
+   */
+  internal var androidExtension: CommonExtension<*, *, *, *>? = null
+    set(value) {
+      field = value
+      featuresHandler.composeHandler.androidExtension = value
+    }
+
   public fun features(action: Action<AndroidFeaturesHandler>) {
     action.execute(featuresHandler)
   }
@@ -703,6 +710,9 @@ constructor(
             "--add-opens=java.base/java.util=ALL-UNNAMED",
           )
         }
+
+        // Required for Robolectric to work.
+        androidExtension!!.testOptions.unitTests.isIncludeAndroidResources = true
       }
 
       featuresHandler.composeHandler.applyTo(project)

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -743,7 +743,6 @@ constructor(
       composeHandler.androidExtension = value
     }
 
-
   /**
    * Enables android instrumentation tests for this project.
    *

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -675,6 +675,7 @@ constructor(
   internal var androidExtension: CommonExtension<*, *, *, *>? = null
     set(value) {
       field = value
+      featuresHandler.androidExtension = value
       featuresHandler.composeHandler.androidExtension = value
     }
 
@@ -710,9 +711,6 @@ constructor(
             "--add-opens=java.base/java.util=ALL-UNNAMED",
           )
         }
-
-        // Required for Robolectric to work.
-        androidExtension!!.testOptions.unitTests.isIncludeAndroidResources = true
       }
 
       featuresHandler.composeHandler.applyTo(project)
@@ -738,6 +736,14 @@ constructor(
   internal val composeHandler =
     objects.newInstance<ComposeHandler>(globalSlackProperties, slackProperties, versionCatalog)
 
+  /** @see [AndroidHandler.androidExtension] */
+  internal var androidExtension: CommonExtension<*, *, *, *>? = null
+    set(value) {
+      field = value
+      composeHandler.androidExtension = value
+    }
+
+
   /**
    * Enables android instrumentation tests for this project.
    *
@@ -759,6 +765,8 @@ constructor(
   /** Enables robolectric for this project. */
   // In the future, we may want to add an enum for picking which shadows/artifacts
   public fun robolectric() {
+    // Required for Robolectric to work.
+    androidExtension!!.testOptions.unitTests.isIncludeAndroidResources = true
     robolectric.set(true)
   }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -370,6 +370,12 @@ public class SlackProperties private constructor(private val project: Project) {
   public val strictValidateAndroidTestManifest: Boolean
     get() = booleanProperty("slack.strict.validateAndroidTestManifests", defaultValue = true)
 
+  /**
+   * Always enables resources in android unit tests. Only present for benchmarking purposes and should otherwise be off.
+   */
+  public val alwaysEnableResourcesInTests: Boolean
+    get() = booleanProperty("slack.gradle.config.test.alwaysEnableResources", defaultValue = false)
+
   internal fun requireAndroidSdkProperties(): AndroidSdkProperties {
     val compileSdk = compileSdkVersion ?: error("slack.compileSdkVersion not set")
     val minSdk = minSdkVersion?.toInt() ?: error("slack.minSdkVersion not set")

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -371,7 +371,8 @@ public class SlackProperties private constructor(private val project: Project) {
     get() = booleanProperty("slack.strict.validateAndroidTestManifests", defaultValue = true)
 
   /**
-   * Always enables resources in android unit tests. Only present for benchmarking purposes and should otherwise be off.
+   * Always enables resources in android unit tests. Only present for benchmarking purposes and
+   * should otherwise be off.
    */
   public val alwaysEnableResourcesInTests: Boolean
     get() = booleanProperty("slack.gradle.config.test.alwaysEnableResources", defaultValue = false)

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -468,7 +468,6 @@ internal class StandardProjectConfigurations(
             // See https://developer.android.com/training/testing/unit-testing/local-unit-tests
             // #error-not-mocked for more details
             unitTests.isReturnDefaultValues = true
-            unitTests.isIncludeAndroidResources = true
 
             // Configure individual Tests tasks.
             agpHandler.allUnitTestOptions(unitTests) { test ->
@@ -506,7 +505,7 @@ internal class StandardProjectConfigurations(
     pluginManager.withPlugin("com.android.test") {
       slackProperties.versions.bundles.commonLint.ifPresent { dependencies.add("lintChecks", it) }
       configure<TestExtension> {
-        slackExtension.androidHandler.featuresHandler.composeHandler.androidExtension = this
+        slackExtension.androidHandler.androidExtension = this
         commonBaseExtensionConfig(false)
         defaultConfig { targetSdk = sdkVersions.targetSdk }
       }
@@ -540,7 +539,7 @@ internal class StandardProjectConfigurations(
         }
       }
       configure<BaseAppModuleExtension> {
-        slackExtension.androidHandler.featuresHandler.composeHandler.androidExtension = this
+        slackExtension.androidHandler.androidExtension = this
         commonBaseExtensionConfig(true)
         defaultConfig {
           // TODO this won't work with SDK previews but will fix in a followup
@@ -714,7 +713,7 @@ internal class StandardProjectConfigurations(
         }
       }
       configure<LibraryExtension> {
-        slackExtension.androidHandler.featuresHandler.composeHandler.androidExtension = this
+        slackExtension.androidHandler.androidExtension = this
         commonBaseExtensionConfig(true)
         lint { configureLint(project, slackProperties, sdkVersions, false) }
         if (isLibraryWithVariants) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -468,6 +468,9 @@ internal class StandardProjectConfigurations(
             // See https://developer.android.com/training/testing/unit-testing/local-unit-tests
             // #error-not-mocked for more details
             unitTests.isReturnDefaultValues = true
+            if (slackProperties.alwaysEnableResourcesInTests) {
+              unitTests.isIncludeAndroidResources = true
+            }
 
             // Configure individual Tests tasks.
             agpHandler.allUnitTestOptions(unitTests) { test ->


### PR DESCRIPTION
MergeResources is an expensive task and we currently enable it on every android project by default. However, only Robolectric needs this in our needs, so we can save time by only enabling it when tests need it.

In our internal codebase this brings our CI unit test job down from ~18k tasks to ~15k total tasks. Working on benchmarks with this next to see time improvements.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->