### PR TITLE
Fix accidental configureEach in namedLazy

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
@@ -274,7 +274,7 @@ internal inline fun <reified T : Task> Project.namedLazy(
 
   var didRun = false
 
-  tasks.withType(T::class.java).configureEach {
+  tasks.withType(T::class.java) {
     if (name == targetName) {
       action(tasks.named(name, T::class.java))
       didRun = true


### PR DESCRIPTION
This was an accidental behavior change introduced in #258

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->