### PR TITLE
Add lintErrorRuleIds property

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -240,6 +240,10 @@ public class SlackProperties private constructor(private val project: Project) {
   public val lintBaselineFileName: String
     get() = stringProperty("slack.lint.baseline-file-name", "lint-baseline.xml")
 
+  /** Comma-separated list of lint rule IDs that should be set to `error` severity. */
+  public val lintErrorRuleIds: String?
+    get() = project.optionalStringProperty("slack.lint.severity.errorRuleIds")
+
   /** Flag to enable/disable KSP. */
   public val allowKsp: Boolean
     get() = booleanProperty("slack.allow-ksp")

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -1076,6 +1076,10 @@ private fun Lint.configureLint(
   enable += "ImplicitSamInstance"
   error += "ImplicitSamInstance"
 
+  for (ruleId in slackProperties.lintErrorRuleIds?.splitToSequence(',').orEmpty()) {
+    error += ruleId
+  }
+
   androidSdkVersions?.let { sdkVersions ->
     if (sdkVersions.minSdk >= 28) {
       // Lint doesn't understand AppComponentFactory


### PR DESCRIPTION
This allows projects to specify extra rule IDs that should be promoted to error severity at a global level. Otherwise they'd have to have some sort of subprojects config to set this in lint each time.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->