### PR TITLE
[Skippy] Improve pattern configuration

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
@@ -71,10 +71,13 @@ import slack.gradle.util.SgpLogger
  * @property changedFilePaths A relative (to the repo root) path to a changed_files.txt that
  *   contains a newline-delimited list of changed files. This is usually computed from a GitHub PR's
  *   changed files.
- * @property includePatterns A list of glob patterns for files to include in computing affected
+ * @property includePatterns A set of glob patterns for files to include in computing affected
  *   projects. This should usually be source files, build files, gradle.properties files, and other
  *   projects that affect builds.
- * @property neverSkipPatterns A list of glob patterns that, if matched with a file, indicate that
+ * @property excludePatterns A set of glob patterns for files to exclude from computing affected
+ *   projects. This is run _after_ [includePatterns] and can be useful for excluding files that
+ *   would otherwise be included by an existing inclusion pattern.
+ * @property neverSkipPatterns A set of glob patterns that, if matched with a file, indicate that
  *   nothing should be skipped and [compute] will return null. This is useful for globally-affecting
  *   things like root build files, `libs.versions.toml`, etc. **NOTE**: This list is always merged
  *   with [includePatterns] as these are implicitly relevant files.
@@ -87,6 +90,7 @@ internal class AffectedProjectsComputer(
   private val changedFilePaths: List<Path>,
   private val diagnostics: DiagnosticWriter = DiagnosticWriter.NoOp,
   private val includePatterns: Set<String> = DEFAULT_INCLUDE_PATTERNS,
+  private val excludePatterns: Set<String> = emptySet(),
   private val neverSkipPatterns: Set<String> = DEFAULT_NEVER_SKIP_PATTERNS,
   private val debug: Boolean = false,
   private val fileSystem: FileSystem = FileSystem.SYSTEM,
@@ -106,9 +110,15 @@ internal class AffectedProjectsComputer(
     val mergedIncludePatterns = (includePatterns + neverSkipPatterns).toSet()
     log("mergedIncludePatterns: $mergedIncludePatterns")
 
-    val filteredChangedFilePaths =
-      logTimedValue("filtering changed files") {
+    val includedChangedFilePaths =
+      logTimedValue("filtering changed files with includes") {
         filterIncludes(changedFilePaths, mergedIncludePatterns)
+      }
+    log("includedChangedFilePaths: $includedChangedFilePaths")
+
+    val filteredChangedFilePaths =
+      logTimedValue("filtering changed files with excludes") {
+        filterExcludes(includedChangedFilePaths, excludePatterns)
       }
     log("filteredChangedFilePaths: $filteredChangedFilePaths")
 
@@ -338,6 +348,10 @@ internal class AffectedProjectsComputer(
     /** Returns a filtered list of [filePaths] that match the given [includePatterns]. */
     fun filterIncludes(filePaths: List<Path>, includePatterns: Collection<String>) =
       filePaths.filter { includePatterns.any { pattern -> pattern.toPathMatcher().matches(it) } }
+
+    /** Returns a filtered list of [filePaths] that do _not_ match the given [includePatterns]. */
+    fun filterExcludes(filePaths: List<Path>, excludePatterns: Collection<String>) =
+      filePaths.filterNot { excludePatterns.any { pattern -> pattern.toPathMatcher().matches(it) } }
 
     /** Returns whether any [filePaths] match any [neverSkipPatterns]. */
     fun anyNeverSkip(filePaths: List<Path>, neverSkipPathMatchers: List<PathMatcher>) =

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
@@ -16,6 +16,7 @@
 package slack.gradle.avoidance
 
 import com.jraska.module.graph.DependencyGraph
+import java.util.Collections.unmodifiableSet
 import kotlin.time.measureTimedValue
 import okio.FileSystem
 import okio.Path
@@ -308,41 +309,45 @@ internal class AffectedProjectsComputer(
   }
 
   companion object {
-    val DEFAULT_INCLUDE_PATTERNS =
-      setOf(
-        "**/*.kt",
-        "*.gradle",
-        "**/*.gradle",
-        "*.gradle.kts",
-        "**/*.gradle.kts",
-        "**/*.java",
-        "**/AndroidManifest.xml",
-        "**/res/**",
-        "**/src/*/resources/**",
-        "gradle.properties",
-        "**/gradle.properties",
+    val DEFAULT_INCLUDE_PATTERNS: Set<String> =
+      unmodifiableSet(
+        setOf(
+          "**/*.kt",
+          "*.gradle",
+          "**/*.gradle",
+          "*.gradle.kts",
+          "**/*.gradle.kts",
+          "**/*.java",
+          "**/AndroidManifest.xml",
+          "**/res/**",
+          "**/src/*/resources/**",
+          "gradle.properties",
+          "**/gradle.properties",
+        )
       )
 
-    val DEFAULT_NEVER_SKIP_PATTERNS =
-      setOf(
-        // root build.gradle.kts and settings.gradle.kts files
-        "*.gradle.kts",
-        "*.gradle",
-        // root gradle.properties file
-        "gradle.properties",
-        // Version catalogs
-        "**/*.versions.toml",
-        // Gradle wrapper files
-        "**/gradle/wrapper/**",
-        "gradle/wrapper/**",
-        "gradlew",
-        "gradlew.bat",
-        "**/gradlew",
-        "**/gradlew.bat",
-        // buildSrc
-        "buildSrc/**",
-        // CI
-        "**/.github/workflows/**",
+    val DEFAULT_NEVER_SKIP_PATTERNS: Set<String> =
+      unmodifiableSet(
+        setOf(
+          // root build.gradle.kts and settings.gradle.kts files
+          "*.gradle.kts",
+          "*.gradle",
+          // root gradle.properties file
+          "gradle.properties",
+          // Version catalogs
+          "**/*.versions.toml",
+          // Gradle wrapper files
+          "**/gradle/wrapper/**",
+          "gradle/wrapper/**",
+          "gradlew",
+          "gradlew.bat",
+          "**/gradlew",
+          "**/gradlew.bat",
+          // buildSrc
+          "buildSrc/**",
+          // CI
+          "**/.github/workflows/**",
+        )
       )
 
     /** Returns a filtered list of [filePaths] that match the given [includePatterns]. */

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
@@ -16,10 +16,11 @@
 package slack.gradle.avoidance
 
 import com.jraska.module.graph.DependencyGraph
-import java.util.Collections.unmodifiableSet
 import kotlin.time.measureTimedValue
 import okio.FileSystem
 import okio.Path
+import slack.gradle.avoidance.AffectedProjectsDefaults.DEFAULT_INCLUDE_PATTERNS
+import slack.gradle.avoidance.AffectedProjectsDefaults.DEFAULT_NEVER_SKIP_PATTERNS
 import slack.gradle.util.SgpLogger
 
 /**
@@ -309,47 +310,6 @@ internal class AffectedProjectsComputer(
   }
 
   companion object {
-    val DEFAULT_INCLUDE_PATTERNS: Set<String> =
-      unmodifiableSet(
-        setOf(
-          "**/*.kt",
-          "*.gradle",
-          "**/*.gradle",
-          "*.gradle.kts",
-          "**/*.gradle.kts",
-          "**/*.java",
-          "**/AndroidManifest.xml",
-          "**/res/**",
-          "**/src/*/resources/**",
-          "gradle.properties",
-          "**/gradle.properties",
-        )
-      )
-
-    val DEFAULT_NEVER_SKIP_PATTERNS: Set<String> =
-      unmodifiableSet(
-        setOf(
-          // root build.gradle.kts and settings.gradle.kts files
-          "*.gradle.kts",
-          "*.gradle",
-          // root gradle.properties file
-          "gradle.properties",
-          // Version catalogs
-          "**/*.versions.toml",
-          // Gradle wrapper files
-          "**/gradle/wrapper/**",
-          "gradle/wrapper/**",
-          "gradlew",
-          "gradlew.bat",
-          "**/gradlew",
-          "**/gradlew.bat",
-          // buildSrc
-          "buildSrc/**",
-          // CI
-          "**/.github/workflows/**",
-        )
-      )
-
     /** Returns a filtered list of [filePaths] that match the given [includePatterns]. */
     fun filterIncludes(filePaths: List<Path>, includePatterns: Collection<String>) =
       filePaths.filter { includePatterns.any { pattern -> pattern.toPathMatcher().matches(it) } }

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
@@ -86,8 +86,8 @@ internal class AffectedProjectsComputer(
   private val dependencyGraph: () -> DependencyGraph,
   private val changedFilePaths: List<Path>,
   private val diagnostics: DiagnosticWriter = DiagnosticWriter.NoOp,
-  private val includePatterns: List<String> = DEFAULT_INCLUDE_PATTERNS,
-  private val neverSkipPatterns: List<String> = DEFAULT_NEVER_SKIP_PATTERNS,
+  private val includePatterns: Set<String> = DEFAULT_INCLUDE_PATTERNS,
+  private val neverSkipPatterns: Set<String> = DEFAULT_NEVER_SKIP_PATTERNS,
   private val debug: Boolean = false,
   private val fileSystem: FileSystem = FileSystem.SYSTEM,
   private val logger: SgpLogger = SgpLogger.noop()
@@ -298,8 +298,8 @@ internal class AffectedProjectsComputer(
   }
 
   companion object {
-    internal val DEFAULT_INCLUDE_PATTERNS =
-      listOf(
+    val DEFAULT_INCLUDE_PATTERNS =
+      setOf(
         "**/*.kt",
         "*.gradle",
         "**/*.gradle",
@@ -313,8 +313,8 @@ internal class AffectedProjectsComputer(
         "**/gradle.properties",
       )
 
-    internal val DEFAULT_NEVER_SKIP_PATTERNS =
-      listOf(
+    val DEFAULT_NEVER_SKIP_PATTERNS =
+      setOf(
         // root build.gradle.kts and settings.gradle.kts files
         "*.gradle.kts",
         "*.gradle",

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsComputer.kt
@@ -331,6 +331,8 @@ internal class AffectedProjectsComputer(
         "**/gradlew.bat",
         // buildSrc
         "buildSrc/**",
+        // CI
+        "**/.github/workflows/**",
       )
 
     /** Returns a filtered list of [filePaths] that match the given [includePatterns]. */

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsDefaults.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsDefaults.kt
@@ -55,7 +55,7 @@ public object AffectedProjectsDefaults {
         // buildSrc
         "buildSrc/**",
         // CI
-        "**/.github/workflows/**",
+        ".github/workflows/**",
       )
     )
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsDefaults.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/AffectedProjectsDefaults.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.avoidance
+
+import java.util.Collections.unmodifiableSet
+
+public object AffectedProjectsDefaults {
+  public val DEFAULT_INCLUDE_PATTERNS: Set<String> =
+    unmodifiableSet(
+      setOf(
+        "**/*.kt",
+        "*.gradle",
+        "**/*.gradle",
+        "*.gradle.kts",
+        "**/*.gradle.kts",
+        "**/*.java",
+        "**/AndroidManifest.xml",
+        "**/res/**",
+        "**/src/*/resources/**",
+        "gradle.properties",
+        "**/gradle.properties",
+      )
+    )
+
+  public val DEFAULT_NEVER_SKIP_PATTERNS: Set<String> =
+    unmodifiableSet(
+      setOf(
+        // root build.gradle.kts and settings.gradle.kts files
+        "*.gradle.kts",
+        "*.gradle",
+        // root gradle.properties file
+        "gradle.properties",
+        // Version catalogs
+        "**/*.versions.toml",
+        // Gradle wrapper files
+        "**/gradle/wrapper/**",
+        "gradle/wrapper/**",
+        "gradlew",
+        "gradlew.bat",
+        "**/gradlew",
+        "**/gradlew.bat",
+        // buildSrc
+        "buildSrc/**",
+        // CI
+        "**/.github/workflows/**",
+      )
+    )
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
@@ -62,6 +62,10 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
       .convention(AffectedProjectsComputer.DEFAULT_INCLUDE_PATTERNS)
 
   @get:Input
+  public val excludePatterns: SetProperty<String> =
+    project.objects.setProperty<String>().convention(emptySet())
+
+  @get:Input
   public val neverSkipPatterns: SetProperty<String> =
     project.objects
       .setProperty<String>()
@@ -132,6 +136,7 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
               }
             },
             includePatterns = includePatterns.get(),
+            excludePatterns = excludePatterns.get(),
             neverSkipPatterns = neverSkipPatterns.get(),
             debug = debug.get(),
             diagnostics = this,

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
@@ -24,8 +24,8 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 import slack.gradle.SlackProperties
+import slack.gradle.setProperty
 import slack.gradle.util.SgpLogger
 
 /**
@@ -55,15 +56,15 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
     project.objects.property(Boolean::class.java).convention(false)
 
   @get:Input
-  public val includePatterns: ListProperty<String> =
+  public val includePatterns: SetProperty<String> =
     project.objects
-      .listProperty(String::class.java)
+      .setProperty<String>()
       .convention(AffectedProjectsComputer.DEFAULT_INCLUDE_PATTERNS)
 
   @get:Input
-  public val neverSkipPatterns: ListProperty<String> =
+  public val neverSkipPatterns: SetProperty<String> =
     project.objects
-      .listProperty(String::class.java)
+      .setProperty<String>()
       .convention(AffectedProjectsComputer.DEFAULT_NEVER_SKIP_PATTERNS)
 
   /**

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
@@ -35,6 +35,8 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.Option
 import slack.gradle.SlackProperties
+import slack.gradle.avoidance.AffectedProjectsDefaults.DEFAULT_INCLUDE_PATTERNS
+import slack.gradle.avoidance.AffectedProjectsDefaults.DEFAULT_NEVER_SKIP_PATTERNS
 import slack.gradle.setProperty
 import slack.gradle.util.SgpLogger
 
@@ -57,9 +59,7 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
 
   @get:Input
   public val includePatterns: SetProperty<String> =
-    project.objects
-      .setProperty<String>()
-      .convention(AffectedProjectsComputer.DEFAULT_INCLUDE_PATTERNS)
+    project.objects.setProperty<String>().convention(DEFAULT_INCLUDE_PATTERNS)
 
   @get:Input
   public val excludePatterns: SetProperty<String> =
@@ -67,9 +67,7 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
 
   @get:Input
   public val neverSkipPatterns: SetProperty<String> =
-    project.objects
-      .setProperty<String>()
-      .convention(AffectedProjectsComputer.DEFAULT_NEVER_SKIP_PATTERNS)
+    project.objects.setProperty<String>().convention(DEFAULT_NEVER_SKIP_PATTERNS)
 
   /**
    * A relative (to the repo root) path to a changed_files.txt that contains a newline-delimited

--- a/slack-plugin/src/test/kotlin/slack/gradle/avoidance/AffectedProjectsComputerTest.kt
+++ b/slack-plugin/src/test/kotlin/slack/gradle/avoidance/AffectedProjectsComputerTest.kt
@@ -170,6 +170,9 @@ class AffectedProjectsComputerTest {
         "nested/gradlew" to true,
         "gradlew.bat" to true,
         "nested/gradlew.bat" to true,
+        // GH Actions
+        ".github/workflows/ci.yml" to true,
+        ".github/ci.yml" to false,
       )
     for ((path, expectedToBeSkipped) in testInputs) {
       val okioPath = path.toPath()

--- a/slack-plugin/src/test/kotlin/slack/gradle/avoidance/AffectedProjectsComputerTest.kt
+++ b/slack-plugin/src/test/kotlin/slack/gradle/avoidance/AffectedProjectsComputerTest.kt
@@ -29,6 +29,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import slack.gradle.avoidance.AffectedProjectsComputer.Companion.anyNeverSkip
 import slack.gradle.avoidance.AffectedProjectsComputer.Companion.anyNeverSkipDebug
+import slack.gradle.avoidance.AffectedProjectsComputer.Companion.filterExcludes
 import slack.gradle.avoidance.AffectedProjectsComputer.Companion.filterIncludes
 import slack.gradle.util.SgpLogger
 
@@ -181,6 +182,21 @@ class AffectedProjectsComputerTest {
         check(result == null) { "Expected $path to be skipped, but was not. Debug info: $result" }
       }
     }
+  }
+
+  @Test
+  fun excludeFilters() {
+    val patterns =
+      setOf(
+        "**/baz/**",
+      )
+    val testInputs =
+      mapOf(
+        "foo/bar/baz/Example.kt" to false,
+        "foo/bar/AndroidManifest.xml" to true,
+      )
+    assertThat(filterExcludes(testInputs.keys.map { it.toPath() }, patterns))
+      .containsExactlyElementsIn(testInputs.filterValues { it }.keys.map { it.toPath() })
   }
 
   // TODO

--- a/slack-plugin/src/test/kotlin/slack/gradle/avoidance/AffectedProjectsComputerTest.kt
+++ b/slack-plugin/src/test/kotlin/slack/gradle/avoidance/AffectedProjectsComputerTest.kt
@@ -92,7 +92,7 @@ class AffectedProjectsComputerTest {
 
   @Test
   fun `smoke test for default include patterns`() {
-    val patterns = AffectedProjectsComputer.DEFAULT_INCLUDE_PATTERNS
+    val patterns = AffectedProjectsDefaults.DEFAULT_INCLUDE_PATTERNS
     val testInputs =
       mapOf(
         "foo/bar/baz/Example.kt" to true,
@@ -132,7 +132,7 @@ class AffectedProjectsComputerTest {
 
   @Test
   fun `smoke test for default never skip patterns`() {
-    val patterns = AffectedProjectsComputer.DEFAULT_NEVER_SKIP_PATTERNS.map(String::toPathMatcher)
+    val patterns = AffectedProjectsDefaults.DEFAULT_NEVER_SKIP_PATTERNS.map(String::toPathMatcher)
     val testInputs =
       mapOf(
         "foo/bar/baz/Example.kt" to false,


### PR DESCRIPTION
1. Make the default patterns public. This allows consumers to more easily reuse them when customizing their own.
2. Use sets for the type to better enforce uniqueness requirements.
3. Add github actions to never-skip defaults.
4. Add excludePatterns to allow finer-grained control. This runs _after_ include filtering so that users can manually exclude certain files that may otherwise be captured in an inclusion filter and is difficult to describe in a simple glob pattern. GitHub action does similar controls for CI matrices.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->