### PR TITLE
Allow relative project paths and check existence

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/GlobalConfig.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/GlobalConfig.kt
@@ -53,7 +53,19 @@ private constructor(
         kotlinDaemonArgs = globalSlackProperties.kotlinDaemonArgs.split(" "),
         errorProneCheckNamesAsErrors =
           globalSlackProperties.errorProneCheckNamesAsErrors?.split(":").orEmpty(),
-        affectedProjects = globalSlackProperties.affectedProjects?.readLines()?.toSet()
+        affectedProjects =
+          globalSlackProperties.affectedProjects?.let {
+            // Resolve from the project. This allows it to either be an absolute path or a relative
+            // one from the root project.
+            val resolved = project.file(it)
+            // Check file existence. This way we can allow specifying the property even if it
+            // doesn't exist, which can be more convenient in CI pipelines.
+            if (resolved.exists()) {
+              resolved.readLines().toSet()
+            } else {
+              null
+            }
+          }
       )
     }
   }


### PR DESCRIPTION
Addresses two things
- allows a relative path to the affected_projects.txt file from the root project dir as well as absolute.
- allows specifying a non-existent file, which is useful for CI where the computation step may produce no file (and thus all projects should run)

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->