### PR TITLE
Don't apply KotlinCompile configs automatically to stub gen tasks

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
@@ -33,6 +33,7 @@ import org.gradle.kotlin.dsl.retry
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import slack.gradle.tasks.CoreBootstrapTask
+import slack.gradle.util.configureKotlinCompile
 import slack.gradle.util.synchronousEnvProperty
 import slack.stats.ModuleStatsTasks
 
@@ -85,14 +86,12 @@ internal class SlackBasePlugin : Plugin<Project> {
         incoming.afterResolve {
           dependencies.forEach { dependency ->
             if (dependency.name == "eithernet") {
-              target.tasks
-                .withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>()
-                .configureEach {
-                  kotlinOptions {
-                    @Suppress("SuspiciousCollectionReassignment")
-                    freeCompilerArgs += "-opt-in=com.slack.eithernet.ExperimentalEitherNetApi"
-                  }
+              target.tasks.configureKotlinCompile {
+                kotlinOptions {
+                  @Suppress("SuspiciousCollectionReassignment")
+                  freeCompilerArgs += "-opt-in=com.slack.eithernet.ExperimentalEitherNetApi"
                 }
+              }
             }
           }
         }

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -72,7 +72,6 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import slack.dependencyrake.RakeDependencies
 import slack.gradle.AptOptionsConfig.AptOptionsConfigurer
 import slack.gradle.AptOptionsConfigs.invoke
@@ -82,6 +81,7 @@ import slack.gradle.permissionchecks.PermissionChecks
 import slack.gradle.tasks.AndroidTestApksTask
 import slack.gradle.tasks.CheckManifestPermissionsTask
 import slack.gradle.util.booleanProperty
+import slack.gradle.util.configureKotlinCompile
 
 private const val LOG = "SlackPlugin:"
 
@@ -798,7 +798,7 @@ internal class StandardProjectConfigurations(
     plugins.withType<KotlinBasePlugin> {
       configure<KotlinProjectExtension> { kotlinDaemonJvmArgs = globalConfig.kotlinDaemonArgs }
       @Suppress("SuspiciousCollectionReassignment")
-      tasks.configureEach<KotlinCompile> {
+      tasks.configureKotlinCompile {
         kotlinOptions {
           if (!slackProperties.allowWarnings && !name.contains("test", ignoreCase = true)) {
             allWarningsAsErrors = true
@@ -811,7 +811,7 @@ internal class StandardProjectConfigurations(
             slackExtension.androidHandler.featuresHandler.composeHandler.enabled.get() && isAndroid
           ) {
             logger.debug(
-              "Configuring compose compiler args in ${project.path}:${this@configureEach.name}"
+              "Configuring compose compiler args in ${project.path}:${this@configureKotlinCompile.name}"
             )
             freeCompilerArgs += "-Xskip-prerelease-check"
             // Flag to disable Compose's kotlin version check because they're often behind
@@ -972,7 +972,7 @@ internal class StandardProjectConfigurations(
           dependencies.forEach { dependency ->
             KotlinArgConfigs.ALL[dependency.name]?.let { config ->
               if (once.compareAndSet(false, true)) {
-                tasks.withType<KotlinCompile>().configureEach {
+                tasks.configureKotlinCompile {
                   kotlinOptions {
                     @Suppress("SuspiciousCollectionReassignment") // This isn't suspicious
                     freeCompilerArgs += config.args

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/kgpUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/kgpUtil.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.util
+
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+/**
+ * Configures [KotlinCompile] tasks with the given [action] but _ignores_ [KaptGenerateStubsTask]
+ * types as they inherit arguments from standard tasks via
+ * [KaptGenerateStubsTask.compileKotlinArgumentsContributor] and applying arguments to them could
+ * result in duplicates.
+ *
+ * See
+ * https://github.com/JetBrains/kotlin/blob/0e4e53786c1b0341befe8e71a5e6e0bc0e464370/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptGenerateStubsTask.kt#L111-L113
+ */
+internal fun TaskContainer.configureKotlinCompile(action: KotlinCompile.() -> Unit) {
+  withType<KotlinCompile>()
+    // Kapt stub gen is a special case because KGP sets it up to copy compiler args from the
+    // standard kotlin compilation, which can lead to duplicates. SOOOO we skip configuration of
+    // it here.
+    .matching { it !is KaptGenerateStubsTask }
+    .configureEach { action() }
+}


### PR DESCRIPTION
KGP automatically copies arguments from the "real" kotlincompile task [here](https://github.com/JetBrains/kotlin/blob/0e4e53786c1b0341befe8e71a5e6e0bc0e464370/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/KaptGenerateStubsTask.kt#L111-L113) and can result in duplicates if we add them on our own.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->