### PR TITLE
Remove moshi-kotlin and only use code gen

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,6 @@ jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 junit = "junit:junit:4.13.2"
 markdown = "org.jetbrains:markdown:0.4.1"
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -115,7 +115,6 @@ dependencies {
   api(libs.okhttp)
 
   implementation(libs.moshi)
-  implementation(libs.moshi.kotlin)
 
   // Graphing library with Betweenness Centrality algo for modularization score
   implementation(libs.jgrapht)

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
 
   compileOnly(platform(kotlin("bom", version = libs.versions.kotlin.get())))
   compileOnly(kotlin("gradle-plugin", version = libs.versions.kotlin.get()))
-  implementation(kotlin("reflect", version = libs.versions.kotlin.get()))
 
   // compileOnly because we want to leave versioning to the consumers
   // Add gradle plugins for the slack project itself, separate from plugins. We do this so we can

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
 
   compileOnly(platform(kotlin("bom", version = libs.versions.kotlin.get())))
   compileOnly(kotlin("gradle-plugin", version = libs.versions.kotlin.get()))
+  compileOnly(kotlin("reflect", version = libs.versions.kotlin.get()))
 
   // compileOnly because we want to leave versioning to the consumers
   // Add gradle plugins for the slack project itself, separate from plugins. We do this so we can

--- a/slack-plugin/src/main/kotlin/slack/gradle/Platforms.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/Platforms.kt
@@ -15,6 +15,8 @@
  */
 package slack.gradle
 
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.adapter
 import java.io.File
 import okio.buffer
 import okio.source
@@ -254,9 +256,7 @@ public object Platforms {
       project.providers.provider {
         val path = slackProperties.versionsJson ?: return@provider sneakyNull()
         println("Parsing versions json at $path")
-        path.source().buffer().use {
-          JsonTools.MOSHI.adapter(VersionsOutput::class.java).fromJson(it)!!
-        }
+        path.source().buffer().use { JsonTools.MOSHI.adapter<VersionsOutput>().fromJson(it)!! }
       }
 
     val providers = project.providers
@@ -322,12 +322,14 @@ public object Platforms {
   }
 }
 
+@JsonClass(generateAdapter = true)
 internal data class VersionsOutput(val outdated: Outdated) {
   val identifierMap = outdated.dependencies.associateBy { "${it.group}:${it.name}" }
 }
 
-internal data class Outdated(val dependencies: Set<Artifact>)
+@JsonClass(generateAdapter = true) internal data class Outdated(val dependencies: Set<Artifact>)
 
+@JsonClass(generateAdapter = true)
 internal data class Artifact(
   val group: String,
   val available: Available,
@@ -335,6 +337,7 @@ internal data class Artifact(
   val name: String
 )
 
+@JsonClass(generateAdapter = true)
 internal data class Available(val release: String?, val integration: String?) {
   fun newTarget(): String {
     return release ?: integration ?: error("No available target found")

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/JsonTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/JsonTools.kt
@@ -20,7 +20,6 @@ import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.addAdapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -30,7 +29,6 @@ internal object JsonTools {
     Moshi.Builder()
       // Used in SlackTools for thermals data
       .addAdapter<LocalDateTime>(LocalDateTimeJsonAdapter())
-      .addLast(KotlinJsonAdapterFactory())
       .build()
 }
 

--- a/slack-plugin/src/main/kotlin/slack/stats/LanguageStats.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/LanguageStats.kt
@@ -16,6 +16,7 @@
 package slack.stats
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
 // Example
 // "HTML" :{
@@ -23,6 +24,7 @@ import com.squareup.moshi.Json
 //  "blank": 3575,
 //  "comment": 0,
 //  "code": 116111},
+@JsonClass(generateAdapter = true)
 internal data class LanguageStats(
   @Json(name = "nFiles") val files: Int,
   val code: Int,

--- a/slack-plugin/src/main/kotlin/slack/stats/LocTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/LocTask.kt
@@ -15,6 +15,7 @@
  */
 package slack.stats
 
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.adapter
 import java.io.File
 import okio.buffer
@@ -208,6 +209,7 @@ internal abstract class LocTask : DefaultTask() {
     }
   }
 
+  @JsonClass(generateAdapter = true)
   data class LocData(
     val srcs: Map<String, LanguageStats>,
     val generatedSrcs: Map<String, LanguageStats>

--- a/slack-plugin/src/main/kotlin/slack/stats/ModuleStats.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/ModuleStats.kt
@@ -20,9 +20,7 @@ import app.cash.sqldelight.gradle.SqlDelightTask
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.google.devtools.ksp.gradle.KspTask
 import com.squareup.moshi.JsonClass
-import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.squareup.wire.gradle.WireTask
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
@@ -385,8 +383,6 @@ internal abstract class ModuleStatsCollectorTask @Inject constructor(objects: Ob
 
   @get:OutputFile abstract val outputFile: RegularFileProperty
 
-  private val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
-
   init {
     group = "slack"
   }
@@ -397,7 +393,7 @@ internal abstract class ModuleStatsCollectorTask @Inject constructor(objects: Ob
     val (sources, generatedSources) =
       if (locSrcFiles.isNotEmpty()) {
         locDataFiles.singleFile.source().buffer().use {
-          moshi.adapter<LocTask.LocData>().fromJson(it)!!
+          JsonTools.MOSHI.adapter<LocTask.LocData>().fromJson(it)!!
         }
       } else {
         LocTask.LocData.EMPTY
@@ -407,8 +403,7 @@ internal abstract class ModuleStatsCollectorTask @Inject constructor(objects: Ob
 
     logger.debug("Writing stats to ${outputFile.asFile.get()}")
     outputFile.asFile.get().sink().buffer().use { sink ->
-      moshi
-        .adapter<ModuleStats>()
+      JsonTools.MOSHI.adapter<ModuleStats>()
         .toJson(
           sink,
           ModuleStats(modulePath.get(), sources, generatedSources, tags.get(), dependencies)

--- a/slack-plugin/src/main/kotlin/slack/stats/ModuleStats.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/ModuleStats.kt
@@ -19,6 +19,7 @@ import app.cash.sqldelight.gradle.GenerateSchemaTask
 import app.cash.sqldelight.gradle.SqlDelightTask
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.google.devtools.ksp.gradle.KspTask
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -439,8 +440,10 @@ internal object StatsUtils {
   }
 }
 
+@JsonClass(generateAdapter = true)
 public data class AggregateModuleScore(val scores: List<ModuleScore>)
 
+@JsonClass(generateAdapter = true)
 public data class ModuleScore(
   val moduleName: String,
   val score: Long,
@@ -484,6 +487,7 @@ private fun ModuleStats.weighted(
 // TODO capture build times in this. Percent of total build, mainly. Possibly factor it together
 // with centrality
 //  where centrality is a multiplier for build times.
+@JsonClass(generateAdapter = true)
 public data class Weights(
   val percentOfTotalCode: Double,
   val javaKotlinRatio: Double,
@@ -565,6 +569,7 @@ public data class Weights(
   }
 }
 
+@JsonClass(generateAdapter = true)
 internal data class ModuleStats(
   val modulePath: String,
   val source: Map<String, LanguageStats>,


### PR DESCRIPTION
Code gen'd adapters are faster and we'll get better compile-time error checking for mis-configured adapters

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->