### PR TITLE
Rework download progress and use workers in robolectric jar downloads

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,5 @@ okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp
 okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okio = "com.squareup.okio:okio:3.3.0"
 oshi = "com.github.oshi:oshi-core:6.4.0"
-progressBar = "me.tongfei:progressbar:0.9.5"
 rxjava = "io.reactivex.rxjava3:rxjava:3.1.6"
 truth = "com.google.truth:truth:1.1.3"

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -108,9 +108,6 @@ dependencies {
   // Graphing library with Betweenness Centrality algo for modularization score
   implementation(libs.jgrapht)
 
-  // Progress bar for downloads
-  implementation(libs.progressBar)
-
   // Better I/O
   api(libs.okio)
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
@@ -39,6 +39,7 @@ import slack.gradle.util.JsonTools
 import slack.gradle.util.Thermals
 import slack.gradle.util.ThermalsWatcher
 import slack.gradle.util.mapToBoolean
+import slack.gradle.util.shutdown
 
 /** Misc tools for Slack Gradle projects, usable in tasks as a [BuildService] too. */
 public abstract class SlackTools @Inject constructor(providers: ProviderFactory) :
@@ -115,11 +116,7 @@ public abstract class SlackTools @Inject constructor(providers: ProviderFactory)
       logger.error("Failed to report thermals", t)
     } finally {
       if (okHttpClient.isInitialized()) {
-        with(okHttpClient.value) {
-          dispatcher.executorService.shutdown()
-          connectionPool.evictAll()
-          cache?.close()
-        }
+        okHttpClient.value.shutdown()
       }
     }
   }

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/BaseDownloadTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/BaseDownloadTask.kt
@@ -69,15 +69,7 @@ internal abstract class BaseDownloadTask(
     val progressListener = ProgressLoggerProgressListener(fileName, progressLogger)
 
     val client =
-      OkHttpClient.Builder()
-        .addInterceptor { chain ->
-          val originalResponse = chain.proceed(chain.request())
-          originalResponse
-            .newBuilder()
-            .body(ProgressResponseBody(originalResponse.body, progressListener))
-            .build()
-        }
-        .build()
+      OkHttpClient.Builder().addInterceptor(ProgressReportingInterceptor(progressListener)).build()
 
     client.newCall(request).execute().use { response ->
       if (!response.isSuccessful) throw IOException("Unexpected code $response")

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/DetektDownloadTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/DetektDownloadTask.kt
@@ -15,6 +15,8 @@
  */
 package slack.gradle.tasks
 
+import org.gradle.api.tasks.UntrackedTask
+
 /**
  * Downloads the Detekt binary from its GitHub releases.
  *
@@ -23,6 +25,7 @@ package slack.gradle.tasks
  *     ./gradlew updateDetekt
  * ```
  */
+@UntrackedTask(because = "These are one-off, on-demand download tasks")
 internal abstract class DetektDownloadTask :
   BaseDownloadTask(
     targetName = "Detekt",

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/GjfDownloadTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/GjfDownloadTask.kt
@@ -15,6 +15,8 @@
  */
 package slack.gradle.tasks
 
+import org.gradle.api.tasks.UntrackedTask
+
 /**
  * Downloads the GJF binary from its GitHub releases.
  *
@@ -23,6 +25,7 @@ package slack.gradle.tasks
  *     ./gradlew updateGjf
  * ```
  */
+@UntrackedTask(because = "These are one-off, on-demand download tasks")
 internal abstract class GjfDownloadTask :
   BaseDownloadTask(
     targetName = "GoogleJavaFormat",

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/KtLintDownloadTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/KtLintDownloadTask.kt
@@ -15,6 +15,8 @@
  */
 package slack.gradle.tasks
 
+import org.gradle.api.tasks.UntrackedTask
+
 /**
  * Downloads the KtLint binary from its GitHub releases.
  *
@@ -23,6 +25,7 @@ package slack.gradle.tasks
  *     ./gradlew updateKtLint
  * ```
  */
+@UntrackedTask(because = "These are one-off, on-demand download tasks")
 internal abstract class KtLintDownloadTask :
   BaseDownloadTask(
     targetName = "KtLint",

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/KtfmtDownloadTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/KtfmtDownloadTask.kt
@@ -15,6 +15,8 @@
  */
 package slack.gradle.tasks
 
+import org.gradle.api.tasks.UntrackedTask
+
 /**
  * Downloads the ktfmt binary from maven central.
  *
@@ -23,6 +25,7 @@ package slack.gradle.tasks
  *     ./gradlew updateKtfmt
  * ```
  */
+@UntrackedTask(because = "These are one-off, on-demand download tasks")
 internal abstract class KtfmtDownloadTask :
   BaseDownloadTask(
     targetName = "ktfmt",

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/ProgressResponseBody.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/ProgressResponseBody.kt
@@ -15,6 +15,7 @@
  */
 package slack.gradle.tasks
 
+import okhttp3.Interceptor
 import okhttp3.ResponseBody
 import okio.Buffer
 import okio.BufferedSource
@@ -58,6 +59,17 @@ internal constructor(
 
 internal interface ProgressListener {
   fun update(bytesRead: Long, contentLength: Long, done: Boolean)
+}
+
+internal class ProgressReportingInterceptor(private val progressListener: ProgressListener) :
+  Interceptor {
+  override fun intercept(chain: Interceptor.Chain): okhttp3.Response {
+    val originalResponse = chain.proceed(chain.request())
+    return originalResponse
+      .newBuilder()
+      .body(ProgressResponseBody(originalResponse.body, progressListener))
+      .build()
+  }
 }
 
 /** A [ProgressListener] that logs progress to a [ProgressLogger]. */

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/ProgressResponseBody.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/ProgressResponseBody.kt
@@ -21,6 +21,12 @@ import okio.BufferedSource
 import okio.ForwardingSource
 import okio.Source
 import okio.buffer
+import org.gradle.internal.logging.progress.ProgressLogger
+
+private const val ONE_MEGABYTE_IN_BYTES: Double = (1L * 1024L * 1024L).toDouble()
+
+private val Long.mb: String
+  get() = String.format("%.2f", this / ONE_MEGABYTE_IN_BYTES)
 
 internal class ProgressResponseBody
 internal constructor(
@@ -52,4 +58,29 @@ internal constructor(
 
 internal interface ProgressListener {
   fun update(bytesRead: Long, contentLength: Long, done: Boolean)
+}
+
+/** A [ProgressListener] that logs progress to a [ProgressLogger]. */
+internal class ProgressLoggerProgressListener(
+  private val name: String,
+  private val progressLogger: ProgressLogger
+) : ProgressListener {
+  private var firstUpdate = true
+
+  override fun update(bytesRead: Long, contentLength: Long, done: Boolean) {
+    if (done) {
+      progressLogger.progress("Download completed")
+    } else {
+      if (firstUpdate) {
+        firstUpdate = false
+        if (contentLength == -1L) {
+          progressLogger.completed("content-length: unknown", /* failed */ true)
+          error("content-length: unknown")
+        }
+      }
+      if (contentLength != -1L) {
+        progressLogger.progress("$name > ${bytesRead.mb} MB/${contentLength.mb} MB")
+      }
+    }
+  }
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/SortDependenciesDownloadTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/SortDependenciesDownloadTask.kt
@@ -15,6 +15,8 @@
  */
 package slack.gradle.tasks
 
+import org.gradle.api.tasks.UntrackedTask
+
 /**
  * Downloads the Sort Dependencies binary from maven central.
  *
@@ -23,6 +25,7 @@ package slack.gradle.tasks
  *     ./gradlew updateSortDependencies
  * ```
  */
+@UntrackedTask(because = "These are one-off, on-demand download tasks")
 internal abstract class SortDependenciesDownloadTask :
   BaseDownloadTask(
     targetName = "Sort Dependencies",

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/robolectric/DependencyJar.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/robolectric/DependencyJar.kt
@@ -15,11 +15,14 @@
  */
 package slack.gradle.tasks.robolectric
 
+import java.io.Serializable
+
+// Serializable for Gradle use
 internal data class DependencyJar(
   val groupId: String,
   val artifactId: String,
   val version: String,
   val classifier: String? = null
-) {
+) : Serializable {
   val name: String = "$artifactId-$version.jar"
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/OkHttpExt.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/OkHttpExt.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.util
+
+import okhttp3.OkHttpClient
+
+/** Shuts down this [OkHttpClient] and all of its resources. */
+internal fun OkHttpClient.shutdown() {
+  dispatcher.executorService.shutdown()
+  connectionPool.evictAll()
+  cache?.close()
+}


### PR DESCRIPTION
Using Gradle's ProgressLogger API ([which is annoyingly internal, but super useful](https://github.com/gradle/gradle/issues/3654)) to get a much nicer progress output.

This also moves robolectric jar downloads to use the worker API, allowing them to parallelize their downloads. On my gigabit wifi, this takes the task runtime down from ~21sec to ~13sec.

This also ultimately removes the custom progressbar lib we used since it's no longer used.

This should almost be two different PRs, but they have overlapping changes in progress listener changes so I decided to keep them together since they're both small.

Gradle may someday change the ProgressLogger API since it's internal, but if that happens we can easily remove it.

**Demo**

https://user-images.githubusercontent.com/1361086/218298297-4280a42b-8218-41f3-a36d-caa45e6760f1.mov



<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->