### PR TITLE
Backport new jniLibs access in AGP 8 handling

### DIFF
--- a/agp-handlers/agp-handler-73/src/main/kotlin/slack/gradle/agphandler/v73/AgpHandlerFactory73.kt
+++ b/agp-handlers/agp-handler-73/src/main/kotlin/slack/gradle/agphandler/v73/AgpHandlerFactory73.kt
@@ -15,6 +15,7 @@
  */
 package slack.gradle.agphandler.v73
 
+import com.android.build.api.dsl.PackagingOptions
 import com.android.build.gradle.internal.dsl.TestOptions
 import com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
 import com.google.auto.service.AutoService
@@ -42,6 +43,13 @@ private class AgpHandler73 : AgpHandler {
 
   override fun allUnitTestOptions(options: TestOptions.UnitTestOptions, body: (Test) -> Unit) {
     options.all(typedClosureOf(body))
+  }
+
+  override fun jniLibsPickFirst(
+    packagingOptions: PackagingOptions,
+    pickFirsts: Collection<String>
+  ) {
+    packagingOptions.jniLibs.pickFirsts += pickFirsts
   }
 }
 

--- a/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
+++ b/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
@@ -15,6 +15,7 @@
  */
 package slack.gradle.agphandler.v80
 
+import com.android.build.api.dsl.PackagingOptions
 import com.android.build.gradle.internal.dsl.TestOptions
 import com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
 import com.google.auto.service.AutoService
@@ -40,5 +41,12 @@ private class AgpHandler80 : AgpHandler {
 
   override fun allUnitTestOptions(options: TestOptions.UnitTestOptions, body: (Test) -> Unit) {
     options.all(body)
+  }
+
+  override fun jniLibsPickFirst(
+    packagingOptions: PackagingOptions,
+    pickFirsts: Collection<String>
+  ) {
+    packagingOptions.jniLibs.pickFirsts += pickFirsts
   }
 }

--- a/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandler.kt
+++ b/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandler.kt
@@ -15,6 +15,7 @@
  */
 package slack.gradle.agp
 
+import com.android.build.api.dsl.PackagingOptions
 import com.android.build.gradle.internal.dsl.TestOptions
 import org.gradle.api.tasks.testing.Test
 
@@ -26,6 +27,12 @@ public interface AgpHandler {
 
   /** Shim for `testOptions.unitTest.all`, which had a signature change in AGP 8.x. */
   public fun allUnitTestOptions(options: TestOptions.UnitTestOptions, body: (Test) -> Unit)
+
+  /**
+   * Shim for packagingOptions.jniLibs.pickFirst, which had a signature change in AGP 8.x from
+   * `JniLibsPackagingOptions` to `JniLibsPackaging`.
+   */
+  public fun jniLibsPickFirst(packagingOptions: PackagingOptions, pickFirsts: Collection<String>)
 }
 
 /**

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -573,6 +573,14 @@ internal class StandardProjectConfigurations(
               // https://slack-pde.slack.com/archives/C8EER3C04/p1621353426001500
               "annotated-jdk/**"
             )
+          agpHandler.jniLibsPickFirst(
+            this,
+            setOf(
+              // Some libs like Flipper bring their own copy of common native libs (like C++) and we
+              // need to de-dupe
+              "**/*.so"
+            )
+          )
           jniLibs.pickFirsts +=
             setOf(
               // Some libs like Flipper bring their own copy of common native libs (like C++) and we

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -581,12 +581,6 @@ internal class StandardProjectConfigurations(
               "**/*.so"
             )
           )
-          jniLibs.pickFirsts +=
-            setOf(
-              // Some libs like Flipper bring their own copy of common native libs (like C++) and we
-              // need to de-dupe
-              "**/*.so"
-            )
         }
         buildTypes {
           getByName("debug") {


### PR DESCRIPTION
The returned class went from `JniPackagingOptions` to `JniPackaging`, which is a signature change that breaks at runtime.
