### PR TITLE
Implement ComputeAffectedProjects

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ gradlePlugins-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plu
 gradlePlugins-doctor = "com.osacky.doctor:doctor-plugin:0.8.1"
 gradlePlugins-enterprise = "com.gradle:gradle-enterprise-gradle-plugin:3.12.2"
 gradlePlugins-errorProne = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version.ref = "errorproneGradle" }
+gradlePlugins-graphAssert = "com.jraska.module.graph.assertion:plugin:2.3.1"
 gradlePlugins-ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 gradlePlugins-moshix = { module = "dev.zacsweers.moshix:moshi-gradle-plugin", version.ref = "moshix" }
 gradlePlugins-napt = "com.sergei-lapin.napt:gradle:1.16"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ moshi = "1.14.0"
 moshix = "0.21.0"
 nullawayGradle = "1.3.0"
 okhttp = "5.0.0-alpha.10"
+okio = "3.3.0"
 sortDependencies = "0.2"
 spotless = "6.17.0"
 sqldelight = "2.0.0-alpha05"
@@ -77,7 +78,8 @@ moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "mosh
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
-okio = "com.squareup.okio:okio:3.3.0"
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 oshi = "com.github.oshi:oshi-core:6.4.0"
 rxjava = "io.reactivex.rxjava3:rxjava:3.1.6"
 truth = "com.google.truth:truth:1.1.3"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,9 +29,7 @@ dependencyResolutionManagement {
 
   // Non-delegate APIs are annoyingly not public so we have to use withGroovyBuilder
   fun hasProperty(key: String): Boolean {
-    return settings.withGroovyBuilder {
-      "hasProperty"(key) as Boolean
-    }
+    return settings.withGroovyBuilder { "hasProperty"(key) as Boolean }
   }
 
   repositories {
@@ -53,7 +51,8 @@ dependencyResolutionManagement {
 
     google()
 
-    // Kotlin bootstrap repository, useful for testing against Kotlin dev builds. Usually only tested on CI shadow jobs
+    // Kotlin bootstrap repository, useful for testing against Kotlin dev builds. Usually only
+    // tested on CI shadow jobs
     // https://kotlinlang.slack.com/archives/C0KLZSCHF/p1616514468003200?thread_ts=1616509748.001400&cid=C0KLZSCHF
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap") {
       name = "Kotlin-Bootstrap"
@@ -68,9 +67,7 @@ dependencyResolutionManagement {
         // For R8/D8 releases
         maven("https://storage.googleapis.com/r8-releases/raw")
       }
-      filter {
-        includeModule("com.android.tools", "r8")
-      }
+      filter { includeModule("com.android.tools", "r8") }
     }
 
     // ExclusiveContent is used here because this proxies jcenter under the hood!
@@ -84,6 +81,7 @@ dependencyResolutionManagement {
         includeModule("net.ltgt.gradle", "gradle-errorprone-plugin")
         includeModule("net.ltgt.gradle", "gradle-nullaway-plugin")
         includeModule("com.sergei-lapin.napt", "gradle")
+        includeModule("com.jraska.module.graph.assertion", "plugin")
       }
     }
   }
@@ -92,9 +90,7 @@ dependencyResolutionManagement {
 pluginManagement {
   // Non-delegate APIs are annoyingly not public so we have to use withGroovyBuilder
   fun hasProperty(key: String): Boolean {
-    return settings.withGroovyBuilder {
-      "hasProperty"(key) as Boolean
-    }
+    return settings.withGroovyBuilder { "hasProperty"(key) as Boolean }
   }
 
   repositories {
@@ -116,7 +112,8 @@ pluginManagement {
 
     google()
 
-    // Kotlin bootstrap repository, useful for testing against Kotlin dev builds. Usually only tested on CI shadow jobs
+    // Kotlin bootstrap repository, useful for testing against Kotlin dev builds. Usually only
+    // tested on CI shadow jobs
     // https://kotlinlang.slack.com/archives/C0KLZSCHF/p1616514468003200?thread_ts=1616509748.001400&cid=C0KLZSCHF
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap") {
       name = "Kotlin-Bootstrap"
@@ -132,7 +129,10 @@ pluginManagement {
       forRepository(::gradlePluginPortal)
       filter {
         includeModule("com.github.ben-manes", "gradle-versions-plugin")
-        includeModule("com.github.ben-manes.versions", "com.github.ben-manes.versions.gradle.plugin")
+        includeModule(
+          "com.github.ben-manes.versions",
+          "com.github.ben-manes.versions.gradle.plugin"
+        )
         includeModule("com.gradle", "gradle-enterprise-gradle-plugin")
         includeModule("com.gradle.enterprise", "com.gradle.enterprise.gradle.plugin")
         includeModule("com.diffplug.spotless", "com.diffplug.spotless.gradle.plugin")
@@ -140,7 +140,10 @@ pluginManagement {
         includeModule("org.gradle.kotlin.kotlin-dsl", "org.gradle.kotlin.kotlin-dsl.gradle.plugin")
         includeModule("org.gradle.kotlin", "gradle-kotlin-dsl-plugins")
         includeModule("com.autonomousapps", "plugin-best-practices-plugin")
-        includeModule("com.autonomousapps.plugin-best-practices-plugin", "com.autonomousapps.plugin-best-practices-plugin.gradle.plugin")
+        includeModule(
+          "com.autonomousapps.plugin-best-practices-plugin",
+          "com.autonomousapps.plugin-best-practices-plugin.gradle.plugin"
+        )
       }
     }
   }
@@ -166,9 +169,13 @@ rootProject.name = "slack-gradle-plugin"
 
 // Please keep these in alphabetical order!
 include(":slack-plugin")
+
 include(":sgp-monkeypatch-agp")
+
 include(":agp-handlers:agp-handler-api")
+
 include(":agp-handlers:agp-handler-74")
+
 include(":agp-handlers:agp-handler-80")
 
 // https://docs.gradle.org/5.6/userguide/groovy_plugin.html#sec:groovy_compilation_avoidance

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
   api(projects.agpHandlers.agpHandler80)
   testImplementation(libs.agp)
 
+  implementation(libs.gradlePlugins.graphAssert) { because("To use is Gradle graphing APIs.") }
   implementation(libs.commonsText) { because("For access to its StringEscapeUtils") }
   implementation(libs.guava)
   implementation(libs.kotlinCliUtil)

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -118,6 +118,7 @@ dependencies {
   // Better I/O
   api(libs.okio)
 
+  testImplementation(libs.okio.fakefilesystem)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
   api(projects.agpHandlers.agpHandler80)
   testImplementation(libs.agp)
 
-  implementation(libs.gradlePlugins.graphAssert) { because("To use is Gradle graphing APIs.") }
+  implementation(libs.gradlePlugins.graphAssert) { because("To use in Gradle graphing APIs.") }
   implementation(libs.commonsText) { because("For access to its StringEscapeUtils") }
   implementation(libs.guava)
   implementation(libs.kotlinCliUtil)

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -421,6 +421,10 @@ public class SlackProperties private constructor(private val project: Project) {
   public val sortDependenciesIgnore: String?
     get() = optionalStringProperty("slack.sortDependencies.ignore")
 
+  /** Enables verbose debug logging across the plugin. */
+  public val debug: Boolean
+    get() = booleanProperty("slack.debug", defaultValue = false)
+
   /**
    * Global control for enabling stricter validation of projects, such as ensuring Kotlin projects
    * have at least one `.kt` source file.

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -28,7 +28,7 @@ import slack.cli.AppleSiliconCompat
 import slack.executeBlocking
 import slack.executeBlockingWithResult
 import slack.gradle.agp.VersionNumber
-import slack.gradle.avoidance.ComputeAffectedProjects
+import slack.gradle.avoidance.ComputeAffectedProjectsTask
 import slack.gradle.lint.LintTasks
 import slack.gradle.tasks.AndroidTestApksTask
 import slack.gradle.tasks.CoreBootstrapTask
@@ -106,7 +106,7 @@ internal class SlackRootPlugin : Plugin<Project> {
     project.configureMisc(slackProperties)
     UnitTests.configureRootProject(project)
     ModuleStatsTasks.configureRoot(project, slackProperties)
-    ComputeAffectedProjects.register(project, slackProperties)
+    ComputeAffectedProjectsTask.register(project, slackProperties)
     val scanApi = ScanApi(project)
     project.configureBuildScanMetadata(scanApi)
     if (scanApi.isAvailable) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -28,6 +28,7 @@ import slack.cli.AppleSiliconCompat
 import slack.executeBlocking
 import slack.executeBlockingWithResult
 import slack.gradle.agp.VersionNumber
+import slack.gradle.avoidance.ComputeAffectedProjects
 import slack.gradle.lint.LintTasks
 import slack.gradle.tasks.AndroidTestApksTask
 import slack.gradle.tasks.CoreBootstrapTask
@@ -105,6 +106,7 @@ internal class SlackRootPlugin : Plugin<Project> {
     project.configureMisc(slackProperties)
     UnitTests.configureRootProject(project)
     ModuleStatsTasks.configureRoot(project, slackProperties)
+    ComputeAffectedProjects.register(project, slackProperties)
     val scanApi = ScanApi(project)
     project.configureBuildScanMetadata(scanApi)
     if (scanApi.isAvailable) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
@@ -288,7 +288,7 @@ private fun Path.findNearestProjectDir(
       isDirectory(fileSystem) -> this
       else -> error("Unsupported file type: $this")
     }
-  return findNearestProjectDirRecursive(repoRoot, currentDir, cache)
+  return findNearestProjectDirRecursive(repoRoot, this, currentDir, cache)
 }
 
 private fun Path.isRegularFile(fileSystem: FileSystem): Boolean =
@@ -301,11 +301,12 @@ private fun Path.exists(): Boolean = toNioPath().exists()
 
 private fun findNearestProjectDirRecursive(
   repoRoot: Path,
+  originalPath: Path,
   currentDir: Path?,
   cache: MutableMap<Path, Path?>
 ): Path? {
   if (currentDir == null || currentDir == repoRoot) {
-    error("Could not find build.gradle(.kts) for $currentDir")
+    error("Could not find build.gradle(.kts) for $originalPath")
   }
 
   return cache.getOrPut(currentDir) {
@@ -315,7 +316,7 @@ private fun findNearestProjectDirRecursive(
     if (hasBuildFile) {
       return currentDir
     }
-    findNearestProjectDirRecursive(repoRoot, currentDir.parent, cache)
+    findNearestProjectDirRecursive(repoRoot, originalPath, currentDir.parent, cache)
   }
 }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.avoidance
+
+import com.jraska.module.graph.DependencyGraph
+import java.io.File
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.time.measureTimedValue
+import slack.gradle.util.SgpLogger
+
+internal class AffectedProjectsComputer(
+  private val rootDirPath: Path,
+  private val dependencyGraph: () -> DependencyGraph,
+  private val changedFilePaths: List<Path>,
+  private val diagnostics: DiagnosticWriter = DiagnosticWriter.NoOp,
+  private val includePatterns: List<String> = DEFAULT_INCLUDE_PATTERNS,
+  private val neverSkipPatterns: List<String> = DEFAULT_NEVER_SKIP_PATTERNS,
+  private val debug: Boolean = false,
+  private val fileSystem: FileSystem = FileSystems.getDefault(),
+  private val logger: SgpLogger = SgpLogger.noop()
+) {
+  fun compute(): AffectedProjectsResult? {
+    return logTimedValue("full computation") { computeImpl() }
+  }
+
+  private fun computeImpl(): AffectedProjectsResult? {
+    log("changedFilePaths: $changedFilePaths")
+
+    log("includePatterns: $includePatterns")
+    val filteredChangedFilePaths =
+      logTimedValue("filtering changed files") {
+        changedFilePaths.filter {
+          includePatterns.any { pattern -> fileSystem.getPathMatcher("glob:$pattern").matches(it) }
+        }
+      }
+    log("filteredChangedFilePaths: $filteredChangedFilePaths")
+
+    val neverSkipPathMatchers =
+      logTimedValue("creating path matchers") {
+        neverSkipPatterns.map { fileSystem.getPathMatcher("glob:$it") }
+      }
+    log("neverSkipPatterns: $neverSkipPatterns")
+
+    if (debug) {
+      // Do a slower, more verbose check in debug
+      val pathsWithSkippability =
+        logTimedValue("checking for non-skippable files") {
+          filteredChangedFilePaths.associateWith { path ->
+            neverSkipPathMatchers.find { it.matches(path) }
+          }
+        }
+      if (pathsWithSkippability.values.any { it != null }) {
+        // Produce no outputs, run everything
+        logger.lifecycle(
+          "Never-skip pattern(s) matched: ${pathsWithSkippability.filterValues { it != null }}."
+        )
+        return null
+      }
+    } else {
+      // Do a fast check for never-skip paths when not debugging
+      if (filteredChangedFilePaths.any { path -> neverSkipPathMatchers.any { it.matches(path) } }) {
+        // Produce no outputs, run everything
+        logger.lifecycle("Never-skip pattern(s) matched.")
+        return null
+      }
+    }
+
+    val nearestProjectCache = mutableMapOf<Path, Path?>()
+
+    // Mapping of Gradle project paths (like ":app") to the ChangedProject representation.
+    val changedProjects =
+      logTimedValue("computing changed projects") {
+        filteredChangedFilePaths
+          .groupBy { it.findNearestProjectDir(rootDirPath, nearestProjectCache) }
+          .filterNotNullKeys()
+          .entries
+          .associate { (projectPath, files) ->
+            val gradlePath = ":${projectPath.toString().replace(File.separatorChar, ':')}"
+            gradlePath to ChangedProject(projectPath, gradlePath, files.toSet())
+          }
+      }
+    diagnostics.write("changedProjects.txt") {
+      changedProjects.entries
+        .sortedBy { it.key }
+        .joinToString("\n") { (_, v) ->
+          val testOnlyString = if (v.onlyTestsAreChanged) " (tests only)" else ""
+          val lintBaselineOnly = if (v.onlyLintBaselineChanged) " (lint-baseline.xml only)" else ""
+          "${v.gradlePath}$testOnlyString$lintBaselineOnly\n${v.changedPaths.sorted().joinToString("\n") { "-- $it" } }"
+        }
+    }
+
+    val projectsToDependencies: Map<String, Set<String>> =
+      logTimedValue("computing dependencies") {
+        dependencyGraph().nodes().associate { node ->
+          val dependencies = mutableSetOf<DependencyGraph.Node>()
+          node.visitDependencies(dependencies)
+          node.key to dependencies.mapTo(mutableSetOf()) { it.key }
+        }
+      }
+
+    diagnostics.write("projectsToDependencies.txt") {
+      buildString {
+        for ((project, dependencies) in projectsToDependencies.toSortedMap()) {
+          appendLine(project)
+          for (dep in dependencies.sorted()) {
+            appendLine("-> $dep")
+          }
+        }
+      }
+    }
+
+    val projectsToDependents = logTimedValue("computing dependents", projectsToDependencies::flip)
+
+    diagnostics.write("projectsToDependents.txt") {
+      buildString {
+        for ((project, dependencies) in projectsToDependents.toSortedMap()) {
+          appendLine(project)
+          for (dep in dependencies.sorted()) {
+            appendLine("-> $dep")
+          }
+        }
+      }
+    }
+
+    val allAffectedProjects =
+      buildSet {
+          for ((path, change) in changedProjects) {
+            add(path)
+            if (change.affectsDependents) {
+              addAll(projectsToDependents[path] ?: emptySet())
+            }
+          }
+        }
+        .toSortedSet()
+
+    logger.lifecycle("Found ${allAffectedProjects.size} affected projects.")
+
+    val allRequiredProjects =
+      allAffectedProjects
+        .flatMapTo(mutableSetOf()) { project ->
+          val dependencies = projectsToDependencies[project].orEmpty()
+          dependencies + project
+        }
+        .toSortedSet()
+    return AffectedProjectsResult(allAffectedProjects, allRequiredProjects)
+  }
+
+  private fun log(message: String) {
+    // counter-intuitive to read but lifecycle is preferable when actively debugging, whereas
+    // debug() only logs quietly unless --debug is used
+    if (debug) {
+      logger.lifecycle(message)
+    } else {
+      logger.debug(message)
+    }
+  }
+
+  private inline fun <T> logTimedValue(name: String, body: () -> T): T {
+    val (value, duration) = measureTimedValue(body)
+    log("$name took $duration")
+    return value
+  }
+
+  companion object {
+    internal val DEFAULT_INCLUDE_PATTERNS =
+      listOf(
+        "**/*.kt",
+        "*.gradle.kts",
+        "**/*.gradle.kts",
+        "**/*.java",
+        "**/AndroidManifest.xml",
+        "**/res/**",
+        "**/gradle.properties",
+      )
+
+    internal val DEFAULT_NEVER_SKIP_PATTERNS =
+      listOf(
+        // root build.gradle.kts and settings.gradle.kts files
+        "*.gradle.kts",
+        // root gradle.properties file
+        "gradle.properties",
+        "**/*.versions.toml",
+      )
+  }
+}
+
+/**
+ * Given a file path like
+ * `/Users/username/projects/MyApp/app/src/main/kotlin/com/example/myapp/MainActivity.kt`, returns
+ * the nearest Gradle project [Path] like `/Users/username/projects/MyApp/app`.
+ */
+private fun Path.findNearestProjectDir(repoRoot: Path, cache: MutableMap<Path, Path?>): Path? {
+  val currentDir =
+    when {
+      !exists() -> {
+        /*
+         * Deleted file. Still check the parent dirs though because if the project itself still
+         * exists, it still affects downstream
+         *
+         * There _is_ an edge case here though: what if the intermediary project was deleted but
+         * nested below another, real project? How do we know when to stop?
+         * Well, we're protected from this scenario by the fact that such a change would incur a change to
+         * `settings.gradle.kts`, and subsequently all projects would be deemed affected.
+         */
+        parent
+      }
+      isRegularFile() -> parent
+      isDirectory() -> this
+      else -> error("Unsupported file type: $this")
+    }
+  return findNearestProjectDirRecursive(repoRoot, currentDir, cache)
+}
+
+private fun findNearestProjectDirRecursive(
+  repoRoot: Path,
+  currentDir: Path?,
+  cache: MutableMap<Path, Path?>
+): Path? {
+  if (currentDir == null || currentDir == repoRoot) {
+    error("Could not find build.gradle(.kts) for $currentDir")
+  }
+
+  return cache.getOrPut(currentDir) {
+    // Note the dir may not exist, but that's ok because we still want to check its parents
+    val hasBuildFile =
+      currentDir.resolve("build.gradle.kts").exists() || currentDir.resolve("build.gradle").exists()
+    if (hasBuildFile) {
+      return currentDir
+    }
+    findNearestProjectDirRecursive(repoRoot, currentDir.parent, cache)
+  }
+}
+
+private fun DependencyGraph.Node.visitDependencies(setToAddTo: MutableSet<DependencyGraph.Node>) {
+  for (dependency in dependsOn) {
+    if (!setToAddTo.add(dependency)) {
+      // Only add transitives if we haven't already seen this dependency.
+      dependency.visitDependencies(setToAddTo)
+    }
+  }
+}
+
+/**
+ * Flips a map. In the context of [ComputeAffectedProjectsTask], we use this to flip a map of
+ * projects to their dependencies to a map of projects to the projects that depend on them. We use
+ * this to find all affected projects given a seed of changed projects.
+ *
+ * Example:
+ *
+ *  ```
+ *  Given a map
+ *  {a:[b, c], b:[d], c:[d], d:[]}
+ *  return
+ *  {b:[a], c:[a], d:[b, c]}
+ *  ```
+ */
+private fun Map<String, Set<String>>.flip(): Map<String, Set<String>> {
+  val flipped = mutableMapOf<String, MutableSet<String>>()
+  for ((project, dependenciesSet) in this) {
+    for (dependency in dependenciesSet) {
+      flipped.getOrPut(dependency, ::mutableSetOf).add(project)
+    }
+  }
+  return flipped
+}
+
+/** Return a new map with null keys filtered out. */
+private fun <K, V : Any> Map<K?, V>.filterNotNullKeys(): Map<K, V> {
+  return filterKeys { it != null }.mapKeys { it.key!! }
+}
+
+/**
+ * Represents a changed project as computed by [ComputeAffectedProjectsTask.changedFiles].
+ *
+ * @property path The [Path] to the project directory.
+ * @property gradlePath The Gradle project path (e.g. `:app`).
+ * @property changedPaths The set of [Paths][Path] to files that have changed.
+ */
+private data class ChangedProject(
+  val path: Path,
+  val gradlePath: String,
+  val changedPaths: Set<Path>,
+) {
+  /**
+   * Returns true if all changed files are in a test directory and therefore do not carry-over to
+   * downstream dependents.
+   */
+  val testPaths: Set<Path> = changedPaths.filterTo(mutableSetOf(), testPathMatcher::matches)
+  val onlyTestsAreChanged = testPaths.size == changedPaths.size
+
+  /**
+   * Returns true if all changed files are just `lint-baseline.xml`. This is useful because it means
+   * they don't affect downstream dependants.
+   */
+  val lintBaseline: Set<Path> =
+    changedPaths.filterTo(mutableSetOf(), lintBaselinePathMatcher::matches)
+  val onlyLintBaselineChanged = lintBaseline.size == changedPaths.size
+
+  /**
+   * Remaining affected files that aren't test paths or lint baseline, and therefore affect
+   * dependants.
+   */
+  val dependantAffectingFiles = changedPaths - testPaths - lintBaseline
+
+  /** Shorthand for if [dependantAffectingFiles] is not empty. */
+  val affectsDependents = dependantAffectingFiles.isNotEmpty()
+
+  companion object {
+    // This covers snapshot tests too as they are under src/test/snapshots/**
+    private val testPathMatcher =
+      FileSystems.getDefault().getPathMatcher("glob:**/src/*{test,androidTest}/**")
+    private val lintBaselinePathMatcher =
+      FileSystems.getDefault().getPathMatcher("glob:**/lint-baseline.xml")
+  }
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
@@ -16,7 +16,6 @@
 package slack.gradle.avoidance
 
 import com.jraska.module.graph.DependencyGraph
-import java.io.File
 import kotlin.io.path.exists
 import kotlin.time.measureTimedValue
 import okio.FileSystem
@@ -151,7 +150,7 @@ internal class AffectedProjectsComputer(
           .filterNotNullKeys()
           .entries
           .associate { (projectPath, files) ->
-            val gradlePath = ":${projectPath.toString().replace(File.separatorChar, ':')}"
+            val gradlePath = ":${projectPath.toString().replace(Path.DIRECTORY_SEPARATOR, ":")}"
             gradlePath to ChangedProject(projectPath, gradlePath, files.toSet())
           }
       }

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsResult.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsResult.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.avoidance
+
+import java.util.SortedSet
+
+internal data class AffectedProjectsResult(
+  val affectedProjects: SortedSet<String>,
+  val focusProjects: SortedSet<String>,
+)

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
@@ -339,7 +339,8 @@ internal abstract class ComputeAffectedProjects : DefaultTask() {
         "*.gradle.kts",
         "**/*.gradle.kts",
         "**/*.java",
-        "**/*.xml",
+        "**/AndroidManifest.xml",
+        "**/res/**",
         "**/gradle.properties",
       )
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
@@ -1,0 +1,354 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.avoidance
+
+import com.jraska.module.graph.DependencyGraph
+import com.jraska.module.graph.assertion.GradleDependencyGraphFactory
+import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.nameWithoutExtension
+import kotlin.time.measureTimedValue
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.UntrackedTask
+import org.gradle.api.tasks.options.Option
+import slack.gradle.SlackProperties
+
+/**
+ * TODO more granular stuff
+ * - not all xml files are equal. baseline.xml is not the same as a resource file
+ */
+@UntrackedTask(because = "This task modifies build scripts in place.")
+internal abstract class ComputeAffectedProjects : DefaultTask() {
+
+  @get:Internal abstract val rootDir: DirectoryProperty
+
+  @get:Input abstract val debug: Property<Boolean>
+
+  @get:Input
+  val includePatterns: ListProperty<String> =
+    project.objects.listProperty(String::class.java).convention(DEFAULT_INCLUDE_PATTERNS)
+
+  @get:Input
+  val neverSkipPatterns: ListProperty<String> =
+    project.objects.listProperty(String::class.java).convention(DEFAULT_NEVER_SKIP_PATTERNS)
+
+  @get:Input abstract val dependencyGraph: Property<DependencyGraph.SerializableGraph>
+
+  @get:Option(option = "changed-files", description = "A relative file path to changed_files.txt.")
+  @get:Input
+  abstract val changedFiles: Property<String>
+
+  @get:OutputDirectory abstract val diagnosticsDir: DirectoryProperty
+  @get:OutputFile abstract val outputFile: RegularFileProperty
+
+  init {
+    group = "slack"
+    description = "Computes affected projects and writes them to a file."
+  }
+
+  private fun log(message: String) {
+    val withPrefix = "$LOG $message"
+    // counter-intuitive to read but lifecycle is preferable when actively debugging, whereas
+    // debug() only logs quietly unless --debug is used
+    if (debug.get()) {
+      logger.lifecycle(withPrefix)
+    } else {
+      logger.debug(withPrefix)
+    }
+  }
+
+  @TaskAction
+  fun computeTimed() {
+    logTimedValue("computation") { compute() }
+  }
+
+  @TaskAction
+  fun compute() {
+    val fs = FileSystems.getDefault()
+
+    log("reading changed files from: ${changedFiles.get()}")
+    val changedFilesPaths =
+      logTimedValue("reading changed files") {
+        rootDir.file(changedFiles).get().asFile.readLines().map { Paths.get(it.trim()) }
+      }
+    log("changedFilesPaths: $changedFilesPaths")
+
+    log("includePatterns: ${includePatterns.get()}")
+    val filteredChangedFilePaths =
+      logTimedValue("filtering changed files") {
+        changedFilesPaths.filter {
+          includePatterns.get().any { pattern -> fs.getPathMatcher("glob:$pattern").matches(it) }
+        }
+      }
+    log("filteredChangedFilePaths: $filteredChangedFilePaths")
+
+    val rootDirPath = rootDir.get().asFile.toPath()
+
+    val pathMatchers =
+      logTimedValue("creating path matchers") {
+        neverSkipPatterns.get().map { fs.getPathMatcher("glob:$it") }
+      }
+    log("neverSkipPatterns: ${neverSkipPatterns.get()}")
+
+    // TODO this is slow as it checks all of them, but in the future we could hide this behind a
+    //  debug flag
+    val pathsWithSkippability =
+      logTimedValue("checking for non-skippable files") {
+        filteredChangedFilePaths.associateWith { path -> pathMatchers.find { it.matches(path) } }
+      }
+    if (pathsWithSkippability.values.any { it != null }) {
+      // TODO write all projects to file? Or denote a blank file as meaning all? Or don't write a
+      //  file?
+      logger.lifecycle(
+        "$LOG Never-skip pattern(s) matched: ${pathsWithSkippability.filterValues { it != null }}."
+      )
+      return
+    }
+
+    // Mapping of Gradle project paths (like ":app") to the ChangedProject representation.
+    val changedProjects =
+      logTimedValue("computing changed projects") {
+        filteredChangedFilePaths
+          .groupBy { it.findNearestProjectDir(rootDirPath) }
+          .entries
+          .associate { (projectPath, files) ->
+            val gradlePath = projectPath.resolveProjectPath(rootDirPath)
+            gradlePath to ChangedProject(projectPath, gradlePath, files.toSet())
+          }
+      }
+
+    val graph = logTimedValue("creating graph") { DependencyGraph.create(dependencyGraph.get()) }
+
+    val projectsToDependencies: Map<String, Set<String>> =
+      logTimedValue("computing dependencies") {
+        graph.nodes().associate { node ->
+          node.key to node.allDependencies().mapTo(mutableSetOf()) { it.key }
+        }
+      }
+
+    writeDiagnostic("projectsToDependencies.txt") {
+      buildString {
+        for ((project, dependencies) in projectsToDependencies.toSortedMap()) {
+          appendLine(project)
+          for (dep in dependencies.sorted()) {
+            appendLine("-> $dep")
+          }
+        }
+      }
+    }
+
+    val projectsToDependents = logTimedValue("computing dependents", projectsToDependencies::flip)
+
+    writeDiagnostic("projectsToDependents.txt") {
+      buildString {
+        for ((project, dependencies) in projectsToDependents.toSortedMap()) {
+          appendLine(project)
+          for (dep in dependencies.sorted()) {
+            appendLine("-> $dep")
+          }
+        }
+      }
+    }
+
+    val allAffectedProjects = buildSet {
+      for ((path, change) in changedProjects) {
+        add(path)
+
+        if (!change.onlyTestsAreChanged) {
+          addAll(projectsToDependents[path] ?: emptySet())
+        }
+        //        addAll(graph.subTree(changedProject).findRoot().allDependencies().map { it.key })
+      }
+    }
+
+    outputFile.get().asFile.writeText(allAffectedProjects.sorted().joinToString("\n"))
+  }
+
+  private fun writeDiagnostic(fileName: String, content: () -> String) {
+    if (debug.get()) {
+      val file = diagnosticsDir.file(fileName).get().asFile
+      file.parentFile.mkdirs()
+      file.writeText(content())
+    }
+  }
+
+  companion object {
+    private const val LOG = "[Skippy]"
+
+    // TODO what about paparazzi snapshots, lint baselines
+    private val DEFAULT_INCLUDE_PATTERNS =
+      listOf(
+        "**/*.kt",
+        "*.gradle.kts",
+        "**/*.gradle.kts",
+        "**/*.java",
+        "**/*.xml",
+        "**/gradle.properties",
+      )
+
+    private val DEFAULT_NEVER_SKIP_PATTERNS =
+      listOf(
+        "*.gradle.kts",
+        "gradle.properties",
+        "**/*.versions.toml",
+        "ci/**",
+        ".buildkite/**",
+      )
+
+    fun register(
+      rootProject: Project,
+      slackProperties: SlackProperties
+    ): TaskProvider<ComputeAffectedProjects> {
+      // TODO any others?
+      val configurationsToLook: Set<String> =
+        setOf(
+          "api",
+          "implementation",
+          "ksp",
+          "testImplementation",
+          "androidTestImplementation",
+          "compileOnly"
+        )
+
+      val moduleGraph by lazy {
+        GradleDependencyGraphFactory.create(rootProject, configurationsToLook).serializableGraph()
+      }
+
+      return rootProject.tasks.register(
+        "computeAffectedProjects",
+        ComputeAffectedProjects::class.java
+      ) {
+        debug.set(slackProperties.debug)
+        rootDir.set(project.layout.projectDirectory)
+        dependencyGraph.set(rootProject.provider { moduleGraph })
+        diagnosticsDir.set(project.layout.buildDirectory.dir("skippy/diagnostics"))
+        outputFile.set(project.layout.buildDirectory.file("skippy/affected_projects.txt"))
+        // TODO neverSkipPatterns
+        // TODO includePatterns
+      }
+    }
+  }
+
+  private inline fun <T> logTimedValue(name: String, body: () -> T): T {
+    val (value, duration) = measureTimedValue(body)
+    log("$name took $duration")
+    return value
+  }
+}
+
+/**
+ * Given a file path like
+ * `/Users/username/projects/MyApp/app/src/main/kotlin/com/example/myapp/MainActivity.kt`, returns a
+ * Gradle project path (e.g. `:app`).
+ */
+private fun Path.resolveProjectPath(rootDir: Path): String {
+  val projectDir = findNearestProjectDir(rootDir)
+  return rootDir.relativize(projectDir).nameWithoutExtension.replace(File.separatorChar, ':')
+}
+
+/**
+ * Given a file path like
+ * `/Users/username/projects/MyApp/app/src/main/kotlin/com/example/myapp/MainActivity.kt`, returns
+ * the nearest Gradle project [Path] like `/Users/username/projects/MyApp/app`.
+ */
+// TODO move up and do a superficial cache
+private fun Path.findNearestProjectDir(repoRoot: Path): Path {
+  var currentDir = this.parent
+  check(currentDir.isDirectory())
+  while (currentDir != null && currentDir != repoRoot && currentDir != currentDir.root) {
+    val hasBuildFile =
+      currentDir.resolve("build.gradle.kts").exists() || currentDir.resolve("build.gradle").exists()
+    if (hasBuildFile) {
+      return currentDir
+    } else {
+      currentDir = currentDir.parent
+    }
+  }
+  error("Could not find build.gradle(.kts) for $this")
+}
+
+private fun DependencyGraph.Node.allDependencies(): Set<DependencyGraph.Node> {
+  return buildSet {
+    addAll(dependsOn)
+    for (dependency in dependsOn) {
+      addAll(dependency.allDependencies())
+    }
+  }
+}
+
+/**
+ * Flips a map. In the context of [ComputeAffectedProjects], we use this to flip a map of projects
+ * to their dependencies to a map of projects to the projects that depend on them. We use this to
+ * find all affected projects given a seed of changed projects.
+ *
+ * Example:
+ *
+ *  ```
+ *  Given a map
+ *  {a:[b, c], b:[d], c:[d], d:[]}
+ *  return
+ *  {b:[a], c:[a], d:[b, c]}
+ *  ```
+ */
+private fun Map<String, Set<String>>.flip(): Map<String, Set<String>> {
+  val flipped = mutableMapOf<String, MutableSet<String>>()
+  for ((project, dependenciesSet) in this) {
+    for (dependency in dependenciesSet) {
+      flipped.getOrPut(dependency, ::mutableSetOf).add(project)
+    }
+  }
+  return flipped
+}
+
+/**
+ * Represents a changed project as computed by [ComputeAffectedProjects.changedFiles].
+ *
+ * @property path The [Path] to the project directory.
+ * @property gradlePath The Gradle project path (e.g. `:app`).
+ * @property changedPaths The set of [Paths][Path] to files that have changed.
+ */
+private data class ChangedProject(
+  val path: Path,
+  val gradlePath: String,
+  val changedPaths: Set<Path>
+) {
+  /**
+   * Returns true if all changed files are in a test directory and therefore do not carry-over to
+   * downstream dependents.
+   */
+  val onlyTestsAreChanged: Boolean
+    get() = changedPaths.any(testPathMatcher::matches)
+
+  companion object {
+    private val testPathMatcher =
+      FileSystems.getDefault().getPathMatcher("glob:**/src/**/*{test,androidTest}/**")
+  }
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
@@ -289,10 +289,10 @@ private fun Path.findNearestProjectDir(repoRoot: Path, cache: MutableMap<Path, P
       // TODO deleted file. Temporarily make it and try again?
       else -> error("Unsupported file type: $this")
     }
-  return findNearestProjectDir(repoRoot, currentDir, cache)
+  return findNearestProjectDirRecursive(repoRoot, currentDir, cache)
 }
 
-private fun findNearestProjectDir(
+private fun findNearestProjectDirRecursive(
   repoRoot: Path,
   currentDir: Path?,
   cache: MutableMap<Path, Path>
@@ -307,7 +307,7 @@ private fun findNearestProjectDir(
     if (hasBuildFile) {
       return currentDir
     }
-    findNearestProjectDir(repoRoot, currentDir.parent, cache)
+    findNearestProjectDirRecursive(repoRoot, currentDir.parent, cache)
   }
 }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
@@ -350,8 +350,6 @@ internal abstract class ComputeAffectedProjects : DefaultTask() {
         // root gradle.properties file
         "gradle.properties",
         "**/*.versions.toml",
-        "ci/**",
-        ".buildkite/**",
       )
 
     fun register(

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
@@ -41,32 +41,50 @@ import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 import slack.gradle.SlackProperties
 
-/**
- * TODO more granular stuff
- * - not all xml files are equal. baseline.xml is not the same as a resource file
- */
+/** TODO more granular stuff */
 @UntrackedTask(because = "This task modifies build scripts in place.")
 internal abstract class ComputeAffectedProjects : DefaultTask() {
 
+  /** Root repo directory. Used to compute relative paths and not considered an input. */
   @get:Internal abstract val rootDir: DirectoryProperty
 
+  /** Debugging flag. If enabled, extra diagnostics and logging is performed. */
   @get:Input abstract val debug: Property<Boolean>
 
+  /**
+   * A list of glob patterns for files to include in computing affected projects. This should
+   * usually be source files, build files, gradle.properties files, and other projects that affect
+   * builds.
+   */
   @get:Input
   val includePatterns: ListProperty<String> =
     project.objects.listProperty(String::class.java).convention(DEFAULT_INCLUDE_PATTERNS)
 
+  /**
+   * A list of glob patterns that, if matched with a file, indicate that nothing should be skipped
+   * and no [outputFile] or [outputFocusFile] will be generated.
+   *
+   * This is useful for globally-affecting things like root build files, `libs.versions.toml`, etc.
+   */
   @get:Input
   val neverSkipPatterns: ListProperty<String> =
     project.objects.listProperty(String::class.java).convention(DEFAULT_NEVER_SKIP_PATTERNS)
 
+  /** The serialized dependency graph as computed from our known configurations. */
   @get:Input abstract val dependencyGraph: Property<DependencyGraph.SerializableGraph>
 
+  /**
+   * A relative (to the repo root) path to a changed_files.txt that contains a newline-delimited
+   * list of changed files. This is usually computed from a GitHub PR's changed files.
+   */
   @get:Option(option = "changed-files", description = "A relative file path to changed_files.txt.")
   @get:Input
   abstract val changedFiles: Property<String>
 
+  /** Output diagnostics directory for use in debugging. */
   @get:OutputDirectory abstract val diagnosticsDir: DirectoryProperty
+
+  /** The output list of affected projects. */
   @get:OutputFile abstract val outputFile: RegularFileProperty
 
   /** An output .focus file that could be used with the Focus plugin. */

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjects.kt
@@ -270,8 +270,7 @@ internal abstract class ComputeAffectedProjects : DefaultTask() {
  * Gradle project path (e.g. `:app`).
  */
 private fun Path.resolveProjectPath(rootDir: Path): String {
-  val projectDir = findNearestProjectDir(rootDir)
-  return rootDir.relativize(projectDir).nameWithoutExtension.replace(File.separatorChar, ':')
+  return rootDir.relativize(this).nameWithoutExtension.replace(File.separatorChar, ':')
 }
 
 /**
@@ -283,9 +282,8 @@ private fun Path.resolveProjectPath(rootDir: Path): String {
 private fun Path.findNearestProjectDir(repoRoot: Path): Path {
   var currentDir = this.parent
   check(currentDir.isDirectory())
-  while (currentDir != null && currentDir != repoRoot && currentDir != currentDir.root) {
-    val hasBuildFile =
-      currentDir.resolve("build.gradle.kts").exists() || currentDir.resolve("build.gradle").exists()
+  while (currentDir != null && currentDir != repoRoot) {
+    val hasBuildFile = resolve("build.gradle.kts").exists() || resolve("build.gradle").exists()
     if (hasBuildFile) {
       return currentDir
     } else {

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
@@ -17,8 +17,9 @@ package slack.gradle.avoidance
 
 import com.jraska.module.graph.DependencyGraph
 import com.jraska.module.graph.assertion.GradleDependencyGraphFactory
-import java.nio.file.Paths
 import kotlin.time.measureTimedValue
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
@@ -173,7 +174,7 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
       }
       val (affectedProjects, focusProjects) =
         AffectedProjectsComputer(
-            rootDirPath = rootDir.asFile.get().toPath(),
+            rootDirPath = rootDir.asFile.get().toOkioPath(normalize = true),
             dependencyGraph = {
               logTimedValue("creating dependency graph") {
                 DependencyGraph.create(dependencyGraph.get())
@@ -187,7 +188,9 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
               logTimedValue("reading changed files") {
                 val file = changedFiles.get()
                 log("reading changed files from: $file")
-                rootDir.file(file).get().asFile.readLines().map { Paths.get(it.trim()) }
+                rootDir.file(file).get().asFile.readLines().map {
+                  it.trim().toPath(normalize = true)
+                }
               },
             logger = prefixLogger,
           )

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
@@ -89,7 +89,7 @@ import slack.gradle.SlackProperties
  * ```
  */
 @UntrackedTask(because = "This task is a meta task that more or less runs as a utility script.")
-internal abstract class ComputeAffectedProjects : DefaultTask() {
+internal abstract class ComputeAffectedProjectsTask : DefaultTask() {
 
   /** Debugging flag. If enabled, extra diagnostics and logging is performed. */
   @get:Input abstract val debug: Property<Boolean>
@@ -356,7 +356,7 @@ internal abstract class ComputeAffectedProjects : DefaultTask() {
     fun register(
       rootProject: Project,
       slackProperties: SlackProperties
-    ): TaskProvider<ComputeAffectedProjects> {
+    ): TaskProvider<ComputeAffectedProjectsTask> {
       // TODO any others?
       val configurationsToLook: Set<String> =
         setOf(
@@ -375,7 +375,7 @@ internal abstract class ComputeAffectedProjects : DefaultTask() {
 
       return rootProject.tasks.register(
         "computeAffectedProjects",
-        ComputeAffectedProjects::class.java
+        ComputeAffectedProjectsTask::class.java
       ) {
         debug.set(slackProperties.debug)
         rootDir.set(project.layout.projectDirectory)
@@ -453,9 +453,9 @@ private fun DependencyGraph.Node.visitDependencies(setToAddTo: MutableSet<Depend
 }
 
 /**
- * Flips a map. In the context of [ComputeAffectedProjects], we use this to flip a map of projects
- * to their dependencies to a map of projects to the projects that depend on them. We use this to
- * find all affected projects given a seed of changed projects.
+ * Flips a map. In the context of [ComputeAffectedProjectsTask], we use this to flip a map of
+ * projects to their dependencies to a map of projects to the projects that depend on them. We use
+ * this to find all affected projects given a seed of changed projects.
  *
  * Example:
  *
@@ -482,7 +482,7 @@ private fun <K, V : Any> Map<K?, V>.filterNotNullKeys(): Map<K, V> {
 }
 
 /**
- * Represents a changed project as computed by [ComputeAffectedProjects.changedFiles].
+ * Represents a changed project as computed by [ComputeAffectedProjectsTask.changedFiles].
  *
  * @property path The [Path] to the project directory.
  * @property gradlePath The Gradle project path (e.g. `:app`).

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/DiagnosticWriter.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/DiagnosticWriter.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.avoidance
+
+internal fun interface DiagnosticWriter {
+  fun write(name: String, content: () -> String)
+
+  object NoOp : DiagnosticWriter {
+    override fun write(name: String, content: () -> String) {}
+  }
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/GlobUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/GlobUtil.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.avoidance
+
+import java.util.regex.PatternSyntaxException
+import okio.Path
+
+internal fun interface PathMatcher {
+  fun matches(path: Path): Boolean
+}
+
+// TODO if we ever support windows, there's a separate windows method.
+internal fun String.toPathMatcher(): PathMatcher {
+  val regex = Globs.toUnixRegexPattern(this).toRegex()
+  return PathMatcher { path -> regex.matches(path.toString()) }
+}
+
+// Copied from the JDK Globs.java and is used by the JDK's PathMatcher, but it's not exposed as
+// public API for reuse.
+private object Globs {
+  private const val REGEX_META_CHARS = ".^$+{[]|()"
+  private const val GLOB_META_CHARS = "\\*?[{"
+
+  private val Char.isRegexMeta: Boolean
+    get() {
+      return REGEX_META_CHARS.indexOf(this) != -1
+    }
+
+  private val Char.isGlobMeta: Boolean
+    get() {
+      return GLOB_META_CHARS.indexOf(this) != -1
+    }
+
+  private const val EOL = 0.toChar() // TBD
+
+  private fun next(glob: String, i: Int): Char {
+    return if (i < glob.length) {
+      glob[i]
+    } else EOL
+  }
+
+  /**
+   * Creates a regex pattern from the given glob expression.
+   *
+   * @throws PatternSyntaxException
+   */
+  private fun toRegexPattern(globPattern: String, isDos: Boolean): String {
+    var inGroup = false
+    val regex = StringBuilder("^")
+    var i = 0
+    while (i < globPattern.length) {
+      var c = globPattern[i++]
+      when (c) {
+        '\\' -> {
+          // escape special characters
+          if (i == globPattern.length) {
+            throw PatternSyntaxException("No character to escape", globPattern, i - 1)
+          }
+          val next = globPattern[i++]
+          if (next.isGlobMeta || next.isRegexMeta) {
+            regex.append('\\')
+          }
+          regex.append(next)
+        }
+        '/' ->
+          if (isDos) {
+            regex.append("\\\\")
+          } else {
+            regex.append(c)
+          }
+        '[' -> {
+          // don't match name separator in class
+          if (isDos) {
+            regex.append("[[^\\\\]&&[")
+          } else {
+            regex.append("[[^/]&&[")
+          }
+          if (next(globPattern, i) == '^') {
+            // escape the regex negation char if it appears
+            regex.append("\\^")
+            i++
+          } else {
+            // negation
+            if (next(globPattern, i) == '!') {
+              regex.append('^')
+              i++
+            }
+            // hyphen allowed at start
+            if (next(globPattern, i) == '-') {
+              regex.append('-')
+              i++
+            }
+          }
+          var hasRangeStart = false
+          var last = 0.toChar()
+          while (i < globPattern.length) {
+            c = globPattern[i++]
+            if (c == ']') {
+              break
+            }
+            if (c == '/' || isDos && c == '\\') {
+              throw PatternSyntaxException("Explicit 'name separator' in class", globPattern, i - 1)
+            }
+            // TBD: how to specify ']' in a class?
+            if (c == '\\' || c == '[' || c == '&' && next(globPattern, i) == '&') {
+              // escape '\', '[' or "&&" for regex class
+              regex.append('\\')
+            }
+            regex.append(c)
+            if (c == '-') {
+              if (!hasRangeStart) {
+                throw PatternSyntaxException("Invalid range", globPattern, i - 1)
+              }
+              if (next(globPattern, i++).also { c = it } == EOL || c == ']') {
+                break
+              }
+              if (c < last) {
+                throw PatternSyntaxException("Invalid range", globPattern, i - 3)
+              }
+              regex.append(c)
+              hasRangeStart = false
+            } else {
+              hasRangeStart = true
+              last = c
+            }
+          }
+          if (c != ']') {
+            throw PatternSyntaxException("Missing ']", globPattern, i - 1)
+          }
+          regex.append("]]")
+        }
+        '{' -> {
+          if (inGroup) {
+            throw PatternSyntaxException("Cannot nest groups", globPattern, i - 1)
+          }
+          regex.append("(?:(?:")
+          inGroup = true
+        }
+        '}' ->
+          if (inGroup) {
+            regex.append("))")
+            inGroup = false
+          } else {
+            regex.append('}')
+          }
+        ',' ->
+          if (inGroup) {
+            regex.append(")|(?:")
+          } else {
+            regex.append(',')
+          }
+        '*' ->
+          if (next(globPattern, i) == '*') {
+            // crosses directory boundaries
+            regex.append(".*")
+            i++
+          } else {
+            // within directory boundary
+            if (isDos) {
+              regex.append("[^\\\\]*")
+            } else {
+              regex.append("[^/]*")
+            }
+          }
+        '?' ->
+          if (isDos) {
+            regex.append("[^\\\\]")
+          } else {
+            regex.append("[^/]")
+          }
+        else -> {
+          if (c.isRegexMeta) {
+            regex.append('\\')
+          }
+          regex.append(c)
+        }
+      }
+    }
+    if (inGroup) {
+      throw PatternSyntaxException("Missing '}", globPattern, i - 1)
+    }
+    return regex.append('$').toString()
+  }
+
+  fun toUnixRegexPattern(globPattern: String): String {
+    return toRegexPattern(globPattern, false)
+  }
+
+  fun toWindowsRegexPattern(globPattern: String): String {
+    return toRegexPattern(globPattern, true)
+  }
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/SgpLogger.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/SgpLogger.kt
@@ -1,0 +1,132 @@
+package slack.gradle.util
+
+import org.gradle.api.logging.Logger
+
+/** A simple logging abstraction for use in SGP. */
+internal interface SgpLogger {
+  fun debug(message: String)
+  fun info(message: String)
+  fun lifecycle(message: String)
+  fun warn(message: String)
+  fun warn(message: String, error: Throwable)
+  fun error(message: String)
+  fun error(message: String, error: Throwable)
+
+  companion object {
+    fun gradle(logger: Logger): SgpLogger = GradleSgpLogger(logger)
+    fun noop(): SgpLogger = NoopSgpLogger
+    fun system(): SgpLogger = SystemSgpLogger
+    fun prefix(prefix: String, delegate: SgpLogger): SgpLogger = PrefixSgpLogger(prefix, delegate)
+  }
+}
+
+/** A simple delegating logger that allows overwriting functions as desired. */
+internal abstract class DelegatingSgpLogger(private val delegate: SgpLogger) :
+  SgpLogger by delegate
+
+/** A logger that always adds the given [prefix] to log messages. */
+internal class PrefixSgpLogger(private val prefix: String, private val delegate: SgpLogger) :
+  SgpLogger {
+  override fun debug(message: String) {
+    delegate.debug("$prefix $message")
+  }
+
+  override fun info(message: String) {
+    delegate.info("$prefix $message")
+  }
+
+  override fun lifecycle(message: String) {
+    delegate.lifecycle("$prefix $message")
+  }
+
+  override fun warn(message: String) {
+    delegate.warn("$prefix $message")
+  }
+
+  override fun warn(message: String, error: Throwable) {
+    delegate.warn("$prefix $message", error)
+  }
+
+  override fun error(message: String) {
+    delegate.error("$prefix $message")
+  }
+
+  override fun error(message: String, error: Throwable) {
+    delegate.error("$prefix $message", error)
+  }
+}
+
+/** A quiet no-op [SgpLogger]. */
+private object NoopSgpLogger : SgpLogger {
+  override fun debug(message: String) {}
+  override fun info(message: String) {}
+  override fun lifecycle(message: String) {}
+  override fun warn(message: String) {}
+  override fun warn(message: String, error: Throwable) {}
+  override fun error(message: String) {}
+  override fun error(message: String, error: Throwable) {}
+}
+
+/** An [SgpLogger] that just writes to [System.out] and [System.err]. */
+private object SystemSgpLogger : SgpLogger {
+  override fun debug(message: String) {
+    println(message)
+  }
+
+  override fun info(message: String) {
+    println(message)
+  }
+
+  override fun lifecycle(message: String) {
+    println(message)
+  }
+
+  override fun warn(message: String) {
+    System.err.println(message)
+  }
+
+  override fun warn(message: String, error: Throwable) {
+    System.err.println(message)
+    error.printStackTrace(System.err)
+  }
+
+  override fun error(message: String) {
+    System.err.println(message)
+  }
+
+  override fun error(message: String, error: Throwable) {
+    System.err.println(message)
+    error.printStackTrace(System.err)
+  }
+}
+
+/** A Gradle [Logger]-based [SgpLogger]. */
+private class GradleSgpLogger(private val delegate: Logger) : SgpLogger {
+  override fun debug(message: String) {
+    delegate.debug(message)
+  }
+
+  override fun info(message: String) {
+    delegate.info(message)
+  }
+
+  override fun lifecycle(message: String) {
+    delegate.lifecycle(message)
+  }
+
+  override fun warn(message: String) {
+    delegate.warn(message)
+  }
+
+  override fun warn(message: String, error: Throwable) {
+    delegate.warn(message, error)
+  }
+
+  override fun error(message: String) {
+    delegate.error(message)
+  }
+
+  override fun error(message: String, error: Throwable) {
+    delegate.error(message, error)
+  }
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/SgpLogger.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/SgpLogger.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package slack.gradle.util
 
 import org.gradle.api.logging.Logger

--- a/slack-plugin/src/test/kotlin/slack/gradle/avoidance/AffectedProjectsComputerTest.kt
+++ b/slack-plugin/src/test/kotlin/slack/gradle/avoidance/AffectedProjectsComputerTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.avoidance
+
+import com.google.common.truth.Truth.assertThat
+import com.jraska.module.graph.DependencyGraph
+import okio.BufferedSink
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
+import okio.buffer
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import slack.gradle.util.SgpLogger
+
+class AffectedProjectsComputerTest {
+
+  // FakeFileSystem doesn't work because it doesn't support isRegularFile/isDirectory ops.
+  @get:Rule val tmpFolder = TemporaryFolder()
+
+  private val diagnostics = mutableMapOf<String, String>()
+  private val diagnosticWriter = DiagnosticWriter { name, content -> diagnostics[name] = content() }
+  private val fileSystem = FileSystem.SYSTEM
+  private lateinit var rootDirPath: Path
+  private lateinit var rootTestProject: TestProject
+
+  @Before
+  fun setup() {
+    rootDirPath = tmpFolder.newFolder("project").toOkioPath()
+    rootTestProject =
+      TestProject(fileSystem, rootDirPath, ":") {
+        buildFile()
+        settingsFile()
+      }
+  }
+
+  private fun createComputer(dependencyGraph: DependencyGraph, changedFilePaths: List<String>) =
+    AffectedProjectsComputer(
+      dependencyGraph = { dependencyGraph },
+      changedFilePaths = createChangedFilePaths(changedFilePaths),
+      rootDirPath = rootDirPath,
+      debug = true,
+      logger = SgpLogger.system(),
+      diagnostics = diagnosticWriter,
+    )
+
+  @Test
+  fun `singular graph with no changes and no files is empty`() {
+    createComputer(
+        dependencyGraph = DependencyGraph.createSingular(":foo"),
+        changedFilePaths = emptyList(),
+      )
+      .assertEmptyCompute()
+  }
+
+  @Test
+  fun `singular graph with singular change`() {
+    val projectName = "foo"
+    newSubProject(projectName) {
+      buildFile()
+      sourceFile("Example.kt", "class Example")
+    }
+    createComputer(
+        dependencyGraph = DependencyGraph.createSingular(":$projectName"),
+        changedFilePaths = listOf("$projectName/src/main/kotlin/com/example/Example.kt"),
+      )
+      .assertComputed(
+        expectedAffectedProjects = listOf(":$projectName"),
+        expectedFocusProjects = listOf(":$projectName"),
+      )
+  }
+
+  // TODO
+  //  - Debug logging
+  //  - Include filters
+  //  - Never skip filters
+  //  - Non-existent file, non-existent project (settings must change)
+  //  - Focus file outputs
+  //  - ???
+  //  - Gradle tests
+  //    - test fixtures
+
+  private fun createChangedFilePaths(paths: List<String>) = paths.map { it.toPath() }.toList()
+
+  private fun newSubProject(name: String, body: TestProject.() -> Unit): TestProject {
+    return rootTestProject.subproject(name, body)
+  }
+}
+
+private fun AffectedProjectsComputer.assertNullCompute() = compute().assertNull()
+
+private fun AffectedProjectsComputer.assertEmptyCompute() = compute().assertEmpty()
+
+private fun AffectedProjectsComputer.assertComputed(
+  expectedAffectedProjects: List<String>,
+  expectedFocusProjects: List<String>,
+) {
+  val result = compute().checkNotNull()
+  assertThat(result.affectedProjects).containsExactlyElementsIn(expectedAffectedProjects)
+  assertThat(result.focusProjects).containsExactlyElementsIn(expectedFocusProjects)
+}
+
+private fun AffectedProjectsResult?.checkNotNull() =
+  checkNotNull(this) { "Expected result to be non-null" }
+
+private fun AffectedProjectsResult?.assertNull() {
+  check(this == null) { "Expected result to be null" }
+}
+
+private fun AffectedProjectsResult?.assertEmpty() {
+  val result = checkNotNull()
+  assertThat(result.affectedProjects).isEmpty()
+  assertThat(result.focusProjects).isEmpty()
+}
+
+private class TestProject(
+  private val fileSystem: FileSystem,
+  private val rootPath: Path,
+  private val gradlePath: String,
+  body: TestProject.() -> Unit
+) {
+  private val relativePath = gradlePath.removePrefix(":").replace(":", Path.DIRECTORY_SEPARATOR)
+  private val projectPath = rootPath / relativePath
+  private val sourcePath =
+    projectPath / "src" / "main" / "kotlin" / "com" / "example" / relativePath
+  private var settingsFile: Path? = null
+
+  val subprojects = mutableListOf<TestProject>()
+
+  init {
+    // Creates the project and source dirs
+    fileSystem.createDirectories(projectPath)
+    body()
+  }
+
+  fun subproject(gradlePath: String, body: TestProject.() -> Unit): TestProject {
+    val project = TestProject(fileSystem, rootPath, gradlePath, body)
+    subprojects += project
+    appendToSettings(gradlePath)
+    return project
+  }
+
+  fun buildFile(
+    isKts: Boolean = false,
+    content: String = "buildscript { repositories { mavenCentral() } }"
+  ) {
+    buildFile(isKts) { writeUtf8(content) }
+  }
+
+  fun buildFile(isKts: Boolean = false, body: BufferedSink.() -> Unit) {
+    val name = if (isKts) "build.gradle.kts" else "build.gradle"
+    fileSystem.write(projectPath / name, writerAction = body)
+  }
+
+  private fun ensureSourcePath() {
+    if (!fileSystem.exists(sourcePath)) {
+      fileSystem.createDirectories(sourcePath)
+    }
+  }
+
+  fun sourceFile(name: String, content: String) {
+    sourceFile(name) { writeUtf8(content) }
+  }
+
+  fun sourceFile(name: String, body: BufferedSink.() -> Unit) {
+    ensureSourcePath()
+    fileSystem.write(sourcePath / name, writerAction = body)
+  }
+
+  fun settingsFile(isKts: Boolean = false, vararg includes: String) {
+    settingsFile(isKts) { writeUtf8(includes.joinToString("\n") { "include(\"$it\")" }) }
+  }
+
+  fun appendToSettings(gradlePath: String) {
+    settingsFile?.let {
+      fileSystem.appendingSink(it, mustExist = true).buffer().use {
+        it.writeUtf8("\ninclude(\"$gradlePath\")")
+      }
+    }
+  }
+
+  fun settingsFile(isKts: Boolean = false, body: BufferedSink.() -> Unit) {
+    val name = if (isKts) "settings.gradle.kts" else "settings.gradle"
+    val path = projectPath / name
+    fileSystem.write(path, writerAction = body)
+    settingsFile = path
+  }
+}


### PR DESCRIPTION
This implements a new `ComputeAffectedProjects` task. Most of the relevant docs are on the class and its properties/function itself, but the overview is this task is that it's used to compute affected projects from a given input of changed files (i.e. from a pull request).

**Logic Flow**
1. Parse input changed files
2. Filter input files against a set of input glob patterns to include only relevant files (i.e. source files like `.kt` files)
    - If no files patch, no projects are affected!
3. Check filtered files against a set of "never-skippable" glob patterns, such as version catalog files or root build files. If any file matches, the whole change is deemed not skippable and no file is emitted. This, in practice, means "all projects are affected".
4. Map filtered changed files to changed projects
5. Given a set of changed projects, inspect the build graph (reusing some logic from the graph-assert plugin) and determine affected projects based on dependent projects of the changed projects.
6. Output an affected_projects.txt file of affected projects

**Extras**
- This also outputs a `focus.settings.gradle` file, which can be used with https://github.com/dropbox/focus to only load the projects needed to run affected projects. This further reduces overhead.
- There's a lot of helpful diagnostics and debug logging available via the new `slack.debug` property.
- The computation task is _fast_, runs on the order of milliseconds.
- If a project's changed files are determined to be only tests or the lint baseline, it does _not_ mark dependents as affected. A nice little extra optimization.

This does _not_ implement integration into unit tests, lint tasks, and android test APKs yet. Saving that for a separate PR to simplify this one. I have been testing it extensively locally with the Slack android codebase using those integrations and debug diagnostics though!

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->