### PR TITLE
Implement SgpSettingsPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,41 @@ questions in the discussions section of the project!
 We may later publish some of these components. If you're interested in this, feel free to raise in
 a discussions post or vote for existing suggestions.
 
+
+## Usage requirements
+
+SGP is more or less set up via its `Settings` plugin. Apply this in the `settings.gradle.kts` file
+and it will automatically configure all subprojects and the root project.
+
+```kotlin
+// In settings.gradle.kts
+plugins {
+  id("com.slack.gradle.settings")
+}
+
+slack {
+  // Optionally configure versions. This will default to sourcing from `libs.versions.toml`.
+  versions {
+    jvmTarget.set(11)
+  }
+}
+```
+
+SGP expects a `libs` version catalog to be present.
+
+The following versions are required to be set the above catalog or via the `slack.versions` DSL in the settings plugin.
+Their docs can be found in `SlackVersions.kt`.
+- `kotlin` - The Kotlin version to use.
+- `jdk` - The JDK version to use.
+- `jvmTarget` - The JVM target to use in Kotlin and Java (as `--release`) compilations.
+
+The following plugins are applied by default but can be disabled via Gradle properties if you don't need them.
+- Gradle's test retry – `slack.auto-apply.test-retry`
+- Spotless – `slack.auto-apply.spotless`
+- Detekt – `slack.auto-apply.detekt`
+- NullAway – `slack.auto-apply.nullaway`
+- Android Cache Fix – `slack.auto-apply.cache-fix`
+
 ## Highlights
 
 ### Common project configuration
@@ -24,8 +59,12 @@ This includes a whole host of things!
 - Common Kotlin configuration (freeCompilerArgs, JVM target, etc).
 - Common Java configuration (toolchains, release versions, etc).
 - Common annotation processors.
-- SlackExtension (see next section).
+- `SlackExtension` (see next section).
 - Formatting (via Spotless).
+  - Kotlin
+  - Java
+  - JSON
+  - Some standard files like newline endings
 - Platforms and BOM dependencies (see "Platform plugins" section below).
 - Common lint checks (both on Android and plain JVM projects).
 
@@ -157,21 +196,6 @@ generated baselines from each subproject into a single global baseline.
 ### Misc tools
 
 There are a _ton_ of miscellaneous tools, utilities, and glue code for Gradle (and various plugins) sprinkled throughout this project.
-
-## Usage requirements
-
-SGP expects there to be a `libs` version catalog.
-
-The following versions are required to be set the above catalog.
-Their docs can be found in `SlackVersions.kt`.
-- `jdk`
-
-The following plugins are applied by default but can be disabled if you don't need them.
-- Gradle's test retry – `slack.auto-apply.test-retry`
-- Spotless – `slack.auto-apply.spotless`
-- Detekt – `slack.auto-apply.detekt`
-- NullAway – `slack.auto-apply.nullaway`
-- Android Cache Fix – `slack.auto-apply.cache-fix`
 
 License
 --------

--- a/agp-handlers/agp-handler-73/src/main/kotlin/slack/gradle/agphandler/v73/AgpHandlerFactory73.kt
+++ b/agp-handlers/agp-handler-73/src/main/kotlin/slack/gradle/agphandler/v73/AgpHandlerFactory73.kt
@@ -32,9 +32,7 @@ public class AgpHandlerFactory73 : AgpHandlerFactory {
 
   override fun currentVersion(): String = ANDROID_GRADLE_PLUGIN_VERSION
 
-  override fun create(): AgpHandler {
-    return AgpHandler73()
-  }
+  override fun createHandler(): AgpHandler = AgpHandler73()
 }
 
 private class AgpHandler73 : AgpHandler {

--- a/agp-handlers/agp-handler-80/build.gradle.kts
+++ b/agp-handlers/agp-handler-80/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   compileOnly(gradleApi())
   compileOnly(gradleKotlinDsl())
   compileOnly("com.android.tools.build:gradle:8.0.0-alpha10")
+  compileOnly("com.android.tools.build:gradle-settings-api:8.0.0-alpha10")
   api(projects.agpHandlers.agpHandlerApi)
   implementation(libs.autoService.annotations)
   ksp(libs.autoService.ksp)

--- a/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
+++ b/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
@@ -22,6 +22,7 @@ import com.google.auto.service.AutoService
 import org.gradle.api.tasks.testing.Test
 import slack.gradle.agp.AgpHandler
 import slack.gradle.agp.AgpHandlerFactory
+import slack.gradle.agp.AgpSettingsHandler
 import slack.gradle.agp.VersionNumber
 
 @AutoService(AgpHandlerFactory::class)
@@ -32,6 +33,10 @@ public class AgpHandlerFactory80 : AgpHandlerFactory {
 
   override fun create(): AgpHandler {
     return AgpHandler80()
+  }
+
+  override fun createSettingsHandler(): AgpSettingsHandler {
+    return AgpSettingsHandler80()
   }
 }
 

--- a/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
+++ b/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
@@ -31,13 +31,9 @@ public class AgpHandlerFactory80 : AgpHandlerFactory {
 
   override fun currentVersion(): String = ANDROID_GRADLE_PLUGIN_VERSION
 
-  override fun create(): AgpHandler {
-    return AgpHandler80()
-  }
+  override fun createHandler(): AgpHandler = AgpHandler80()
 
-  override fun createSettingsHandler(): AgpSettingsHandler {
-    return AgpSettingsHandler80()
-  }
+  override fun createSettingsHandler(): AgpSettingsHandler = AgpSettingsHandler80()
 }
 
 private class AgpHandler80 : AgpHandler {

--- a/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpSettingsHandler80.kt
+++ b/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpSettingsHandler80.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.agphandler.v80
+
+import com.android.build.api.dsl.SettingsExtension
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.initialization.Settings
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import slack.gradle.agp.AgpSettingsHandler
+import slack.gradle.agp.getVersionsCatalog
+
+internal class AgpSettingsHandler80 : AgpSettingsHandler {
+  private fun VersionCatalog.getVersionInt(name: String): Int {
+    return findVersion(name)
+      .map { it.toString().toInt() }
+      .orElseThrow {
+        IllegalStateException("'$name' must be defined in libs.versions.toml versions!")
+      }
+  }
+
+  override fun apply(settings: Settings) {
+    val catalog = settings.getVersionsCatalog()
+    settings.apply(plugin = "com.android.settings")
+    settings.configure<SettingsExtension> {
+      compileSdk = catalog.getVersionInt("compileSdk")
+      minSdk = catalog.getVersionInt("minSdk")
+
+      // TODO support execution profiles
+      //  https://developer.android.com/studio/preview/features#tool_execution_profiles
+    }
+  }
+}

--- a/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandlerFactory.kt
+++ b/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandlerFactory.kt
@@ -24,7 +24,16 @@ package slack.gradle.agp
  */
 public interface AgpHandlerFactory {
   public val minVersion: VersionNumber
-  /** Attempts to get the current AGP version or throws and exception if it cannot. */
+  /** Attempts to ascertain the current AGP version or throws and exception if it cannot. */
   public fun currentVersion(): String
+  /**
+   * Creates a new [AgpHandler] instance for the current AGP version if [currentVersion] was deemed
+   * to match.
+   */
   public fun create(): AgpHandler
+  /**
+   * Creates a new [AgpSettingsHandler] instance for the current AGP version if [currentVersion] was
+   * deemed to match.
+   */
+  public fun createSettingsHandler(): AgpSettingsHandler = AgpSettingsHandler.NoOp
 }

--- a/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpSettingsHandler.kt
+++ b/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpSettingsHandler.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.agp
+
+import org.gradle.api.initialization.Settings
+
+/** An AgpHandler for Gradle [Settings] plugin configuration. */
+public interface AgpSettingsHandler {
+  public fun apply(settings: Settings)
+
+  public companion object {
+    internal val NoOp =
+      object : AgpSettingsHandler {
+        override fun apply(settings: Settings) {}
+      }
+  }
+}

--- a/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/VersionCatalogs.kt
+++ b/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/VersionCatalogs.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.agp
+
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.getByType
+
+public fun ExtensionAware.getVersionsCatalog(catalogName: String = "libs"): VersionCatalog {
+  return getVersionsCatalogOrNull(catalogName) ?: error("No versions catalog found!")
+}
+
+public fun ExtensionAware.getVersionsCatalogOrNull(catalogName: String = "libs"): VersionCatalog? {
+  return try {
+    extensions.getByType<VersionCatalogsExtension>().named(catalogName)
+  } catch (ignored: Exception) {
+    null
+  }
+}

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -26,6 +26,10 @@ gradlePlugin {
     id = "com.slack.gradle.apk-versioning"
     implementationClass = "slack.gradle.ApkVersioningPlugin"
   }
+  plugins.create("settings") {
+    id = "com.slack.gradle.settings"
+    implementationClass = "slack.gradle.settings.SgpSettingsPlugin"
+  }
 }
 
 sourceSets {

--- a/slack-plugin/src/main/kotlin/slack/gradle/AgpHandlers.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/AgpHandlers.kt
@@ -15,40 +15,7 @@
  */
 package slack.gradle
 
-import java.util.ServiceLoader
-import slack.gradle.agp.AgpHandler
 import slack.gradle.agp.AgpHandlerFactory
-import slack.gradle.agp.AgpSettingsHandler
 import slack.gradle.agp.VersionNumber
-
-internal object AgpHandlers {
-  private fun factory(): AgpHandlerFactory {
-    /** Load handlers and pick the highest compatible version (by [AgpHandlerFactory.minVersion]) */
-    return ServiceLoader.load(AgpHandlerFactory::class.java)
-      .iterator()
-      .asSequence()
-      .mapNotNull { factory ->
-        // Filter out any factories that can't compute the AGP version, as
-        // they're _definitely_ not compatible
-        try {
-          FactoryData(VersionNumber.parse(factory.currentVersion()), factory)
-        } catch (t: Throwable) {
-          null
-        }
-      }
-      .filter { (agpVersion, factory) -> agpVersion.baseVersion >= factory.minVersion }
-      .maxByOrNull { (_, factory) -> factory.minVersion }
-      ?.factory
-      ?: error("Unrecognized AGP version!")
-  }
-
-  fun createHandler(): AgpHandler {
-    return factory().create()
-  }
-
-  fun createSettingsHandler(): AgpSettingsHandler {
-    return factory().createSettingsHandler()
-  }
-}
 
 private data class FactoryData(val agpVersion: VersionNumber, val factory: AgpHandlerFactory)

--- a/slack-plugin/src/main/kotlin/slack/gradle/Platforms.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/Platforms.kt
@@ -27,6 +27,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.kotlin.dsl.dependencies
+import slack.gradle.agp.getVersionsCatalog
 import slack.gradle.dependencies.DependencyCollection
 import slack.gradle.dependencies.DependencyDef
 import slack.gradle.dependencies.boms

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
@@ -32,6 +32,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.retry
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
+import slack.gradle.agp.getVersionsCatalogOrNull
 import slack.gradle.tasks.CoreBootstrapTask
 import slack.gradle.util.configureKotlinCompile
 import slack.gradle.util.synchronousEnvProperty

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
@@ -23,7 +23,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.VersionCatalog
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -212,18 +211,6 @@ internal fun Project.jdkVersion(): Int {
 
 internal fun Project.jvmTargetVersion(): Int {
   return SlackProperties(this).jvmTarget
-}
-
-internal fun Project.getVersionsCatalog(): VersionCatalog {
-  return getVersionsCatalogOrNull() ?: error("No versions catalog found!")
-}
-
-internal fun Project.getVersionsCatalogOrNull(): VersionCatalog? {
-  return try {
-    project.extensions.getByType<VersionCatalogsExtension>().named("libs")
-  } catch (ignored: Exception) {
-    null
-  }
 }
 
 /** Returns a map of module identifiers to toml library reference aliases */

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -17,6 +17,7 @@ package slack.gradle
 
 import java.io.File
 import org.gradle.api.Project
+import slack.gradle.agp.getVersionsCatalog
 import slack.gradle.util.booleanProperty
 import slack.gradle.util.getOrCreateExtra
 import slack.gradle.util.intProperty

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -15,6 +15,7 @@
  */
 package slack.gradle
 
+import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import slack.gradle.settings.slackVersions
@@ -25,7 +26,6 @@ import slack.gradle.util.intProperty
 import slack.gradle.util.intProvider
 import slack.gradle.util.optionalStringProperty
 import slack.gradle.util.safeProperty
-import java.io.File
 
 /**
  * (Mostly Gradle) properties for configuration of SlackPlugin.

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -17,7 +17,7 @@ package slack.gradle
 
 import java.io.File
 import org.gradle.api.Project
-import slack.gradle.agp.getVersionsCatalog
+import slack.gradle.settings.slackVersions
 import slack.gradle.util.booleanProperty
 import slack.gradle.util.getOrCreateExtra
 import slack.gradle.util.intProperty
@@ -51,11 +51,8 @@ public class SlackProperties private constructor(private val project: Project) {
   private fun optionalStringProperty(key: String, defaultValue: String? = null): String? =
     project.optionalStringProperty(key, defaultValue = defaultValue)
 
-  internal val versions: SlackVersions by lazy {
-    project.rootProject.getOrCreateExtra("slack-versions") {
-      SlackVersions(project.rootProject.getVersionsCatalog())
-    }
-  }
+  // TODO eventually define this somewhere separate from SlackProperties?
+  internal val versions: SlackVersions = project.slackVersions()
 
   /** Indicates that this android library project has variants. Flag-only, value is ignored. */
   public val libraryWithVariants: Boolean

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
@@ -34,7 +34,6 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.registerIfAbsent
 import slack.gradle.SlackTools.Companion.SERVICE_NAME
 import slack.gradle.SlackTools.Parameters
-import slack.gradle.agp.AgpHandler
 import slack.gradle.util.JsonTools
 import slack.gradle.util.Thermals
 import slack.gradle.util.ThermalsWatcher
@@ -44,7 +43,6 @@ import slack.gradle.util.mapToBoolean
 public abstract class SlackTools @Inject constructor(providers: ProviderFactory) :
   BuildService<Parameters>, AutoCloseable {
 
-  public val agpHandler: AgpHandler by lazy { AgpHandlers.createHandler() }
   public val moshi: Moshi
     get() = JsonTools.MOSHI
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
@@ -27,6 +27,12 @@ internal class SlackVersions(
   val catalog: VersionCatalog,
   settingsVersions: SgpSettingsVersions,
 ) {
+  // Required
+  val kotlin: String = settingsVersions.kotlin.get()
+  val jdk: Int = settingsVersions.jdk.get()
+  val jvmTarget: Int = settingsVersions.jvmTarget.get()
+
+  // Optional
   val agp: String? = settingsVersions.agp.orNull
   val composeCompiler: String? = settingsVersions.composeCompiler.orNull
   val composeCompilerKotlinVersion: String? = settingsVersions.composeCompilerKotlinVersion.orNull
@@ -36,9 +42,6 @@ internal class SlackVersions(
   val ktlint: String? = settingsVersions.ktlint.orNull
   val ktfmt: String? = settingsVersions.ktfmt.orNull
   val objenesis: String? = settingsVersions.objenesis.orNull
-  val kotlin: String = settingsVersions.kotlin.get()
-  val jdk: Int = settingsVersions.jdk.get()
-  val jvmTarget: Int = settingsVersions.jvmTarget.get()
 
   val bundles = Bundles()
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
@@ -20,33 +20,25 @@ import org.gradle.api.artifacts.ExternalModuleDependencyBundle
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.provider.Provider
+import slack.gradle.settings.SgpSettingsVersions
 
 // TODO generate something to map these in the future? Or with reflection?
-internal class SlackVersions(val catalog: VersionCatalog) {
-  val agp: String?
-    get() = getOptionalValue("agp").orElse(null)
-  val composeCompiler: String?
-    get() = getOptionalValue("compose-compiler").orElse(null)
-  val composeCompilerKotlinVersion: String?
-    get() = getOptionalValue("compose-compiler-kotlin-version").orElse(null)
-  val detekt: String?
-    get() = getOptionalValue("detekt").orElse(null)
-  val gjf: String?
-    get() = getOptionalValue("google-java-format").orElse(null)
-  val gson: String?
-    get() = getOptionalValue("gson").orElse(null)
-  val kotlin: String
-    get() = getValue("kotlin")
-  val ktlint: String?
-    get() = getOptionalValue("ktlint").orElse(null)
-  val ktfmt: String?
-    get() = getOptionalValue("ktfmt").orElse(null)
-  val objenesis: String?
-    get() = getOptionalValue("objenesis").orElse(null)
-  val jdk: Int
-    get() = getValue("jdk").toInt()
-  val jvmTarget: Int
-    get() = getOptionalValue("jvmTarget").map { it.toInt() }.orElse(11)
+internal class SlackVersions(
+  val catalog: VersionCatalog,
+  settingsVersions: SgpSettingsVersions,
+) {
+  val agp: String? = settingsVersions.agp.orNull
+  val composeCompiler: String? = settingsVersions.composeCompiler.orNull
+  val composeCompilerKotlinVersion: String? = settingsVersions.composeCompilerKotlinVersion.orNull
+  val detekt: String? = settingsVersions.detekt.orNull
+  val gjf: String? = settingsVersions.gjf.orNull
+  val gson: String? = settingsVersions.gson.orNull
+  val ktlint: String? = settingsVersions.ktlint.orNull
+  val ktfmt: String? = settingsVersions.ktfmt.orNull
+  val objenesis: String? = settingsVersions.objenesis.orNull
+  val kotlin: String = settingsVersions.kotlin.get()
+  val jdk: Int = settingsVersions.jdk.get()
+  val jvmTarget: Int = settingsVersions.jvmTarget.get()
 
   val bundles = Bundles()
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -77,6 +77,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import slack.dependencyrake.RakeDependencies
 import slack.gradle.AptOptionsConfig.AptOptionsConfigurer
 import slack.gradle.AptOptionsConfigs.invoke
+import slack.gradle.agp.getVersionsCatalog
 import slack.gradle.dependencies.KotlinBuildConfig
 import slack.gradle.dependencies.SlackDependencies
 import slack.gradle.permissionchecks.PermissionChecks

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -81,6 +81,7 @@ import slack.gradle.agp.getVersionsCatalog
 import slack.gradle.dependencies.KotlinBuildConfig
 import slack.gradle.dependencies.SlackDependencies
 import slack.gradle.permissionchecks.PermissionChecks
+import slack.gradle.settings.agpHandler
 import slack.gradle.tasks.AndroidTestApksTask
 import slack.gradle.tasks.CheckManifestPermissionsTask
 import slack.gradle.util.booleanProperty
@@ -423,7 +424,7 @@ internal class StandardProjectConfigurations(
 
     val sdkVersions by lazy { slackProperties.requireAndroidSdkProperties() }
     val shouldApplyCacheFixPlugin = slackProperties.enableAndroidCacheFix
-    val agpHandler = slackTools().agpHandler
+    val agpHandler = project.agpHandler()
     val commonBaseExtensionConfig: BaseExtension.(applyTestOptions: Boolean) -> Unit =
       { applyTestOptions ->
         if (shouldApplyCacheFixPlugin) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.settings
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+import slack.gradle.AgpHandlers
+
+public class SgpSettingsPlugin : Plugin<Settings> {
+  override fun apply(settings: Settings) {
+    AgpHandlers.createSettingsHandler().apply(settings)
+    val handler = AgpHandlers.createHandler()
+
+    // as Project objects cannot query for the Settings object (and its extensions), we
+    // deposit the handler instance into each project using the extra Properties.
+    settings.gradle.beforeProject { extensions.extraProperties["_sgp_agphandler"] = handler }
+  }
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
@@ -17,15 +17,37 @@ package slack.gradle.settings
 
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
-import slack.gradle.AgpHandlers
+import org.gradle.api.plugins.ExtensionAware
+import slack.gradle.agp.AgpHandler
+import slack.gradle.agp.AgpHandlerFactory
+import slack.gradle.settings.SgpSettingsPlugin.Companion.AGP_HANDLER_EXTENSION_KEY
 
 public class SgpSettingsPlugin : Plugin<Settings> {
   override fun apply(settings: Settings) {
-    AgpHandlers.createSettingsHandler().apply(settings)
-    val handler = AgpHandlers.createHandler()
+    val agpHandlerFactory = AgpHandlerFactory.load()
+    agpHandlerFactory.createSettingsHandler().apply(settings)
+    val handler = agpHandlerFactory.createHandler()
 
     // as Project objects cannot query for the Settings object (and its extensions), we
     // deposit the handler instance into each project using the extra Properties.
-    settings.gradle.beforeProject { extensions.extraProperties["_sgp_agphandler"] = handler }
+    settings.gradle.beforeProject {
+      extensions.extraProperties[AGP_HANDLER_EXTENSION_KEY] = handler
+    }
+  }
+
+  internal companion object {
+    const val AGP_HANDLER_EXTENSION_KEY: String = "_sgp_agphandler"
+  }
+}
+
+/** Retrieves the cached [AgpHandler] from extras. This is deposited here by [SgpSettingsPlugin]. */
+internal fun ExtensionAware.agpHandler(): AgpHandler {
+  val properties = extensions.extraProperties
+  if (properties.has(AGP_HANDLER_EXTENSION_KEY)) {
+    return properties.get(AGP_HANDLER_EXTENSION_KEY) as AgpHandler
+  } else {
+    error(
+      "No AgpHandler found in extraProperties! Did you forget to apply the SGP settings plugin?"
+    )
   }
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
@@ -33,6 +34,7 @@ import slack.gradle.SlackVersions
 import slack.gradle.agp.AgpHandler
 import slack.gradle.agp.AgpHandlerFactory
 import slack.gradle.agp.getVersionsCatalog
+import slack.gradle.isRootProject
 import slack.gradle.settings.SgpSettingsPlugin.Companion.AGP_HANDLER_EXTENSION_KEY
 import slack.gradle.settings.SgpSettingsPlugin.Companion.SGP_VERSIONS_EXTENSION_KEY
 import slack.gradle.tomlKey
@@ -54,6 +56,12 @@ public class SgpSettingsPlugin : Plugin<Settings> {
     settings.gradle.beforeProject {
       extensions.extraProperties[SGP_VERSIONS_EXTENSION_KEY] = versions
       extensions.extraProperties[AGP_HANDLER_EXTENSION_KEY] = handler
+
+      // Apply base plugin to all subprojects
+      if (project.isRootProject) {
+        apply(plugin = "com.slack.gradle.root")
+      }
+      apply(plugin = "com.slack.gradle.base")
     }
   }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
@@ -54,6 +54,10 @@ public class SgpSettingsPlugin : Plugin<Settings> {
     // as Project objects cannot query for the Settings object (and its extensions), we
     // deposit the handler instance into each project using the extra Properties.
     settings.gradle.beforeProject {
+      // Gradle does this immensely weird thing where it considers all intermediary folders in
+      // between projects to _also_ be projects. We skip those in configuration.
+      if (!file("build.gradle.kts").exists()) return@beforeProject
+
       extensions.extraProperties[SGP_VERSIONS_EXTENSION_KEY] = versions
       extensions.extraProperties[AGP_HANDLER_EXTENSION_KEY] = handler
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
@@ -56,7 +56,7 @@ public class SgpSettingsPlugin : Plugin<Settings> {
     settings.gradle.beforeProject {
       // Gradle does this immensely weird thing where it considers all intermediary folders in
       // between projects to _also_ be projects. We skip those in configuration.
-      if (!file("build.gradle.kts").exists()) return@beforeProject
+      if (!buildFile.exists()) return@beforeProject
 
       extensions.extraProperties[SGP_VERSIONS_EXTENSION_KEY] = versions
       extensions.extraProperties[AGP_HANDLER_EXTENSION_KEY] = handler

--- a/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
@@ -15,39 +15,145 @@
  */
 package slack.gradle.settings
 
+import org.gradle.api.Action
+import javax.inject.Inject
 import org.gradle.api.Plugin
+import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.initialization.Settings
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.property
+import slack.gradle.SlackExtensionMarker
+import slack.gradle.SlackVersions
 import slack.gradle.agp.AgpHandler
 import slack.gradle.agp.AgpHandlerFactory
+import slack.gradle.agp.getVersionsCatalog
 import slack.gradle.settings.SgpSettingsPlugin.Companion.AGP_HANDLER_EXTENSION_KEY
+import slack.gradle.settings.SgpSettingsPlugin.Companion.SGP_VERSIONS_EXTENSION_KEY
+import slack.gradle.tomlKey
 
 public class SgpSettingsPlugin : Plugin<Settings> {
   override fun apply(settings: Settings) {
+    val catalog = settings.getVersionsCatalog()
+    val extension = settings.extensions.create<SgpSettingsExtension>("slack", catalog)
+
     val agpHandlerFactory = AgpHandlerFactory.load()
     agpHandlerFactory.createSettingsHandler().apply(settings)
     val handler = agpHandlerFactory.createHandler()
 
+    lateinit var versions: SlackVersions
+    settings.gradle.settingsEvaluated { versions = extension.versions.finalize() }
+
     // as Project objects cannot query for the Settings object (and its extensions), we
     // deposit the handler instance into each project using the extra Properties.
     settings.gradle.beforeProject {
+      extensions.extraProperties[SGP_VERSIONS_EXTENSION_KEY] = versions
       extensions.extraProperties[AGP_HANDLER_EXTENSION_KEY] = handler
     }
   }
 
   internal companion object {
     const val AGP_HANDLER_EXTENSION_KEY: String = "_sgp_agphandler"
+    const val SGP_VERSIONS_EXTENSION_KEY: String = "_sgp_versions"
   }
 }
 
 /** Retrieves the cached [AgpHandler] from extras. This is deposited here by [SgpSettingsPlugin]. */
 internal fun ExtensionAware.agpHandler(): AgpHandler {
+  return depositedObject(AGP_HANDLER_EXTENSION_KEY)
+}
+
+/** Retrieves the cached [AgpHandler] from extras. This is deposited here by [SgpSettingsPlugin]. */
+internal fun ExtensionAware.slackVersions(): SlackVersions {
+  return depositedObject(SGP_VERSIONS_EXTENSION_KEY)
+}
+
+private inline fun <reified T> ExtensionAware.depositedObject(key: String): T {
   val properties = extensions.extraProperties
-  if (properties.has(AGP_HANDLER_EXTENSION_KEY)) {
-    return properties.get(AGP_HANDLER_EXTENSION_KEY) as AgpHandler
+  if (properties.has(key)) {
+    return properties.get(key) as T
   } else {
     error(
-      "No AgpHandler found in extraProperties! Did you forget to apply the SGP settings plugin?"
+      "No '$key' key found in extraProperties! Did you forget to apply the SGP settings plugin?"
     )
+  }
+}
+
+@SlackExtensionMarker
+public abstract class SgpSettingsExtension
+@Inject
+constructor(
+  objects: ObjectFactory,
+  catalog: VersionCatalog,
+) {
+  public val versions: SgpSettingsVersions = objects.newInstance(catalog)
+
+  public fun versions(action: Action<SgpSettingsVersions>) {
+    action.execute(versions)
+  }
+}
+
+public abstract class SgpSettingsVersions
+@Inject
+constructor(
+  private val providers: ProviderFactory,
+  objects: ObjectFactory,
+  private val catalog: VersionCatalog,
+) {
+  public val agp: Property<String> =
+    objects.property<String>().convention(optionalVersionProvider("agp"))
+  public val composeCompiler: Property<String> =
+    objects.property<String>().convention(optionalVersionProvider("compose-compiler"))
+  public val composeCompilerKotlinVersion: Property<String> =
+    objects
+      .property<String>()
+      .convention(optionalVersionProvider("compose-compiler-kotlin-version"))
+  public val detekt: Property<String> =
+    objects.property<String>().convention(optionalVersionProvider("detekt"))
+  public val gjf: Property<String> =
+    objects.property<String>().convention(optionalVersionProvider("google-java-format"))
+  public val gson: Property<String> =
+    objects.property<String>().convention(optionalVersionProvider("gson"))
+  public val kotlin: Property<String> =
+    objects.property<String>().convention(requiredVersionProvider("kotlin"))
+  public val ktlint: Property<String> =
+    objects.property<String>().convention(optionalVersionProvider("ktlint"))
+  public val ktfmt: Property<String> =
+    objects.property<String>().convention(optionalVersionProvider("ktfmt"))
+  public val objenesis: Property<String> =
+    objects.property<String>().convention(optionalVersionProvider("objenesis"))
+  public val jdk: Property<Int> =
+    objects.property<Int>().convention(requiredVersionProvider("jdk").map(String::toInt))
+  public val jvmTarget: Property<Int> =
+    objects.property<Int>().convention(requiredVersionProvider("jvmTarget").map(String::toInt))
+
+  // TODO eventually somehow define an API for bundles?
+
+  internal fun requiredVersionProvider(
+    key: String,
+    defaultValue: String? = null
+  ): Provider<String> {
+    return optionalVersionProvider(key).let { provider ->
+      defaultValue?.let { provider.orElse(it) }
+        ?: provider.orElse(
+          providers.provider {
+            throw IllegalStateException("No catalog version found for ${tomlKey(key)}")
+          }
+        )
+    }
+  }
+
+  internal fun optionalVersionProvider(key: String): Provider<String> {
+    val tomlKey = tomlKey(key)
+    return providers.provider { catalog.findVersion(tomlKey).map { it.toString() }.orElse(null) }
+  }
+
+  internal fun finalize(): SlackVersions {
+    return SlackVersions(catalog, this)
   }
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
@@ -15,8 +15,8 @@
  */
 package slack.gradle.settings
 
-import org.gradle.api.Action
 import javax.inject.Inject
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.initialization.Settings

--- a/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/settings/SgpSettingsPlugin.kt
@@ -113,6 +113,15 @@ constructor(
   objects: ObjectFactory,
   private val catalog: VersionCatalog,
 ) {
+  // Required properties
+  public val kotlin: Property<String> =
+    objects.property<String>().convention(requiredVersionProvider("kotlin"))
+  public val jdk: Property<Int> =
+    objects.property<Int>().convention(requiredVersionProvider("jdk").map(String::toInt))
+  public val jvmTarget: Property<Int> =
+    objects.property<Int>().convention(requiredVersionProvider("jvmTarget").map(String::toInt))
+
+  // Optional properties
   public val agp: Property<String> =
     objects.property<String>().convention(optionalVersionProvider("agp"))
   public val composeCompiler: Property<String> =
@@ -127,18 +136,12 @@ constructor(
     objects.property<String>().convention(optionalVersionProvider("google-java-format"))
   public val gson: Property<String> =
     objects.property<String>().convention(optionalVersionProvider("gson"))
-  public val kotlin: Property<String> =
-    objects.property<String>().convention(requiredVersionProvider("kotlin"))
   public val ktlint: Property<String> =
     objects.property<String>().convention(optionalVersionProvider("ktlint"))
   public val ktfmt: Property<String> =
     objects.property<String>().convention(optionalVersionProvider("ktfmt"))
   public val objenesis: Property<String> =
     objects.property<String>().convention(optionalVersionProvider("objenesis"))
-  public val jdk: Property<Int> =
-    objects.property<Int>().convention(requiredVersionProvider("jdk").map(String::toInt))
-  public val jvmTarget: Property<Int> =
-    objects.property<Int>().convention(requiredVersionProvider("jvmTarget").map(String::toInt))
 
   // TODO eventually somehow define an API for bundles?
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/CheckDependencyVersionsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/CheckDependencyVersionsTask.kt
@@ -25,7 +25,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import slack.gradle.getVersionsCatalog
+import slack.gradle.agp.getVersionsCatalog
 import slack.gradle.safeCapitalize
 
 /**


### PR DESCRIPTION
This implements a new `Settings` plugin in Gradle for global configuration of different sorts.

Highlights
- Auto-configure AGP 8.x's new `Settings` plugin with values for `minSdk` and `compileSdk` + expose settings hook in `AgpHandlerFactory` as a toe-hold for the future.
- Expose a DSL for configuring `SlackVersions` values, defaulting to those in the `libs.versions.toml` file.
- Cache `AgpHandler` from the settings plugin via depositing the instance in project extras, borrowing from what AGP does.
- Automatically apply SGP's root and base plugins across all subprojects (!!)

Breaking change: minSdk and compileSdk must now move to `libs.versions.toml`.

Example
```kotlin
plugins {
  id("com.slack.gradle.settings")
}

slack {
  versions {
    jvmTarget.set(11)
  }
}
```

TODO in future PRs
- Move more props from `GlobalConfig` to this.