### PR TITLE
Improve compose multiplatform support

### DIFF
--- a/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
+++ b/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandlerFactory80.kt
@@ -48,7 +48,7 @@ private class AgpHandler80 : AgpHandler {
     resourceExclusions: Collection<String>,
     jniPickFirsts: Collection<String>
   ) {
-    commonExtension.packagingOptions {
+    commonExtension.packaging {
       resources.excludes += resourceExclusions
       jniLibs.pickFirsts += jniPickFirsts
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "7.4.0"
 anvil = "2.4.4"
 bugsnagGradle = "7.4.0"
+compose-jb = "1.3.0"
 dependencyAnalysisPlugin = "1.18.0"
 detekt = "1.22.0"
 dokka = "1.7.20"
@@ -41,6 +42,7 @@ commonsText = "org.apache.commons:commons-text:1.10.0"
 detekt = { module = "io.gitlab.arturbosch.detekt:detekt-core", version.ref = "detekt" }
 gradlePlugins-anvil = { module = "com.squareup.anvil:gradle-plugin", version.ref = "anvil" }
 gradlePlugins-bugsnag = { module = "com.bugsnag:bugsnag-android-gradle-plugin", version.ref = "bugsnagGradle" }
+gradlePlugins-compose = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-jb" }
 gradlePlugins-dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysisPlugin" }
 gradlePlugins-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradlePlugins-doctor = "com.osacky.doctor:doctor-plugin:0.8.1"

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
   // Add gradle plugins for the slack project itself, separate from plugins. We do this so we can de-dupe version
   // management between this plugin and the root build.gradle.kts file.
   compileOnly(libs.gradlePlugins.bugsnag)
+  compileOnly(libs.gradlePlugins.compose)
   compileOnly(libs.gradlePlugins.doctor)
   compileOnly(libs.gradlePlugins.versions)
   compileOnly(libs.gradlePlugins.detekt)

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -37,7 +37,6 @@ import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
-import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import slack.gradle.agp.PermissionAllowlistConfigurer
 import slack.gradle.dependencies.SlackDependencies
 
@@ -636,14 +635,6 @@ constructor(
   internal fun applyTo(project: Project) {
     if (enabled.getOrElse(false)) {
       composeBundleAlias?.let { project.dependencies.add("implementation", it) }
-      project.pluginManager.withPlugin("org.jetbrains.compose") {
-        project.dependencies {
-          add(
-            PLUGIN_CLASSPATH_CONFIGURATION_NAME,
-            "androidx.compose.compiler:compiler:$composeCompilerVersion"
-          )
-        }
-      }
     }
   }
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -53,9 +53,24 @@ constructor(
   private val slackProperties: SlackProperties,
   versionCatalog: VersionCatalog
 ) {
-  internal val androidHandler =
-    objects.newInstance<AndroidHandler>(globalSlackProperties, slackProperties, versionCatalog)
-  internal val featuresHandler = objects.newInstance<FeaturesHandler>()
+  internal val androidHandler = objects.newInstance<AndroidHandler>(slackProperties)
+  internal val featuresHandler =
+    objects.newInstance<FeaturesHandler>(globalSlackProperties, slackProperties, versionCatalog)
+
+  /**
+   * This is weird! Due to the non-property nature of some AGP DSL features (e.g. buildFeatures and
+   * composeOptions DSLs), we can't lazily chain their values to our own extension's properties.
+   * Because of this, we lazily set this instance from [StandardProjectConfigurations] during
+   * Android extension evaluation and then make calls to enable them _directly_ set the values on
+   * this instance. Ideally we could eventually remove this if/when AGP finally makes these
+   * properties lazy.
+   */
+  internal var androidExtension: CommonExtension<*, *, *, *>? = null
+    set(value) {
+      field = value
+      androidHandler.androidExtension = value
+      featuresHandler.androidExtension = value
+    }
 
   public fun android(action: Action<AndroidHandler>) {
     action.execute(androidHandler)
@@ -69,6 +84,8 @@ constructor(
     val logVerbose = slackProperties.slackExtensionVerbose
     // Dirty but necessary since the extension isn't configured yet when we call this
     project.afterEvaluate {
+      featuresHandler.applyTo(project)
+
       var kaptRequired = false
       var naptRequired = false
       val avMoshiEnabled = featuresHandler.avExtensionMoshi.getOrElse(false)
@@ -315,7 +332,14 @@ constructor(
 }
 
 @SlackExtensionMarker
-public abstract class FeaturesHandler @Inject constructor(objects: ObjectFactory) {
+public abstract class FeaturesHandler
+@Inject
+constructor(
+  objects: ObjectFactory,
+  globalSlackProperties: SlackProperties,
+  private val slackProperties: SlackProperties,
+  versionCatalog: VersionCatalog
+) {
   // Dagger features
   internal val daggerHandler = objects.newInstance<DaggerHandler>()
 
@@ -337,6 +361,17 @@ public abstract class FeaturesHandler @Inject constructor(objects: ObjectFactory
 
   // Moshi
   internal val moshiHandler = objects.newInstance<MoshiHandler>()
+
+  // Compose features
+  internal val composeHandler =
+    objects.newInstance<ComposeHandler>(globalSlackProperties, slackProperties, versionCatalog)
+
+  /** @see [SlackExtension.androidExtension] */
+  internal var androidExtension: CommonExtension<*, *, *, *>? = null
+    set(value) {
+      field = value
+      composeHandler.androidExtension = value
+    }
 
   /**
    * Enables dagger for this project.
@@ -462,6 +497,25 @@ public abstract class FeaturesHandler @Inject constructor(objects: ObjectFactory
   /** Enables redacted-compiler-plugin on this project. */
   public fun redacted() {
     redacted.set(true)
+  }
+
+  /**
+   * Enables Compose for this project and applies any version catalog bundle dependencies defined by
+   * [SlackProperties.defaultComposeAndroidBundleAlias].
+   */
+  public fun compose(multiplatform: Boolean = false) {
+    compose(multiplatform) {
+      // No further configuration right now
+    }
+  }
+
+  private fun compose(multiplatform: Boolean, action: Action<ComposeHandler>) {
+    composeHandler.enable(multiplatform = multiplatform)
+    action.execute(composeHandler)
+  }
+
+  internal fun applyTo(project: Project) {
+    composeHandler.applyTo(project, slackProperties)
   }
 }
 
@@ -670,33 +724,19 @@ public abstract class AndroidHandler
 @Inject
 constructor(
   objects: ObjectFactory,
-  globalSlackProperties: SlackProperties,
   private val slackProperties: SlackProperties,
-  versionCatalog: VersionCatalog
 ) {
   internal val libraryHandler = objects.newInstance<SlackAndroidLibraryExtension>()
   internal val appHandler = objects.newInstance<SlackAndroidAppExtension>()
 
   @Suppress("MemberVisibilityCanBePrivate")
-  internal val featuresHandler =
-    objects.newInstance<AndroidFeaturesHandler>(
-      globalSlackProperties,
-      slackProperties,
-      versionCatalog
-    )
+  internal val featuresHandler = objects.newInstance<AndroidFeaturesHandler>()
 
-  /**
-   * This is weird! Due to the non-property nature of the AGP buildFeatures and composeOptions DSLs,
-   * we can't lazily chain their values to our own extension's properties. Because of this, we
-   * lazily set this instance from [StandardProjectConfigurations] during Android extension
-   * evaluation and then make calls to [enable] directly set the values on this instance. Ideally we
-   * could eventually remove this if/when AGP finally makes these properties lazy.
-   */
+  /** @see [SlackExtension.androidExtension] */
   internal var androidExtension: CommonExtension<*, *, *, *>? = null
     set(value) {
       field = value
       featuresHandler.androidExtension = value
-      featuresHandler.composeHandler.androidExtension = value
     }
 
   public fun features(action: Action<AndroidFeaturesHandler>) {
@@ -732,36 +772,19 @@ constructor(
           )
         }
       }
-
-      featuresHandler.composeHandler.applyTo(project, slackProperties)
     }
   }
 }
 
 @SlackExtensionMarker
-public abstract class AndroidFeaturesHandler
-@Inject
-constructor(
-  objects: ObjectFactory,
-  globalSlackProperties: SlackProperties,
-  slackProperties: SlackProperties,
-  versionCatalog: VersionCatalog
-) {
+public abstract class AndroidFeaturesHandler @Inject constructor() {
   internal abstract val androidTest: Property<Boolean>
   internal abstract val androidTestExcludeFromFladle: Property<Boolean>
   internal abstract val androidTestAllowedVariants: SetProperty<String>
   internal abstract val robolectric: Property<Boolean>
 
-  // Compose features
-  internal val composeHandler =
-    objects.newInstance<ComposeHandler>(globalSlackProperties, slackProperties, versionCatalog)
-
   /** @see [AndroidHandler.androidExtension] */
   internal var androidExtension: CommonExtension<*, *, *, *>? = null
-    set(value) {
-      field = value
-      composeHandler.androidExtension = value
-    }
 
   /**
    * Enables android instrumentation tests for this project.
@@ -787,21 +810,6 @@ constructor(
     // Required for Robolectric to work.
     androidExtension!!.testOptions.unitTests.isIncludeAndroidResources = true
     robolectric.set(true)
-  }
-
-  /**
-   * Enables Compose for this project and applies any version catalog bundle dependencies defined by
-   * [SlackProperties.defaultComposeAndroidBundleAlias].
-   */
-  public fun compose(multiplatform: Boolean = false) {
-    compose(multiplatform) {
-      // No further configuration right now
-    }
-  }
-
-  private fun compose(multiplatform: Boolean, action: Action<ComposeHandler>) {
-    composeHandler.enable(multiplatform = multiplatform)
-    action.execute(composeHandler)
   }
 }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
@@ -47,6 +47,10 @@ internal class SlackVersions(val catalog: VersionCatalog) {
     get() = getValue("jdk").toInt()
   val jvmTarget: Int
     get() = getOptionalValue("jvmTarget").map { it.toInt() }.orElse(11)
+  val composeJb: String?
+    get() = getOptionalValue("compose-jb").orElse(null)
+  val composeJbKotlinVersion: String?
+    get() = getOptionalValue("compose-compiler-kotlin-version").orElse(null)
 
   val bundles = Bundles()
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -69,11 +69,13 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.withType
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.jetbrains.compose.ComposeExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
+import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import slack.dependencyrake.RakeDependencies
 import slack.gradle.AptOptionsConfig.AptOptionsConfigurer
 import slack.gradle.AptOptionsConfigs.invoke
@@ -968,6 +970,23 @@ internal class StandardProjectConfigurations(
             enabled = false
           }
         }
+      }
+    }
+
+    pluginManager.withPlugin("org.jetbrains.compose") {
+      configure<ComposeExtension> {
+        kotlinCompilerPlugin.set(
+          dependencies.compiler.forKotlin(slackProperties.versions.composeJbKotlinVersion!!)
+        )
+      }
+      dependencies {
+        val composeCompilerVersion =
+          slackProperties.versions.composeCompiler
+            ?: error("Missing `compose-compiler` version in catalog")
+        add(
+          PLUGIN_CLASSPATH_CONFIGURATION_NAME,
+          "androidx.compose.compiler:compiler:$composeCompilerVersion"
+        )
       }
     }
   }

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -511,7 +511,7 @@ internal class StandardProjectConfigurations(
     pluginManager.withPlugin("com.android.test") {
       slackProperties.versions.bundles.commonLint.ifPresent { dependencies.add("lintChecks", it) }
       configure<TestExtension> {
-        slackExtension.androidHandler.androidExtension = this
+        slackExtension.androidExtension = this
         commonBaseExtensionConfig(false)
         defaultConfig { targetSdk = sdkVersions.targetSdk }
       }
@@ -545,7 +545,7 @@ internal class StandardProjectConfigurations(
         }
       }
       configure<BaseAppModuleExtension> {
-        slackExtension.androidHandler.androidExtension = this
+        slackExtension.androidExtension = this
         commonBaseExtensionConfig(true)
         defaultConfig {
           // TODO this won't work with SDK previews but will fix in a followup
@@ -746,7 +746,7 @@ internal class StandardProjectConfigurations(
         }
       }
       configure<LibraryExtension> {
-        slackExtension.androidHandler.androidExtension = this
+        slackExtension.androidExtension = this
         commonBaseExtensionConfig(true)
         lint { configureLint(project, slackProperties, sdkVersions, false) }
         if (isLibraryWithVariants) {
@@ -841,7 +841,7 @@ internal class StandardProjectConfigurations(
           }
           useK2.set(slackProperties.useK2)
 
-          if (slackExtension.androidHandler.featuresHandler.composeHandler.enabled.get()) {
+          if (slackExtension.featuresHandler.composeHandler.enabled.get()) {
             logger.debug(
               "Configuring compose compiler args in ${project.path}:${this@configureKotlinCompile.name}"
             )

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -69,13 +69,11 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.withType
 import org.gradle.language.base.plugins.LifecycleBasePlugin
-import org.jetbrains.compose.ComposeExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
-import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import slack.dependencyrake.RakeDependencies
 import slack.gradle.AptOptionsConfig.AptOptionsConfigurer
 import slack.gradle.AptOptionsConfigs.invoke
@@ -843,9 +841,7 @@ internal class StandardProjectConfigurations(
           }
           useK2.set(slackProperties.useK2)
 
-          if (
-            slackExtension.androidHandler.featuresHandler.composeHandler.enabled.get() && isAndroid
-          ) {
+          if (slackExtension.androidHandler.featuresHandler.composeHandler.enabled.get()) {
             logger.debug(
               "Configuring compose compiler args in ${project.path}:${this@configureKotlinCompile.name}"
             )
@@ -970,23 +966,6 @@ internal class StandardProjectConfigurations(
             enabled = false
           }
         }
-      }
-    }
-
-    pluginManager.withPlugin("org.jetbrains.compose") {
-      configure<ComposeExtension> {
-        kotlinCompilerPlugin.set(
-          dependencies.compiler.forKotlin(slackProperties.versions.composeJbKotlinVersion!!)
-        )
-      }
-      dependencies {
-        val composeCompilerVersion =
-          slackProperties.versions.composeCompiler
-            ?: error("Missing `compose-compiler` version in catalog")
-        add(
-          PLUGIN_CLASSPATH_CONFIGURATION_NAME,
-          "androidx.compose.compiler:compiler:$composeCompilerVersion"
-        )
       }
     }
   }


### PR DESCRIPTION
- Disable the compose/kotlin version check
- Move the compiler version to alway run when the compose plugin is applied
- Promote the `compose()` DSL to top-level and add a multiplatform option

```kotlin
slack {
  features {
    compose(multiplatform = true|false)
  }
}
```
 
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->