### PR TITLE
Integrate sort-dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ plugins {
   alias(libs.plugins.ksp) apply false
   alias(libs.plugins.versionsPlugin)
   alias(libs.plugins.dependencyAnalysis)
+  alias(libs.plugins.sortDependencies) apply false
 }
 
 configure<DetektExtension> {
@@ -206,6 +207,9 @@ subprojects {
     configure<SamWithReceiverExtension> {
       annotation("org.gradle.api.HasImplicitReceiver")
     }
+
+    // TODO toe-hold for https://github.com/square/gradle-dependencies-sorter/issues/18
+//    apply(plugin = "com.squareup.sort-dependencies")
   }
 
   tasks.withType<Detekt>().configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ moshix = "0.21.0"
 nullawayGradle = "1.3.0"
 okhttp = "5.0.0-alpha.10"
 spotless = "6.14.1"
+sortDependencies = "0.1"
 sqldelight = "1.5.1"
 versionsPlugin = "0.45.0"
 
@@ -31,6 +32,7 @@ lint = { id = "com.android.lint", version.ref = "agp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 moshiGradlePlugin = { id = "dev.zacsweers.moshix", version.ref = "moshix" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+sortDependencies = { id = "com.squareup.sort-dependencies", version.ref = "sortDependencies" }
 versionsPlugin = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
 [libraries]
@@ -52,6 +54,7 @@ gradlePlugins-napt = "com.sergei-lapin.napt:gradle:1.16"
 gradlePlugins-nullaway = { module = "net.ltgt.gradle:gradle-nullaway-plugin", version.ref = "nullawayGradle" }
 gradlePlugins-redacted = "dev.zacsweers.redacted:redacted-compiler-plugin-gradle:1.3.0"
 gradlePlugins-retry = "org.gradle:test-retry-gradle-plugin:1.4.0"
+gradlePlugins-sortDependencies = { module = "com.squareup:sort-dependencies-gradle-plugin", version.ref = "sortDependencies" }
 gradlePlugins-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 gradlePlugins-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "versionsPlugin" }
 guava = "com.google.guava:guava:31.1-jre"

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -375,6 +375,10 @@ public class SlackProperties private constructor(private val project: Project) {
   public val detektBaseline: String?
     get() = optionalStringProperty("slack.detekt.baseline")
 
+  /** Comma-separated set of projects to ignore in sorting dependencies. */
+  public val sortDependenciesIgnore: String?
+    get() = optionalStringProperty("slack.sortDependencies.ignore")
+
   /**
    * Global control for enabling stricter validation of projects, such as ensuring Kotlin projects
    * have at least one `.kt` source file.

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -37,6 +37,7 @@ import slack.gradle.tasks.DetektDownloadTask
 import slack.gradle.tasks.GjfDownloadTask
 import slack.gradle.tasks.KtLintDownloadTask
 import slack.gradle.tasks.KtfmtDownloadTask
+import slack.gradle.tasks.SortDependenciesDownloadTask
 import slack.gradle.util.ThermalsData
 import slack.stats.ModuleStatsTasks
 
@@ -154,6 +155,14 @@ internal class SlackRootPlugin : Plugin<Project> {
       project.tasks.register<KtfmtDownloadTask>("updateKtfmt") {
         version.set(ktfmtVersion)
         outputFile.set(project.layout.projectDirectory.file("config/bin/ktfmt"))
+      }
+    }
+
+    // Add sortDependencies download task
+    slackProperties.versions.sortDependencies?.let { sortDependenciesVersion ->
+      project.tasks.register<SortDependenciesDownloadTask>("updateSortDependencies") {
+        version.set(sortDependenciesVersion)
+        outputFile.set(project.layout.projectDirectory.file("config/bin/sort-dependencies"))
       }
     }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
@@ -41,6 +41,8 @@ internal class SlackVersions(val catalog: VersionCatalog) {
     get() = getOptionalValue("ktlint").orElse(null)
   val ktfmt: String?
     get() = getOptionalValue("ktfmt").orElse(null)
+  val sortDependencies: String?
+    get() = getOptionalValue("sortDependencies").orElse(null)
   val objenesis: String?
     get() = getOptionalValue("objenesis").orElse(null)
   val jdk: Int

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -121,7 +121,18 @@ internal class StandardProjectConfigurations(
   fun applyTo(project: Project) {
     val slackProperties = SlackProperties(project)
     val globalConfig = project.slackTools().globalConfig
+    project.applyCommonConfigurations()
     project.applyJvmConfigurations(globalConfig, slackProperties)
+  }
+
+  private fun Project.applyCommonConfigurations() {
+    if (project.buildFile.exists()) {
+      val sortDependenciesIgnoreSet =
+        globalProperties.sortDependenciesIgnore?.splitToSequence(',')?.toSet().orEmpty()
+      if (project.path !in sortDependenciesIgnoreSet) {
+        apply(plugin = "com.squareup.sort-dependencies")
+      }
+    }
   }
 
   @Suppress("unused")

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/SortDependenciesDownloadTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/SortDependenciesDownloadTask.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.tasks
+
+/**
+ * Downloads the Sort Dependencies binary from maven central.
+ *
+ * Usage:
+ * ```
+ *     ./gradlew updateSortDependencies
+ * ```
+ */
+internal abstract class SortDependenciesDownloadTask :
+  BaseDownloadTask(
+    targetName = "Sort Dependencies",
+    addExecPrefix = true,
+    urlTemplate = { version ->
+      "https://repo1.maven.org/maven2/com/squareup/sort-gradle-dependencies-app/$version/sort-gradle-dependencies-app-$version-all.jar"
+    }
+  ) {
+  init {
+    description = "Downloads the Sort Dependencies binary from maven central."
+  }
+}


### PR DESCRIPTION
This adds a new formatter in the same vein as ktfmt, gjf, etc for sorting dependencies in build files. This is mostly is just about adding the binary download task + automatically enabling the gradle plugin.

https://github.com/square/gradle-dependencies-sorter

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->