### PR TITLE
Better support fully modularized lints

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -236,6 +236,10 @@ public class SlackProperties private constructor(private val project: Project) {
   public val lintUpdateBaselines: Boolean
     get() = booleanProperty("slack.lint.update-baselines")
 
+  /** File name to use for a project's lint baseline. */
+  public val lintBaselineFileName: String
+    get() = stringProperty("slack.lint.baseline-file-name", "lint-baseline.xml")
+
   /** Flag to enable/disable KSP. */
   public val allowKsp: Boolean
     get() = booleanProperty("slack.allow-ksp")

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -562,9 +562,7 @@ internal class StandardProjectConfigurations(
           // TODO this won't work with SDK previews but will fix in a followup
           targetSdk = sdkVersions.targetSdk
         }
-        lint {
-          configureLint(project, slackProperties, sdkVersions, checkDependencies = true)
-        }
+        lint { configureLint(project, slackProperties, sdkVersions, checkDependencies = true) }
         agpHandler.packagingOptions(
           this,
           resourceExclusions =

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -1092,11 +1092,13 @@ private fun Lint.configureLint(
   absolutePaths = false
   this.checkDependencies = checkDependencies
 
+  val lintBaselineFile = slackProperties.lintBaselineFileName
+
   // Lint is weird in that it will generate a new baseline file and fail the build if a new
   // one was generated, even if empty.
   // If we're updating baselines, always take the baseline so that we populate it if absent.
   project.layout.projectDirectory
-    .file("lint-baseline.xml")
+    .file(lintBaselineFile)
     .asFile
     .takeIf { it.exists() || slackProperties.lintUpdateBaselines }
     ?.let { baseline = it }

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -563,8 +563,7 @@ internal class StandardProjectConfigurations(
           targetSdk = sdkVersions.targetSdk
         }
         lint {
-          configureLint(project, slackProperties, sdkVersions, true)
-          checkDependencies = true
+          configureLint(project, slackProperties, sdkVersions, checkDependencies = true)
         }
         agpHandler.packagingOptions(
           this,
@@ -1080,6 +1079,7 @@ private fun Lint.configureLint(
   // These store qualified gradle caches in their paths and always change in baselines
   disable += "ObsoleteLintCustomCheck"
   // https://groups.google.com/g/lint-dev/c/Bj0-I1RIPyU/m/mlP5Jpe4AQAJ
+  enable += "ImplicitSamInstance"
   error += "ImplicitSamInstance"
 
   androidSdkVersions?.let { sdkVersions ->
@@ -1098,7 +1098,7 @@ private fun Lint.configureLint(
   // one was generated, even if empty.
   // If we're updating baselines, always take the baseline so that we populate it if absent.
   project.layout.projectDirectory
-    .file("config/lint/baseline.xml")
+    .file("lint-baseline.xml")
     .asFile
     .takeIf { it.exists() || slackProperties.lintUpdateBaselines }
     ?.let { baseline = it }


### PR DESCRIPTION
This changes SGP to better support lints in multiple projects by not assuming `checkDependencies` and making baseline file names configurable. Also opportunistically fixes an implicit sam check that wasn't getting enabled before

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->