### PR TITLE
Add kover property

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -285,6 +285,10 @@ public class SlackProperties private constructor(private val project: Project) {
   public val ciUnitTestVariant: String
     get() = stringProperty("slack.ci-unit-test.variant", "release")
 
+  /** If enabled, applies the kotlinx-kover plugin to projects using ciUnitTest. */
+  public val ciUnitTestEnableKover: Boolean
+    get() = booleanProperty("slack.ci-unit-test.enableKover", false)
+
   /**
    * Parallelism multiplier to use for unit tests. This should be a float value that is multiplied
    * by the number of cores. The value can be a fraction. Default is 0.5.

--- a/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
+++ b/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
@@ -75,6 +75,10 @@ internal object UnitTests {
       return
     }
 
+    if (slackProperties.ciUnitTestEnableKover) {
+      project.pluginManager.apply("org.jetbrains.kotlinx.kover")
+    }
+
     val globalTask = project.rootProject.tasks.named(GLOBAL_CI_UNIT_TEST_TASK_NAME)
 
     // We only want to create tasks once, but a project might apply multiple plugins.


### PR DESCRIPTION
This adds a new `enableKover` property to allow for enabling kotlinx-kover anywhere we apply ciUnitTest. It does not currently do any other configuration as we're still testing this out internally.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->