### PR TITLE
Change memory default

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
@@ -91,7 +91,7 @@ private val BYTES_PER_GB = 1024.0.pow(3)
 private const val NEW_SIZE_PERCENT = 0.67
 
 /** The ratio of Gradle jvm args memory to kotlin daemon memory. */
-private const val DEFAULT_GRADLE_MEMORY_PERCENT = 0.25f
+private const val DEFAULT_GRADLE_MEMORY_PERCENT = 0.50f
 
 /**
  * The core Bootstrap task that all bootstrap-applicable tasks can depend on. This task configures


### PR DESCRIPTION
Resolves #179

Currently in bootstrap we divvy up available memory between two daemons: the kotlin daemon (used for compilation) and gradle daemon (used for literally everything else. Tests, java compilations, dexing, R8, lint, detekt, etc).

Historically, we’ve optimized for the kotlin compilation case locally by allocating 75% of the available memory to the kotlin daemon and 25% to the gradle daemon because that’s what most people were doing locally. However, I’ve lately seen this result in more OOMs during other common things like studio sync and dexing/R8.

Given that we did this previously to optimize things on more thermally constrained devices and now we have M1 macs, we're going to be an even 50/50 split. This would match what we do on CI for gradle daemon-intensive tasks already like lint and unit tests.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->