### PR TITLE
Removed unsupported arg from UnitTests

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
+++ b/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
@@ -149,10 +149,6 @@ internal object UnitTests {
        * https://github.com/tinyspeck/slack-android-ng/issues/22005
        */
 
-      // Improve JVM memory behavior in tests to avoid OOMs
-      // https://www.royvanrijn.com/blog/2018/05/java-and-docker-memory-limits/
-      jvmArgs("-XX:+UseContainerSupport")
-
       // helps when tests leak memory
       setForkEvery(slackProperties.unitTestForkEvery)
 


### PR DESCRIPTION
Removed JVM arg `UseContainerSupport` from UnitTests as it is not supported for all,

ref: https://www.royvanrijn.com/blog/2018/05/java-and-docker-memory-limits/