### PR TITLE
Support the gradle enterprise plugin retry implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Their docs can be found in `SlackVersions.kt`.
 
 The following plugins are applied by default but can be disabled if you don't need them.
 - Gradle's test retry – `slack.auto-apply.test-retry`
+  - By default, this uses the [Gradle test-retry plugin](https://github.com/gradle/test-retry-gradle-plugin), but can be configured to use the Gradle Enterprise plugin's implementation instead by setting the `slack.test.retry.pluginType` property to `GE`.
 - Spotless – `slack.auto-apply.spotless`
 - Detekt – `slack.auto-apply.detekt`
 - NullAway – `slack.auto-apply.nullaway`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ gradlePlugins-bugsnag = { module = "com.bugsnag:bugsnag-android-gradle-plugin", 
 gradlePlugins-dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysisPlugin" }
 gradlePlugins-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradlePlugins-doctor = "com.osacky.doctor:doctor-plugin:0.8.1"
-gradlePlugins-enterprise = "com.gradle:gradle-enterprise-gradle-plugin:3.8.1"
+gradlePlugins-enterprise = "com.gradle:gradle-enterprise-gradle-plugin:3.12.2"
 gradlePlugins-errorProne = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version.ref = "errorproneGradle" }
 gradlePlugins-ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 gradlePlugins-moshix = { module = "dev.zacsweers.moshix:moshi-gradle-plugin", version.ref = "moshix" }

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -17,9 +17,12 @@ package slack.gradle
 
 import java.io.File
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import slack.gradle.util.booleanProperty
+import slack.gradle.util.booleanProvider
 import slack.gradle.util.getOrCreateExtra
 import slack.gradle.util.intProperty
+import slack.gradle.util.intProvider
 import slack.gradle.util.optionalStringProperty
 import slack.gradle.util.safeProperty
 
@@ -342,6 +345,26 @@ public class SlackProperties private constructor(private val project: Project) {
     get() = booleanProperty("slack.auto-apply.nullaway", defaultValue = true)
   public val autoApplyCacheFix: Boolean
     get() = booleanProperty("slack.auto-apply.cache-fix", defaultValue = true)
+
+  /* Test retry controls. */
+  public enum class TestRetryPluginType {
+    RETRY_PLUGIN,
+    GE
+  }
+
+  public val testRetryPluginType: TestRetryPluginType
+    get() =
+      stringProperty("slack.test.retry.pluginType", TestRetryPluginType.RETRY_PLUGIN.name)
+        .let(TestRetryPluginType::valueOf)
+
+  public val testRetryFailOnPassedAfterRetry: Provider<Boolean>
+    get() = project.booleanProvider("slack.test.retry.failOnPassedAfterRetry", defaultValue = false)
+
+  public val testRetryMaxFailures: Provider<Int>
+    get() = project.intProvider("slack.test.retry.maxFailures", defaultValue = 20)
+
+  public val testRetryMaxRetries: Provider<Int>
+    get() = project.intProvider("slack.test.retry.maxRetries", defaultValue = 1)
 
   /* Detekt configs. */
   /** Detekt config files, evaluated from rootProject.file(...). */

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/PropertyUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/PropertyUtil.kt
@@ -171,20 +171,43 @@ internal fun Project.synchronousEnvProperty(env: String, default: String? = null
   return providers.environmentVariable(env).getOrElse(sneakyNull(default))
 }
 
+// TODO rename these scalar types to <type>Value
 internal fun Project.booleanProperty(key: String, defaultValue: Boolean = false): Boolean {
-  return booleanProperty(key, provider { defaultValue })
+  return booleanProvider(key, defaultValue).get()
 }
 
 internal fun Project.booleanProperty(key: String, defaultValue: Provider<Boolean>): Boolean {
-  return safeProperty(key).mapToBoolean().orElse(defaultValue).get()
+  return booleanProvider(key, defaultValue).get()
+}
+
+internal fun Project.booleanProvider(
+  key: String,
+  defaultValue: Boolean = false
+): Provider<Boolean> {
+  return booleanProvider(key, provider { defaultValue })
+}
+
+internal fun Project.booleanProvider(
+  key: String,
+  defaultValue: Provider<Boolean>
+): Provider<Boolean> {
+  return safeProperty(key).mapToBoolean().orElse(defaultValue)
 }
 
 internal fun Project.intProperty(key: String, defaultValue: Int = -1): Int {
-  return intProperty(key, provider { defaultValue })
+  return intProvider(key, defaultValue).get()
 }
 
 internal fun Project.intProperty(key: String, defaultValue: Provider<Int>): Int {
-  return safeProperty(key).mapToInt().orElse(defaultValue).get()
+  return intProvider(key, defaultValue).get()
+}
+
+internal fun Project.intProvider(key: String, defaultValue: Int = -1): Provider<Int> {
+  return intProvider(key, provider { defaultValue })
+}
+
+internal fun Project.intProvider(key: String, defaultValue: Provider<Int>): Provider<Int> {
+  return safeProperty(key).mapToInt().orElse(defaultValue)
 }
 
 internal fun Project.stringProperty(key: String): String {


### PR DESCRIPTION
In GE 3.12+, it has moved the test retry implementation internally and should be used if GE is enabled on the project. This adds support for that + finer grained properties to configure the behavior and its values

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->