### PR TITLE
Source desugar libraries from libs.versions.toml instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ The following versions are required to be set the above catalog.
 Their docs can be found in `SlackVersions.kt`.
 - `jdk`
 
+For Android projects, some extra definitions need to be defined
+- `libs.versions.toml` libraries
+  - `google-coreLibraryDesugaring` - the core library desugaring libraries to use with L8.
+- `gradle.properties` properties
+  - `slack.compileSdkVersion`
+  - `slack.targetSdkVersion`
+  - `slack.minSdkVersion`
+
 The following plugins are applied by default but can be disabled if you don't need them.
 - Gradle's test retry – `slack.auto-apply.test-retry`
   - By default, this uses the [Gradle test-retry plugin](https://github.com/gradle/test-retry-gradle-plugin), but can be configured to use the Gradle Enterprise plugin's implementation instead by setting the `slack.test.retry.pluginType` property to `GE`.

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -447,7 +447,7 @@ internal class StandardProjectConfigurations(
 
         dependencies.add(
           Configurations.CORE_LIBRARY_DESUGARING,
-          SlackDependencies.Google.coreLibraryDesugaring
+          versionCatalog.findLibrary("google-coreLibraryDesugaring"),
         )
 
         if (applyTestOptions) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/dependencies/SlackDependencies.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/dependencies/SlackDependencies.kt
@@ -148,11 +148,6 @@ internal object SlackDependencies : DependencySet() {
     internal val core: Any by artifact("error_prone_core")
   }
 
-  object Google : DependencySet() {
-    val coreLibraryDesugaring: Any by artifact("com.android.tools", "desugar_jdk_libs")
-    val r8: Any by artifact("com.android.tools", "r8")
-  }
-
   object Incap : DependencyGroup("net.ltgt.gradle.incap") {
     val incap: Any by artifact()
     val processor: Any by artifact("incap-processor")


### PR DESCRIPTION
Desugar libs 2.0 has multiple artifacts, so we need to source from the `libs.versions.toml` to allow for customizing this instead.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->