### PR TITLE
Consolidate common lint logic to LintTasks

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -286,6 +286,19 @@ public class SlackProperties private constructor(private val project: Project) {
     get() = stringProperty("slack.ci-unit-test.variant", "release")
 
   /**
+   * Flag to enable ciLint on this project. Default is true.
+   *
+   * When enabled, a task named "ciLint" will be created in this project, which will depend on the
+   * unit test task for a single build variant (e.g. "lint").
+   */
+  public val ciLintEnabled: Boolean
+    get() = booleanProperty("slack.ci-lint.enable", defaultValue = true)
+
+  /** CI lint variant (Android only). Default when unspecified will just use "lint". */
+  public val ciLintVariant: String?
+    get() = optionalStringProperty("slack.ci-lint.variant")
+
+  /**
    * Location for robolectric-core to be referenced by app. Temporary till we have a better solution
    * for "always add these" type of deps.
    *

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -286,17 +286,20 @@ public class SlackProperties private constructor(private val project: Project) {
     get() = stringProperty("slack.ci-unit-test.variant", "release")
 
   /**
-   * Flag to enable ciLint on this project. Default is true.
+   * Flag to enable ciLint on a project. Default is true.
    *
    * When enabled, a task named "ciLint" will be created in this project, which will depend on the
-   * unit test task for a single build variant (e.g. "lint").
+   * all the lint tasks in the project.
    */
   public val ciLintEnabled: Boolean
     get() = booleanProperty("slack.ci-lint.enable", defaultValue = true)
 
-  /** CI lint variant (Android only). Default when unspecified will just use "lint". */
-  public val ciLintVariant: String?
-    get() = optionalStringProperty("slack.ci-lint.variant")
+  /**
+   * Comma-separated list of CI lint variants to run (Android only). Default when unspecified will
+   * lint all variants.
+   */
+  public val ciLintVariants: String?
+    get() = optionalStringProperty("slack.ci-lint.variants")
 
   /**
    * Location for robolectric-core to be referenced by app. Temporary till we have a better solution

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -28,6 +28,7 @@ import slack.cli.AppleSiliconCompat
 import slack.executeBlocking
 import slack.executeBlockingWithResult
 import slack.gradle.agp.VersionNumber
+import slack.gradle.lint.LintTasks
 import slack.gradle.tasks.AndroidTestApksTask
 import slack.gradle.tasks.CoreBootstrapTask
 import slack.gradle.tasks.DetektDownloadTask
@@ -99,6 +100,7 @@ internal class SlackRootPlugin : Plugin<Project> {
       project.configureGit(slackProperties)
     }
     project.configureSlackRootBuildscript()
+    LintTasks.configureRootProject(project)
     project.configureMisc(slackProperties)
     ModuleStatsTasks.configureRoot(project, slackProperties)
     val scanApi = ScanApi(project)

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -18,7 +18,6 @@
 package slack.gradle
 
 import com.android.build.api.artifact.SingleArtifact
-import com.android.build.api.dsl.Lint
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.HasAndroidTestBuilder
@@ -69,6 +68,7 @@ import slack.gradle.AptOptionsConfig.AptOptionsConfigurer
 import slack.gradle.AptOptionsConfigs.invoke
 import slack.gradle.dependencies.KotlinBuildConfig
 import slack.gradle.dependencies.SlackDependencies
+import slack.gradle.lint.LintTasks
 import slack.gradle.permissionchecks.PermissionChecks
 import slack.gradle.tasks.AndroidTestApksTask
 import slack.gradle.tasks.CheckManifestPermissionsTask
@@ -428,7 +428,7 @@ internal class StandardProjectConfigurations(
         }
       }
 
-    val sdkVersions by lazy { slackProperties.requireAndroidSdkProperties() }
+    val sdkVersions = lazy { slackProperties.requireAndroidSdkProperties() }
     val shouldApplyCacheFixPlugin = slackProperties.enableAndroidCacheFix
     val agpHandler = slackTools().agpHandler
     val commonBaseExtensionConfig: BaseExtension.(applyTestOptions: Boolean) -> Unit =
@@ -437,11 +437,11 @@ internal class StandardProjectConfigurations(
           pluginManager.apply("org.gradle.android.cache-fix")
         }
 
-        compileSdkVersion(sdkVersions.compileSdk)
+        compileSdkVersion(sdkVersions.value.compileSdk)
         slackProperties.ndkVersion?.let { ndkVersion = it }
         defaultConfig {
           // TODO this won't work with SDK previews but will fix in a followup
-          minSdk = sdkVersions.minSdk
+          minSdk = sdkVersions.value.minSdk
           vectorDrawables.useSupportLibrary = true
           // Default to the standard android runner, but note this is overridden in :app
           testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -516,17 +516,15 @@ internal class StandardProjectConfigurations(
     }
 
     pluginManager.withPlugin("com.android.test") {
-      slackProperties.versions.bundles.commonLint.ifPresent { dependencies.add("lintChecks", it) }
       configure<TestExtension> {
         slackExtension.androidExtension = this
         commonBaseExtensionConfig(false)
-        defaultConfig { targetSdk = sdkVersions.targetSdk }
+        defaultConfig { targetSdk = sdkVersions.value.targetSdk }
+        LintTasks.configureSubProject(project, slackProperties, this, sdkVersions::value)
       }
     }
 
     pluginManager.withPlugin("com.android.application") {
-      // Add slack-lint as lint checks source
-      slackProperties.versions.bundles.commonLint.ifPresent { dependencies.add("lintChecks", it) }
       prepareAndroidTestConfigurations()
       configure<ApplicationAndroidComponentsExtension> {
         commonComponentsExtension.execute(this)
@@ -556,9 +554,9 @@ internal class StandardProjectConfigurations(
         commonBaseExtensionConfig(true)
         defaultConfig {
           // TODO this won't work with SDK previews but will fix in a followup
-          targetSdk = sdkVersions.targetSdk
+          targetSdk = sdkVersions.value.targetSdk
         }
-        lint { configureLint(project, slackProperties, sdkVersions, checkDependencies = true) }
+        LintTasks.configureSubProject(project, slackProperties, this, sdkVersions::value)
         agpHandler.packagingOptions(
           this,
           resourceExclusions =
@@ -667,8 +665,6 @@ internal class StandardProjectConfigurations(
     }
 
     pluginManager.withPlugin("com.android.library") {
-      // Add slack-lint as lint checks source
-      slackProperties.versions.bundles.commonLint.ifPresent { dependencies.add("lintChecks", it) }
       prepareAndroidTestConfigurations()
       val isLibraryWithVariants = slackProperties.libraryWithVariants
 
@@ -752,7 +748,7 @@ internal class StandardProjectConfigurations(
       configure<LibraryExtension> {
         slackExtension.androidExtension = this
         commonBaseExtensionConfig(true)
-        lint { configureLint(project, slackProperties, sdkVersions, false) }
+        LintTasks.configureSubProject(project, slackProperties, this, sdkVersions::value)
         if (isLibraryWithVariants) {
           buildTypes {
             getByName("debug") {
@@ -920,11 +916,7 @@ internal class StandardProjectConfigurations(
     }
 
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-      // Enable linting on pure JVM projects
-      pluginManager.apply("com.android.lint")
-      configure<Lint> { configureLint(project, slackProperties, null, false) }
-      // Add slack-lint as lint checks source
-      slackProperties.versions.bundles.commonLint.ifPresent { dependencies.add("lintChecks", it) }
+      LintTasks.configureSubProject(project, slackProperties, null, null)
     }
 
     pluginManager.withPlugin("org.jetbrains.kotlin.android") {
@@ -1058,46 +1050,6 @@ internal class StandardProjectConfigurations(
       return isKnownConfiguration(name, Configurations.Groups.PLATFORM)
     }
   }
-}
-
-private fun Lint.configureLint(
-  project: Project,
-  slackProperties: SlackProperties,
-  androidSdkVersions: SlackProperties.AndroidSdkProperties?,
-  checkDependencies: Boolean,
-) {
-  lintConfig = project.rootProject.layout.projectDirectory.file("config/lint/lint.xml").asFile
-  sarifReport = true
-  // This check is _never_ up to date and makes network requests!
-  disable += "NewerVersionAvailable"
-  // These store qualified gradle caches in their paths and always change in baselines
-  disable += "ObsoleteLintCustomCheck"
-  // https://groups.google.com/g/lint-dev/c/Bj0-I1RIPyU/m/mlP5Jpe4AQAJ
-  enable += "ImplicitSamInstance"
-  error += "ImplicitSamInstance"
-
-  androidSdkVersions?.let { sdkVersions ->
-    if (sdkVersions.minSdk >= 28) {
-      // Lint doesn't understand AppComponentFactory
-      // https://issuetracker.google.com/issues/243267012
-      disable += "Instantiatable"
-    }
-  }
-
-  ignoreWarnings = slackProperties.lintErrorsOnly
-  absolutePaths = false
-  this.checkDependencies = checkDependencies
-
-  val lintBaselineFile = slackProperties.lintBaselineFileName
-
-  // Lint is weird in that it will generate a new baseline file and fail the build if a new
-  // one was generated, even if empty.
-  // If we're updating baselines, always take the baseline so that we populate it if absent.
-  project.layout.projectDirectory
-    .file(lintBaselineFile)
-    .asFile
-    .takeIf { it.exists() || slackProperties.lintUpdateBaselines }
-    ?.let { baseline = it }
 }
 
 internal interface KotlinArgConfig {

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.lint
+
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.Lint
+import com.android.build.gradle.AppExtension
+import java.util.concurrent.atomic.AtomicBoolean
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.AppliedPlugin
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import slack.gradle.SlackProperties
+import slack.gradle.configure
+import slack.gradle.safeCapitalize
+
+internal object LintTasks {
+  private const val GLOBAL_CI_LINT_TASK_NAME = "globalCiLint"
+  private const val CI_LINT_TASK_NAME = "ciLint"
+  private const val COMPILE_CI_LINT_NAME = "compileCiLint"
+  private const val LOG = "SlackLints:"
+
+  fun configureRootProject(project: Project): TaskProvider<Task> =
+    project.tasks.register(GLOBAL_CI_LINT_TASK_NAME) {
+      group = LifecycleBasePlugin.VERIFICATION_GROUP
+      description = "Global lifecycle task to run all dependent lint tasks."
+    }
+
+  fun configureSubProject(
+    project: Project,
+    slackProperties: SlackProperties,
+    commonExtension: CommonExtension<*, *, *, *>?,
+    sdkVersions: (() -> SlackProperties.AndroidSdkProperties)?,
+  ) {
+    // Projects can opt out of creating the task with this property.
+    val enabled = slackProperties.ciUnitTestEnabled
+    if (!enabled) {
+      project.logger.debug("$LOG Skipping creation of \"$CI_LINT_TASK_NAME\" task")
+      return
+    }
+
+    // Apply common lints
+    slackProperties.versions.bundles.commonLint.ifPresent {
+      project.dependencies.add("lintChecks", it)
+    }
+
+    val globalTask = project.rootProject.tasks.named(GLOBAL_CI_LINT_TASK_NAME)
+
+    // We only want to create tasks once, but a project might apply multiple plugins.
+    val applied = AtomicBoolean(false)
+
+    if (commonExtension != null) {
+      project.logger.debug("$LOG Applying UnitTestPlugin to Android project")
+      createAndroidCiLintTask(
+        project,
+        globalTask,
+        slackProperties,
+        commonExtension,
+        sdkVersions!!.invoke()
+      )
+    } else {
+      val javaKotlinLibraryHandler = { plugin: AppliedPlugin ->
+        if (applied.compareAndSet(false, true)) {
+          // Enable linting on pure JVM projects
+          project.pluginManager.apply("com.android.lint")
+          project.configure<Lint> { configureLint(project, slackProperties, null, false) }
+          project.logger.debug("$LOG Creating CI lint task")
+          val ciLint =
+            project.tasks.register(COMPILE_CI_LINT_NAME) {
+              group = LifecycleBasePlugin.VERIFICATION_GROUP
+              dependsOn("lint")
+            }
+          globalTask.configure { dependsOn(ciLint) }
+        }
+      }
+      project.pluginManager.withPlugin("java-library", javaKotlinLibraryHandler)
+      project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm", javaKotlinLibraryHandler)
+    }
+  }
+
+  private fun createAndroidCiLintTask(
+    project: Project,
+    globalTask: TaskProvider<*>,
+    slackProperties: SlackProperties,
+    extension: CommonExtension<*, *, *, *>,
+    sdkVersions: SlackProperties.AndroidSdkProperties,
+  ) {
+    extension.lint {
+      configureLint(
+        project,
+        slackProperties,
+        sdkVersions,
+        checkDependencies = extension is AppExtension
+      )
+    }
+
+    val variant = slackProperties.ciLintVariant
+    val lintTaskName =
+      if (variant == null) {
+        "lint"
+      } else {
+        "lint${variant.safeCapitalize()}"
+      }
+
+    project.logger.debug("$LOG Creating CI lint task for variant '$variant'")
+    val ciUnitTest =
+      project.tasks.register(CI_LINT_TASK_NAME) {
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        // Even if the task isn't created yet, we can do this by name alone and it will resolve at
+        // task configuration time.
+        dependsOn(lintTaskName)
+      }
+    globalTask.configure { dependsOn(ciUnitTest) }
+  }
+
+  private fun Lint.configureLint(
+    project: Project,
+    slackProperties: SlackProperties,
+    androidSdkVersions: SlackProperties.AndroidSdkProperties?,
+    checkDependencies: Boolean,
+  ) {
+    lintConfig = project.rootProject.layout.projectDirectory.file("config/lint/lint.xml").asFile
+    sarifReport = true
+    // This check is _never_ up to date and makes network requests!
+    disable += "NewerVersionAvailable"
+    // These store qualified gradle caches in their paths and always change in baselines
+    disable += "ObsoleteLintCustomCheck"
+    // https://groups.google.com/g/lint-dev/c/Bj0-I1RIPyU/m/mlP5Jpe4AQAJ
+    enable += "ImplicitSamInstance"
+    error += "ImplicitSamInstance"
+
+    androidSdkVersions?.let { sdkVersions ->
+      if (sdkVersions.minSdk >= 28) {
+        // Lint doesn't understand AppComponentFactory
+        // https://issuetracker.google.com/issues/243267012
+        disable += "Instantiatable"
+      }
+    }
+
+    ignoreWarnings = slackProperties.lintErrorsOnly
+    absolutePaths = false
+    this.checkDependencies = checkDependencies
+
+    val lintBaselineFile = slackProperties.lintBaselineFileName
+
+    // Lint is weird in that it will generate a new baseline file and fail the build if a new
+    // one was generated, even if empty.
+    // If we're updating baselines, always take the baseline so that we populate it if absent.
+    project.layout.projectDirectory
+      .file(lintBaselineFile)
+      .asFile
+      .takeIf { it.exists() || slackProperties.lintUpdateBaselines }
+      ?.let { baseline = it }
+  }
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -108,6 +108,7 @@ internal object LintTasks {
       )
     }
 
+    // TODO should we change this default to depend on _all_ "lintReport*" AndroidLintTasks?
     val variant = slackProperties.ciLintVariant
     val lintTaskName =
       if (variant == null) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -118,14 +118,14 @@ internal object LintTasks {
       }
 
     project.logger.debug("$LOG Creating CI lint task for variant '$variant'")
-    val ciUnitTest =
+    val ciLintTask =
       project.tasks.register(CI_LINT_TASK_NAME) {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         // Even if the task isn't created yet, we can do this by name alone and it will resolve at
         // task configuration time.
         dependsOn(lintTaskName)
       }
-    globalTask.configure { dependsOn(ciUnitTest) }
+    globalTask.configure { dependsOn(ciLintTask) }
   }
 
   private fun Lint.configureLint(

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -73,7 +73,7 @@ internal object LintTasks {
         sdkVersions!!.invoke()
       )
     } else {
-      val javaKotlinLibraryHandler = { plugin: AppliedPlugin ->
+      val javaKotlinLibraryHandler = { _: AppliedPlugin ->
         if (applied.compareAndSet(false, true)) {
           // Enable linting on pure JVM projects
           project.pluginManager.apply("com.android.lint")


### PR DESCRIPTION
This is similar in structure to #280 but for lints. It creates new `ciLint` and a root `globalCiLint` tasks in the project to ease running things on CI.

This also extracts a lot of lint logic from the bloated `StandardProjectConfigurations` file to this standalone bit of code.

One notable change is that now we run lint for all variants in a project unless otherwise specified. This seems like the right thing to do as we should also be running lint on internal/debug/etc sources too.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->