### PR TITLE
Update to AGP 8.0-alpha10 and further backport packagingOptions changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         ci_java_version: ['17']
         ci_kotlin_version: ['1.7.22']
-        ci_agp_version: ['7.3.1', '7.4.0-rc01', '8.0.0-alpha09']
+        ci_agp_version: ['7.3.1', '7.4.0-rc02', '8.0.0-alpha10']
     env:
       DEP_OVERRIDES: 'true'
       DEP_OVERRIDE_KOTLIN: '${{ matrix.ci_kotlin_version }}'

--- a/agp-handlers/agp-handler-73/src/main/kotlin/slack/gradle/agphandler/v73/AgpHandlerFactory73.kt
+++ b/agp-handlers/agp-handler-73/src/main/kotlin/slack/gradle/agphandler/v73/AgpHandlerFactory73.kt
@@ -15,7 +15,7 @@
  */
 package slack.gradle.agphandler.v73
 
-import com.android.build.api.dsl.PackagingOptions
+import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.internal.dsl.TestOptions
 import com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
 import com.google.auto.service.AutoService
@@ -45,11 +45,15 @@ private class AgpHandler73 : AgpHandler {
     options.all(typedClosureOf(body))
   }
 
-  override fun jniLibsPickFirst(
-    packagingOptions: PackagingOptions,
-    pickFirsts: Collection<String>
+  override fun packagingOptions(
+    commonExtension: CommonExtension<*, *, *, *>,
+    resourceExclusions: Collection<String>,
+    jniPickFirsts: Collection<String>
   ) {
-    packagingOptions.jniLibs.pickFirsts += pickFirsts
+    commonExtension.packagingOptions {
+      resources.excludes += resourceExclusions
+      jniLibs.pickFirsts += jniPickFirsts
+    }
   }
 }
 

--- a/agp-handlers/agp-handler-80/build.gradle.kts
+++ b/agp-handlers/agp-handler-80/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   compileOnly(gradleApi())
   compileOnly(gradleKotlinDsl())
-  compileOnly("com.android.tools.build:gradle:8.0.0-alpha09")
+  compileOnly("com.android.tools.build:gradle:8.0.0-alpha10")
   api(projects.agpHandlers.agpHandlerApi)
   implementation(libs.autoService.annotations)
   ksp(libs.autoService.ksp)

--- a/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
+++ b/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
@@ -15,7 +15,7 @@
  */
 package slack.gradle.agphandler.v80
 
-import com.android.build.api.dsl.PackagingOptions
+import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.internal.dsl.TestOptions
 import com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
 import com.google.auto.service.AutoService
@@ -43,10 +43,14 @@ private class AgpHandler80 : AgpHandler {
     options.all(body)
   }
 
-  override fun jniLibsPickFirst(
-    packagingOptions: PackagingOptions,
-    pickFirsts: Collection<String>
+  override fun packagingOptions(
+    commonExtension: CommonExtension<*, *, *, *>,
+    resourceExclusions: Collection<String>,
+    jniPickFirsts: Collection<String>
   ) {
-    packagingOptions.jniLibs.pickFirsts += pickFirsts
+    commonExtension.packagingOptions {
+      resources.excludes += resourceExclusions
+      jniLibs.pickFirsts += jniPickFirsts
+    }
   }
 }

--- a/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandler.kt
+++ b/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandler.kt
@@ -15,7 +15,7 @@
  */
 package slack.gradle.agp
 
-import com.android.build.api.dsl.PackagingOptions
+import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.internal.dsl.TestOptions
 import org.gradle.api.tasks.testing.Test
 
@@ -29,10 +29,14 @@ public interface AgpHandler {
   public fun allUnitTestOptions(options: TestOptions.UnitTestOptions, body: (Test) -> Unit)
 
   /**
-   * Shim for packagingOptions.jniLibs.pickFirst, which had a signature change in AGP 8.x from
-   * `JniLibsPackagingOptions` to `JniLibsPackaging`.
+   * Shim for packagingOptions, which had a signature change in AGP 8.x from `PackagingOptions` to
+   * `Packaging`.
    */
-  public fun jniLibsPickFirst(packagingOptions: PackagingOptions, pickFirsts: Collection<String>)
+  public fun packagingOptions(
+    commonExtension: CommonExtension<*, *, *, *>,
+    resourceExclusions: Collection<String>,
+    jniPickFirsts: Collection<String>,
+  )
 }
 
 /**

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -553,8 +553,9 @@ internal class StandardProjectConfigurations(
           configureLint(project, slackProperties, sdkVersions, true)
           checkDependencies = true
         }
-        packagingOptions {
-          resources.excludes +=
+        agpHandler.packagingOptions(
+          this,
+          resourceExclusions =
             setOf(
               "META-INF/LICENSE.txt",
               "META-INF/LICENSE",
@@ -573,16 +574,14 @@ internal class StandardProjectConfigurations(
               // We don't know where this comes from but it's 5MB
               // https://slack-pde.slack.com/archives/C8EER3C04/p1621353426001500
               "annotated-jdk/**"
-            )
-          agpHandler.jniLibsPickFirst(
-            this,
+            ),
+          jniPickFirsts =
             setOf(
               // Some libs like Flipper bring their own copy of common native libs (like C++) and we
               // need to de-dupe
               "**/*.so"
             )
-          )
-        }
+        )
         buildTypes {
           getByName("debug") {
             // For upstream android libraries that just have a single release variant, use that.


### PR DESCRIPTION
packagingOptions now returns `Packaging` instead of `PackagingOptions`, so this further generifies the `AgpHandler` implementation