### PR TITLE
Use disallowChanges where possible

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import slack.gradle.util.localGradleProperty
+import slack.gradle.util.setDisallowChanges
 
 /**
  * Uses AGP 4.0's new APIs for manipulating variant properties in a more cache-friendly way.
@@ -89,15 +90,15 @@ internal class ApkVersioningPlugin : Plugin<Project> {
       val shortGitShaProvider = project.gitSha
       val longGitShaProvider = project.fullGitSha
       project.tasks.register<VersionPropertiesTask>("generateVersionProperties") {
-        outputFile.set(
+        outputFile.setDisallowChanges(
           project.layout.buildDirectory.file("intermediates/versioning/version.properties")
         )
-        versionCode.set(versionCodeProvider)
-        versionName.set(versionNameProvider)
-        shortGitSha.set(shortGitShaProvider)
-        longGitSha.set(longGitShaProvider)
-        this.versionMajor.set(versionMajor)
-        this.versionMinor.set(versionMinor)
+        versionCode.setDisallowChanges(versionCodeProvider)
+        versionName.setDisallowChanges(versionNameProvider)
+        shortGitSha.setDisallowChanges(shortGitShaProvider)
+        longGitSha.setDisallowChanges(longGitShaProvider)
+        this.versionMajor.setDisallowChanges(versionMajor)
+        this.versionMinor.setDisallowChanges(versionMinor)
       }
     }
   }
@@ -122,7 +123,7 @@ internal class ApkVersioningPlugin : Plugin<Project> {
 
         // Have to iterate outputs because of APK splits.
         variant.outputs.forEach { variantOutput ->
-          variantOutput.versionName.set(mappedVersionNameProvider)
+          variantOutput.versionName.setDisallowChanges(mappedVersionNameProvider)
 
           // Reuse the same task and just remap its value as needed
           val mappedVersionCodeProvider =
@@ -130,7 +131,7 @@ internal class ApkVersioningPlugin : Plugin<Project> {
               @Suppress("MagicNumber")
               ApkVersioning.VERSION_CODES.getValue(variantOutput.abiString) * 10000000 + rawCode
             }
-          variantOutput.versionCode.set(mappedVersionCodeProvider)
+          variantOutput.versionCode.setDisallowChanges(mappedVersionCodeProvider)
         }
       }
     }

--- a/slack-plugin/src/main/kotlin/slack/gradle/GlobalConfig.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/GlobalConfig.kt
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import slack.gradle.tasks.detektbaseline.MergeDetektBaselinesTask
 import slack.gradle.tasks.robolectric.UpdateRobolectricJarsTask
+import slack.gradle.util.setDisallowChanges
 
 /** Registry of global configuration info. */
 public class GlobalConfig
@@ -44,7 +45,9 @@ private constructor(
           project.gradle.startParameter.taskNames.any { it == MergeDetektBaselinesTask.TASK_NAME }
         ) {
           project.tasks.register<MergeDetektBaselinesTask>(MergeDetektBaselinesTask.TASK_NAME) {
-            outputFile.set(project.layout.projectDirectory.file("config/detekt/baseline.xml"))
+            outputFile.setDisallowChanges(
+              project.layout.projectDirectory.file("config/detekt/baseline.xml")
+            )
           }
         } else {
           null
@@ -88,11 +91,13 @@ private fun Project.createRobolectricJarsDownloadTask(
   return tasks.register<UpdateRobolectricJarsTask>("updateRobolectricJars") {
     val sdksProvider = providers.provider { slackProperties.robolectricTestSdks }
     val iVersionProvider = providers.provider { slackProperties.robolectricIVersion }
-    sdkVersions.set(sdksProvider)
-    instrumentedVersion.set(iVersionProvider)
+    sdkVersions.setDisallowChanges(sdksProvider)
+    instrumentedVersion.setDisallowChanges(iVersionProvider)
     val gradleUserHomeDir = gradle.gradleUserHomeDir
-    outputDir.set(project.layout.dir(project.provider { robolectricJars(gradleUserHomeDir) }))
-    offline.set(project.gradle.startParameter.isOffline)
+    outputDir.setDisallowChanges(
+      project.layout.dir(project.provider { robolectricJars(gradleUserHomeDir) })
+    )
+    offline.setDisallowChanges(project.gradle.startParameter.isOffline)
 
     // If we already have the expected jars downloaded locally, then we can mark this task as up
     // to date.

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import slack.gradle.agp.PermissionAllowlistConfigurer
 import slack.gradle.dependencies.SlackDependencies
+import slack.gradle.util.setDisallowChanges
 
 @DslMarker public annotation class SlackExtensionMarker
 
@@ -151,7 +152,7 @@ constructor(
           pluginManager.apply("dev.zacsweers.moshix")
         }
         if (enableSealed) {
-          configure<MoshiPluginExtension> { this.enableSealed.set(true) }
+          configure<MoshiPluginExtension> { this.enableSealed.setDisallowChanges(true) }
         }
       }
 
@@ -188,8 +189,8 @@ constructor(
         if (daggerConfig.enableAnvil) {
           pluginManager.apply("com.squareup.anvil")
           configure<AnvilExtension> {
-            generateDaggerFactories.set(daggerConfig.anvilFactories)
-            generateDaggerFactoriesOnly.set(daggerConfig.anvilFactoriesOnly)
+            generateDaggerFactories.setDisallowChanges(daggerConfig.anvilFactories)
+            generateDaggerFactoriesOnly.setDisallowChanges(daggerConfig.anvilFactoriesOnly)
           }
 
           val runtimeProjects =
@@ -328,7 +329,7 @@ constructor(
           daggerConfig?.enableAnvil == true &&
           !daggerConfig.alwaysEnableAnvilComponentMerging
       ) {
-        configure<AnvilExtension> { disableComponentMerging.set(true) }
+        configure<AnvilExtension> { disableComponentMerging.setDisallowChanges(true) }
       }
     }
   }
@@ -386,7 +387,7 @@ constructor(
    * @param action optional block for extra configuration, such as anvil generators or android.
    */
   public fun dagger(action: Action<DaggerHandler>? = null) {
-    daggerHandler.enabled.set(true)
+    daggerHandler.enabled.setDisallowChanges(true)
     action?.execute(daggerHandler)
   }
 
@@ -409,15 +410,15 @@ constructor(
     check(enableComponents || projectHasJavaInjections) {
       "This function should not be called with both enableComponents and projectHasJavaInjections set to false. Either remove these parameters or call a more appropriate non-delicate dagger() overload."
     }
-    daggerHandler.enabled.set(true)
-    daggerHandler.useDaggerCompiler.set(enableComponents || projectHasJavaInjections)
+    daggerHandler.enabled.setDisallowChanges(true)
+    daggerHandler.useDaggerCompiler.setDisallowChanges(enableComponents || projectHasJavaInjections)
     action?.execute(daggerHandler)
   }
 
   /** Adds dagger's runtime as dependencies to this but runs no code generation. */
   public fun daggerRuntimeOnly() {
-    daggerHandler.enabled.set(true)
-    daggerHandler.runtimeOnly.set(true)
+    daggerHandler.enabled.setDisallowChanges(true)
+    daggerHandler.runtimeOnly.setDisallowChanges(true)
   }
 
   /**
@@ -451,11 +452,11 @@ constructor(
     with: Boolean = false,
     kotlin: Boolean = false
   ) {
-    autoValue.set(true)
-    avExtensionParcel.set(parcel)
-    avExtensionMoshi.set(moshi)
-    avExtensionWith.set(with)
-    avExtensionKotlin.set(kotlin)
+    autoValue.setDisallowChanges(true)
+    avExtensionParcel.setDisallowChanges(parcel)
+    avExtensionMoshi.setDisallowChanges(moshi)
+    avExtensionWith.setDisallowChanges(with)
+    avExtensionKotlin.setDisallowChanges(kotlin)
   }
 
   /**
@@ -474,25 +475,25 @@ constructor(
     action: Action<MoshiHandler> = Action {}
   ) {
     action.execute(moshiHandler)
-    moshiHandler.moshi.set(true)
-    moshiHandler.moshiAdapters.set(adapters)
-    moshiHandler.moshiCodegen.set(codegen)
-    moshiHandler.moshiKotlinReflect.set(kotlinReflect)
+    moshiHandler.moshi.setDisallowChanges(true)
+    moshiHandler.moshiAdapters.setDisallowChanges(adapters)
+    moshiHandler.moshiCodegen.setDisallowChanges(codegen)
+    moshiHandler.moshiKotlinReflect.setDisallowChanges(kotlinReflect)
   }
 
   /** Enables AutoService on this project. */
   public fun autoService() {
-    autoService.set(true)
+    autoService.setDisallowChanges(true)
   }
 
   /** Enables InCap on this project. */
   public fun incap() {
-    incap.set(true)
+    incap.setDisallowChanges(true)
   }
 
   /** Enables redacted-compiler-plugin on this project. */
   public fun redacted() {
-    redacted.set(true)
+    redacted.setDisallowChanges(true)
   }
 
   /**
@@ -543,9 +544,8 @@ public abstract class MoshiHandler {
     adapters: Boolean,
     metadataReflect: Boolean = false,
   ) {
-    moshi.set(true)
-    moshixAdapters.set(adapters)
-    moshixMetadataReflect.set(metadataReflect)
+    moshixAdapters.setDisallowChanges(adapters)
+    moshixMetadataReflect.setDisallowChanges(metadataReflect)
   }
 
   /**
@@ -562,16 +562,15 @@ public abstract class MoshiHandler {
     kotlinReflect: Boolean = false,
     metadataReflect: Boolean = false
   ) {
-    moshi.set(true)
-    sealed.set(true)
-    sealedCodegen.set(codegen)
-    sealedReflect.set(kotlinReflect)
-    sealedMetadataReflect.set(metadataReflect)
+    sealed.setDisallowChanges(true)
+    sealedCodegen.setDisallowChanges(codegen)
+    sealedReflect.setDisallowChanges(kotlinReflect)
+    sealedMetadataReflect.setDisallowChanges(metadataReflect)
   }
 
   /** Enables [moshi-lazy-adapters](https://github.com/serj-lotutovici/moshi-lazy-adapters). */
   public fun lazyAdapters() {
-    lazyAdapters.set(true)
+    lazyAdapters.setDisallowChanges(true)
   }
 }
 
@@ -611,7 +610,7 @@ public abstract class DaggerHandler @Inject constructor(objects: ObjectFactory) 
    */
   @DelicateSlackPluginApi
   public fun alwaysEnableAnvilComponentMerging() {
-    alwaysEnableAnvilComponentMerging.set(true)
+    alwaysEnableAnvilComponentMerging.setDisallowChanges(true)
   }
 
   /**
@@ -620,7 +619,7 @@ public abstract class DaggerHandler @Inject constructor(objects: ObjectFactory) 
    */
   @DelicateSlackPluginApi
   public fun disableAnvil() {
-    disableAnvil.set(true)
+    disableAnvil.setDisallowChanges(true)
   }
 
   internal fun computeConfig(): DaggerConfig? {
@@ -687,10 +686,8 @@ constructor(
   }
 
   internal fun enable(multiplatform: Boolean) {
-    enabled.set(true)
-    enabled.disallowChanges()
-    this.multiplatform.set(multiplatform)
-    this.multiplatform.disallowChanges()
+    enabled.setDisallowChanges(true)
+    this.multiplatform.setDisallowChanges(multiplatform)
     if (!multiplatform) {
       val extension =
         checkNotNull(androidExtension) {
@@ -714,7 +711,7 @@ constructor(
       } else {
         project.pluginManager.apply("org.jetbrains.compose")
         project.configure<ComposeExtension> {
-          kotlinCompilerPlugin.set(
+          kotlinCompilerPlugin.setDisallowChanges(
             dependencies.compiler.forKotlin(slackProperties.versions.composeJbKotlinVersion!!)
           )
         }
@@ -810,12 +807,9 @@ public abstract class AndroidFeaturesHandler @Inject constructor() {
     excludeFromFladle: Boolean = false,
     allowedVariants: Iterable<String>? = null
   ) {
-    androidTest.set(true)
-    androidTestExcludeFromFladle.set(excludeFromFladle)
-    androidTestAllowedVariants.set(allowedVariants)
-    androidTest.disallowChanges()
-    androidTestExcludeFromFladle.disallowChanges()
-    androidTestAllowedVariants.disallowChanges()
+    androidTest.setDisallowChanges(true)
+    androidTestExcludeFromFladle.setDisallowChanges(excludeFromFladle)
+    androidTestAllowedVariants.setDisallowChanges(allowedVariants)
   }
 
   /** Enables robolectric for this project. */
@@ -823,7 +817,7 @@ public abstract class AndroidFeaturesHandler @Inject constructor() {
   public fun robolectric() {
     // Required for Robolectric to work.
     androidExtension!!.testOptions.unitTests.isIncludeAndroidResources = true
-    robolectric.set(true)
+    robolectric.setDisallowChanges(true)
   }
 }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -180,32 +180,34 @@ internal class SlackRootPlugin : Plugin<Project> {
     // Add ktlint download task
     slackProperties.versions.ktlint?.let { ktlintVersion ->
       project.tasks.register<KtLintDownloadTask>("updateKtLint") {
-        version.set(ktlintVersion)
-        outputFile.set(project.layout.projectDirectory.file("config/bin/ktlint"))
+        version.setDisallowChanges(ktlintVersion)
+        outputFile.setDisallowChanges(project.layout.projectDirectory.file("config/bin/ktlint"))
       }
     }
 
     // Add GJF download task
     slackProperties.versions.gjf?.let { gjfVersion ->
       project.tasks.register<GjfDownloadTask>("updateGjf") {
-        version.set(gjfVersion)
-        outputFile.set(project.layout.projectDirectory.file("config/bin/gjf"))
+        version.setDisallowChanges(gjfVersion)
+        outputFile.setDisallowChanges(project.layout.projectDirectory.file("config/bin/gjf"))
       }
     }
 
     // Add ktfmt download task
     slackProperties.versions.ktfmt?.let { ktfmtVersion ->
       project.tasks.register<KtfmtDownloadTask>("updateKtfmt") {
-        version.set(ktfmtVersion)
-        outputFile.set(project.layout.projectDirectory.file("config/bin/ktfmt"))
+        version.setDisallowChanges(ktfmtVersion)
+        outputFile.setDisallowChanges(project.layout.projectDirectory.file("config/bin/ktfmt"))
       }
     }
 
     // Add sortDependencies download task
     slackProperties.versions.sortDependencies?.let { sortDependenciesVersion ->
       project.tasks.register<SortDependenciesDownloadTask>("updateSortDependencies") {
-        version.set(sortDependenciesVersion)
-        outputFile.set(project.layout.projectDirectory.file("config/bin/sort-dependencies"))
+        version.setDisallowChanges(sortDependenciesVersion)
+        outputFile.setDisallowChanges(
+          project.layout.projectDirectory.file("config/bin/sort-dependencies")
+        )
       }
     }
 
@@ -432,26 +434,26 @@ private fun Project.configureMisc(slackProperties: SlackProperties) {
     @Suppress("MagicNumber")
     configure<DoctorExtension> {
       // We always use G1 because it's faster
-      warnWhenNotUsingParallelGC.set(false)
+      warnWhenNotUsingParallelGC.setDisallowChanges(false)
 
       /** Throw an exception when multiple Gradle Daemons are running. */
-      disallowMultipleDaemons.set(false)
+      disallowMultipleDaemons.setDisallowChanges(false)
 
       // TODO we disable these for now because local development envs are a mess, and these will
       // require more organized
       //  setup. When we do enable them though, they should just be set to `!isCi`
 
       /** Show a message if the download speed is less than this many megabytes / sec. */
-      downloadSpeedWarningThreshold.set(.5f)
+      downloadSpeedWarningThreshold.setDisallowChanges(.5f)
       /**
        * The level at which to warn when a build spends more than this percent garbage collecting.
        */
-      GCWarningThreshold.set(0.10f)
+      GCWarningThreshold.setDisallowChanges(0.10f)
       /**
        * Print a warning to the console if we spend more than this amount of time with Dagger
        * annotation processors.
        */
-      daggerThreshold.set(5000)
+      daggerThreshold.setDisallowChanges(5000)
       /**
        * By default, Gradle caches test results. This can be dangerous if tests rely on timestamps,
        * dates, or other files which are not declared as inputs.
@@ -459,29 +461,29 @@ private fun Project.configureMisc(slackProperties: SlackProperties) {
        * We don't disable caching because we don't see much instability here and disabling them
        * severely impacts CI time.
        */
-      enableTestCaching.set(true)
+      enableTestCaching.setDisallowChanges(true)
       /**
        * By default, Gradle treats empty directories as inputs to compilation tasks. This can cause
        * cache misses.
        */
-      failOnEmptyDirectories.set(true)
+      failOnEmptyDirectories.setDisallowChanges(true)
       /**
        * Do not allow building all apps simultaneously. This is likely not what the user intended.
        */
-      allowBuildingAllAndroidAppsSimultaneously.set(false)
+      allowBuildingAllAndroidAppsSimultaneously.setDisallowChanges(false)
 
       javaHome {
         /** Ensure that we are using JAVA_HOME to build with this Gradle. */
-        ensureJavaHomeMatches.set(true)
+        ensureJavaHomeMatches.setDisallowChanges(true)
 
         /** Ensure we have JAVA_HOME set. */
-        ensureJavaHomeIsSet.set(true)
+        ensureJavaHomeIsSet.setDisallowChanges(true)
 
         /** For now, we just give a heavy-handed warning with a link to our wiki! */
-        failOnError.set(provider { slackProperties.strictJdk })
+        failOnError.setDisallowChanges(provider { slackProperties.strictJdk })
 
         /** Link our wiki page in its messages to get developers up and running. */
-        extraMessage.set(
+        extraMessage.setDisallowChanges(
           "https://github.com/tinyspeck/slack-android-ng/wiki/JDK-Installation-&-JAVA_HOME"
         )
       }

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackTools.kt
@@ -43,6 +43,7 @@ import slack.gradle.agp.AgpHandler
 import slack.gradle.util.JsonTools
 import slack.gradle.util.Thermals
 import slack.gradle.util.ThermalsWatcher
+import slack.gradle.util.setDisallowChanges
 import slack.gradle.util.shutdown
 
 /** Misc tools for Slack Gradle projects, usable in tasks as a [BuildService] too. */
@@ -247,24 +248,24 @@ public abstract class SlackTools : BuildService<Parameters>, AutoCloseable {
     ): Provider<SlackTools> {
       return project.gradle.sharedServices
         .registerIfAbsent(SERVICE_NAME, SlackTools::class.java) {
-          parameters.thermalsOutputFile.set(
+          parameters.thermalsOutputFile.setDisallowChanges(
             project.layout.buildDirectory.file("outputs/logs/last-build-thermals.log")
           )
-          parameters.thermalsOutputJsonFile.set(thermalsLogJsonFileProvider)
-          parameters.offline.set(project.gradle.startParameter.isOffline)
-          parameters.cleanRequested.set(
+          parameters.thermalsOutputJsonFile.setDisallowChanges(thermalsLogJsonFileProvider)
+          parameters.offline.setDisallowChanges(project.gradle.startParameter.isOffline)
+          parameters.cleanRequested.setDisallowChanges(
             project.gradle.startParameter.taskNames.any { it.equals("clean", ignoreCase = true) }
           )
-          parameters.logThermals.set(
+          parameters.logThermals.setDisallowChanges(
             project.provider {
               logThermals && !parameters.cleanRequested.get() && OperatingSystem.current().isMacOsX
             }
           )
-          parameters.enableSkippyDiagnostics.set(enableSkippyDiagnostics)
-          parameters.skippyDiagnosticsOutputFile.set(
+          parameters.enableSkippyDiagnostics.setDisallowChanges(enableSkippyDiagnostics)
+          parameters.skippyDiagnosticsOutputFile.setDisallowChanges(
             project.layout.buildDirectory.file("outputs/logs/skippy-diagnostics.txt")
           )
-          parameters.logVerbosely.set(logVerbosely)
+          parameters.logVerbosely.setDisallowChanges(logVerbosely)
         }
         .apply { get().apply { globalConfig = GlobalConfig(project) } }
     }

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -73,6 +73,7 @@ import slack.gradle.tasks.AndroidTestApksTask
 import slack.gradle.tasks.CheckManifestPermissionsTask
 import slack.gradle.util.booleanProperty
 import slack.gradle.util.configureKotlinCompilationTask
+import slack.gradle.util.setDisallowChanges
 
 private const val LOG = "SlackPlugin:"
 private const val FIVE_MINUTES_MS = 300_000L
@@ -140,7 +141,7 @@ internal class StandardProjectConfigurations(
   @Suppress("unused")
   private fun Project.javaCompilerFor(version: Int): Provider<JavaCompiler> {
     return extensions.getByType<JavaToolchainService>().compilerFor {
-      languageVersion.set(JavaLanguageVersion.of(version))
+      languageVersion.setDisallowChanges(JavaLanguageVersion.of(version))
       slackTools.globalConfig.jvmVendor?.let(vendor::set)
     }
   }
@@ -172,9 +173,10 @@ internal class StandardProjectConfigurations(
           val isNoApi = slackProperties.rakeNoApi
           val rakeDependencies =
             tasks.register<RakeDependencies>("rakeDependencies") {
+              // TODO https://github.com/gradle/gradle/issues/25014
               buildFileProperty.set(project.buildFile)
-              noApi.set(isNoApi)
-              identifierMap.set(
+              noApi.setDisallowChanges(isNoApi)
+              identifierMap.setDisallowChanges(
                 project.provider {
                   project.getVersionsCatalog().identifierMap().mapValues { (_, v) -> "libs.$v" }
                 }
@@ -206,12 +208,12 @@ internal class StandardProjectConfigurations(
     pluginManager.withPlugin("com.sergei-lapin.napt") {
       configure<NaptGradleExtension> {
         // Don't generate triggers, we'll handle ensuring Java files ourselves.
-        generateNaptTrigger.set(false)
+        generateNaptTrigger.setDisallowChanges(false)
 
         // We need to add extra args due to dagger-android running GJF.
         // Can remove once this is fixed or dagger-android's removed.
         // https://github.com/google/dagger/pull/3532
-        forkJvmArgs.set(
+        forkJvmArgs.setDisallowChanges(
           listOf(
             "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
             "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
@@ -283,7 +285,7 @@ internal class StandardProjectConfigurations(
         tasks.configureEach<JavaCompile> {
           if (!isAndroid) {
             logger.logWithTag("Configuring release option for $path")
-            options.release.set(jvmTargetVersion)
+            options.release.setDisallowChanges(jvmTargetVersion)
           }
         }
       }
@@ -303,9 +305,9 @@ internal class StandardProjectConfigurations(
       if (!isAndroid) {
         val target = if (isAndroid) jvmTargetVersion else jdkVersion
         logger.logWithTag("Configuring toolchain for $path to $jdkVersion")
-        javaCompiler.set(
+        javaCompiler.setDisallowChanges(
           javaToolchains.compilerFor {
-            languageVersion.set(JavaLanguageVersion.of(target))
+            languageVersion.setDisallowChanges(JavaLanguageVersion.of(target))
             slackTools.globalConfig.jvmVendor?.let(vendor::set)
           }
         )
@@ -339,13 +341,15 @@ internal class StandardProjectConfigurations(
             CheckSeverity.ERROR
           }
         options.errorprone.nullaway {
-          severity.set(nullAwaySeverity)
+          severity.setDisallowChanges(nullAwaySeverity)
           annotatedPackages.add("slack")
-          checkOptionalEmptiness.set(true)
+          checkOptionalEmptiness.setDisallowChanges(true)
           if (autoPatchEnabled && nullawayBaseline) {
-            suggestSuppressions.set(true)
-            autoFixSuppressionComment.set("Nullability issue auto-patched by NullAway.")
-            castToNonNullMethod.set("slack.commons.JavaPreconditions.castToNotNull")
+            suggestSuppressions.setDisallowChanges(true)
+            autoFixSuppressionComment.setDisallowChanges(
+              "Nullability issue auto-patched by NullAway."
+            )
+            castToNonNullMethod.setDisallowChanges("slack.commons.JavaPreconditions.castToNotNull")
           }
         }
       }
@@ -357,8 +361,10 @@ internal class StandardProjectConfigurations(
 
       tasks.withType(JavaCompile::class.java).configureEach {
         options.errorprone {
-          disableWarningsInGeneratedCode.set(true)
-          excludedPaths.set(".*/build/generated/.*") // The EP flag alone isn't enough
+          disableWarningsInGeneratedCode.setDisallowChanges(true)
+          excludedPaths.setDisallowChanges(
+            ".*/build/generated/.*"
+          ) // The EP flag alone isn't enough
           // https://github.com/google/error-prone/issues/2092
           disable("HidingField")
           error(*slackTools().globalConfig.errorProneCheckNamesAsErrors.toTypedArray())
@@ -617,8 +623,9 @@ internal class StandardProjectConfigurations(
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             description =
               "Checks merged manifest permissions against a known allowlist of permissions."
+            // TODO switch to setDisallowChanges once this uses a regular file
             permissionAllowlistFile.set(file)
-            permissionAllowlist.set(allowListProvider)
+            permissionAllowlist.setDisallowChanges(allowListProvider)
           }
         }
 
@@ -649,18 +656,18 @@ internal class StandardProjectConfigurations(
             }
 
             // 5 minute timeout because let's be real, if it's taking this long something is wrong
-            requestTimeoutMs.set(FIVE_MINUTES_MS)
+            requestTimeoutMs.setDisallowChanges(FIVE_MINUTES_MS)
 
             // Enable uploads if the enable prop is enabled or the branch matches a provided pattern
             // Note we _don't_ use the BugsnagPluginExtension.enabled property itself because we do
             // want bugsnag to do most of its regular process, just skipping uploads unless enabled.
-            uploadJvmMappings.set(enabledProvider)
-            reportBuilds.set(enabledProvider)
+            uploadJvmMappings.setDisallowChanges(enabledProvider)
+            reportBuilds.setDisallowChanges(enabledProvider)
 
             // We don't use these
-            uploadNdkMappings.set(false)
-            uploadNdkUnityLibraryMappings.set(false)
-            uploadReactNativeMappings.set(false)
+            uploadNdkMappings.setDisallowChanges(false)
+            uploadNdkUnityLibraryMappings.setDisallowChanges(false)
+            uploadReactNativeMappings.setDisallowChanges(false)
           }
         }
       }
@@ -824,7 +831,7 @@ internal class StandardProjectConfigurations(
         kotlinDaemonJvmArgs = slackTools.globalConfig.kotlinDaemonArgs
         if (jdkVersion != null) {
           jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of(jdkVersion))
+            languageVersion.setDisallowChanges(JavaLanguageVersion.of(jdkVersion))
             slackTools.globalConfig.jvmVendor?.let(vendor::set)
           }
         }
@@ -837,14 +844,14 @@ internal class StandardProjectConfigurations(
 
         compilerOptions {
           if (!slackProperties.allowWarnings && !name.contains("test", ignoreCase = true)) {
-            allWarningsAsErrors.set(true)
+            allWarningsAsErrors.setDisallowChanges(true)
           }
           if (!isKaptGenerateStubsTask) {
             freeCompilerArgs.addAll(kotlinCompilerArgs)
           }
 
           if (slackProperties.useK2) {
-            languageVersion.set(KotlinVersion.fromVersion("2.0"))
+            languageVersion.setDisallowChanges(KotlinVersion.fromVersion("2.0"))
           }
 
           if (slackExtension.featuresHandler.composeHandler.enabled.get()) {
@@ -871,9 +878,9 @@ internal class StandardProjectConfigurations(
           }
 
           if (this is KotlinJvmCompilerOptions) {
-            jvmTarget.set(JvmTarget.fromTarget(actualJvmTarget))
+            jvmTarget.setDisallowChanges(JvmTarget.fromTarget(actualJvmTarget))
             // Potentially useful for static analysis or annotation processors
-            javaParameters.set(true)
+            javaParameters.setDisallowChanges(true)
             freeCompilerArgs.addAll(KotlinBuildConfig.kotlinJvmCompilerArgs)
           }
         }

--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
@@ -39,6 +39,7 @@ import slack.gradle.avoidance.AffectedProjectsDefaults.DEFAULT_INCLUDE_PATTERNS
 import slack.gradle.avoidance.AffectedProjectsDefaults.DEFAULT_NEVER_SKIP_PATTERNS
 import slack.gradle.setProperty
 import slack.gradle.util.SgpLogger
+import slack.gradle.util.setDisallowChanges
 
 /**
  * ### Usage
@@ -233,12 +234,16 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
         "computeAffectedProjects",
         ComputeAffectedProjectsTask::class.java
       ) {
-        debug.set(slackProperties.debug)
-        rootDir.set(project.layout.projectDirectory)
-        dependencyGraph.set(rootProject.provider { moduleGraph })
-        diagnosticsDir.set(project.layout.buildDirectory.dir("skippy/diagnostics"))
-        outputFile.set(project.layout.buildDirectory.file("skippy/affected_projects.txt"))
-        outputFocusFile.set(project.layout.buildDirectory.file("skippy/focus.settings.gradle"))
+        debug.setDisallowChanges(slackProperties.debug)
+        rootDir.setDisallowChanges(project.layout.projectDirectory)
+        dependencyGraph.setDisallowChanges(rootProject.provider { moduleGraph })
+        diagnosticsDir.setDisallowChanges(project.layout.buildDirectory.dir("skippy/diagnostics"))
+        outputFile.setDisallowChanges(
+          project.layout.buildDirectory.file("skippy/affected_projects.txt")
+        )
+        outputFocusFile.setDisallowChanges(
+          project.layout.buildDirectory.file("skippy/focus.settings.gradle")
+        )
         // Overrides of includes/neverSkippable patterns should be done in the consuming project
         // directly
       }

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/DetektTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/DetektTasks.kt
@@ -19,8 +19,8 @@ import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import java.io.File
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -31,6 +31,7 @@ import slack.gradle.isRootProject
 import slack.gradle.register
 import slack.gradle.tasks.DetektDownloadTask
 import slack.gradle.tasks.detektbaseline.MergeDetektBaselinesTask
+import slack.gradle.util.setDisallowChanges
 import slack.gradle.util.sneakyNull
 
 internal object DetektTasks {
@@ -44,8 +45,8 @@ internal object DetektTasks {
     // Add detekt download task
     slackProperties.versions.detekt?.let { detektVersion ->
       project.tasks.register<DetektDownloadTask>("updateDetekt") {
-        version.set(detektVersion)
-        outputFile.set(project.layout.projectDirectory.file("config/bin/detekt"))
+        version.setDisallowChanges(detektVersion)
+        outputFile.setDisallowChanges(project.layout.projectDirectory.file("config/bin/detekt"))
       }
 
       project.tasks.register(GLOBAL_CI_DETEKT_TASK_NAME) {
@@ -112,12 +113,14 @@ internal object DetektTasks {
       project.tasks.configureEach<Detekt> {
         this.jvmTarget = jvmTarget
         exclude("**/build/**")
-        jdkHome.set(sneakyNull<File>())
+        // Cannot use setDisallowChanges because this property is set without a convention in Detekt
+        jdkHome.set(sneakyNull<Directory>())
       }
       project.tasks.configureEach<DetektCreateBaselineTask> {
         this.jvmTarget = jvmTarget
         exclude("**/build/**")
-        jdkHome.set(sneakyNull<File>())
+        // Cannot use setDisallowChanges because this property is set without a convention in Detekt
+        jdkHome.set(sneakyNull<Directory>())
       }
 
       // Wire up to the global task

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/AndroidTestApksTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/AndroidTestApksTask.kt
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import slack.gradle.register
+import slack.gradle.util.setDisallowChanges
 
 /**
  * A task that aggregates all the androidTest apk paths and writes them (newline-delimited) to an
@@ -69,7 +70,7 @@ public abstract class AndroidTestApksTask : DefaultTask() {
 
     internal fun register(project: Project): TaskProvider<AndroidTestApksTask> {
       return project.tasks.register<AndroidTestApksTask>(NAME) {
-        outputFile.set(
+        outputFile.setDisallowChanges(
           project.layout.buildDirectory.file("slack/androidTestAggregator/aggregatedTestApks.txt")
         )
       }

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
@@ -64,6 +64,7 @@ import slack.gradle.tasks.BootstrapPropertiesMode.LOG
 import slack.gradle.tasks.BootstrapUtils.DaemonArgsProvider
 import slack.gradle.tasks.BootstrapUtils.computeDaemonArgs
 import slack.gradle.util.mapToInt
+import slack.gradle.util.setDisallowChanges
 
 /**
  * Other bootstrap tasks can be finalized by this and/or depend on its outputs by implementing this
@@ -345,9 +346,11 @@ constructor(objects: ObjectFactory, providers: ProviderFactory) : DefaultTask() 
           val jdkVersion = project.jdkVersion()
           val service = project.serviceOf<JavaToolchainService>()
           val defaultLauncher =
-            service.launcherFor { languageVersion.set(JavaLanguageVersion.of(jdkVersion)) }
+            service.launcherFor {
+              languageVersion.setDisallowChanges(JavaLanguageVersion.of(jdkVersion))
+            }
           this.launcher.convention(defaultLauncher)
-          this.jdkVersion.set(jdkVersion)
+          this.jdkVersion.setDisallowChanges(jdkVersion)
 
           val cacheDirProvider = project.layout.projectDirectory.dir(".cache")
           val bootstrapVersionFileProvider = cacheDirProvider.file("bootstrap.txt")
@@ -358,16 +361,18 @@ constructor(objects: ObjectFactory, providers: ProviderFactory) : DefaultTask() 
             } else {
               -1
             }
-          bootstrapVersion.set(version)
-          bootstrapVersionFileProperty.set(bootstrapVersionFileProvider)
-          diagnostics.set(project.layout.buildDirectory.file("bootstrap/diagnostics.txt"))
-          javaInstallationPath.set(
+          bootstrapVersion.setDisallowChanges(version)
+          bootstrapVersionFileProperty.setDisallowChanges(bootstrapVersionFileProvider)
+          diagnostics.setDisallowChanges(
+            project.layout.buildDirectory.file("bootstrap/diagnostics.txt")
+          )
+          javaInstallationPath.setDisallowChanges(
             project.layout.buildDirectory.file("bootstrap/javaInstallation.txt")
           )
-          cacheDir.set(cacheDirProvider)
-          offlineBooleanProperty.set(project.gradle.startParameter.isOffline)
+          cacheDir.setDisallowChanges(cacheDirProvider)
+          offlineBooleanProperty.setDisallowChanges(project.gradle.startParameter.isOffline)
           val gradleHome = project.gradle.gradleUserHomeDir
-          ciBooleanProperty.set(project.isCi)
+          ciBooleanProperty.setDisallowChanges(project.isCi)
 
           // TODO for profiler, we want to set these to the local properties + append
           val propertiesFileProvider: () -> File = {
@@ -378,7 +383,7 @@ constructor(objects: ObjectFactory, providers: ProviderFactory) : DefaultTask() 
               .get()
           }
           gradlePropertiesFile.set(propertiesFileProvider)
-          propertiesMode.set(
+          propertiesMode.setDisallowChanges(
             project.providers
               .gradleProperty(Properties.PROPERTIES_MODE)
               .map { BootstrapPropertiesMode.valueOf(it.uppercase(Locale.US)) }

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/CheckDependencyVersionsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/CheckDependencyVersionsTask.kt
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.TaskProvider
 import slack.gradle.capitalizeUS
 import slack.gradle.getVersionsCatalog
 import slack.gradle.register
+import slack.gradle.util.setDisallowChanges
 
 /**
  * A task that checks expected versions (from [mappedIdentifiersToVersions]) against runtime
@@ -90,7 +91,7 @@ public abstract class CheckDependencyVersionsTask : BaseDependencyCheckTask() {
         "check${name.capitalizeUS()}Versions"
       ) {
         configureIdentifiersToVersions(configuration)
-        outputFile.set(
+        outputFile.setDisallowChanges(
           project.layout.buildDirectory.file(
             "reports/slack/dependencyVersionsIssues/$name/issues.txt"
           )

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/PrintFossaDependencies.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/PrintFossaDependencies.kt
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskProvider
 import slack.gradle.capitalizeUS
 import slack.gradle.register
+import slack.gradle.util.setDisallowChanges
 
 /**
  * A task that writes runtime dependency info found in [identifiersToVersions].
@@ -69,7 +70,9 @@ public abstract class PrintFossaDependencies : BaseDependencyCheckTask() {
       return project.tasks.register<PrintFossaDependencies>(
         "print${name.capitalizeUS()}FossaDependencies"
       ) {
-        outputFile.set(project.layout.buildDirectory.file("reports/slack/fossa/$name.txt"))
+        outputFile.setDisallowChanges(
+          project.layout.buildDirectory.file("reports/slack/fossa/$name.txt")
+        )
         configureIdentifiersToVersions(configuration)
       }
     }

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/robolectric/UpdateRobolectricJarsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/robolectric/UpdateRobolectricJarsTask.kt
@@ -40,6 +40,7 @@ import org.gradle.workers.WorkerExecutor
 import slack.gradle.property
 import slack.gradle.tasks.BootstrapTask
 import slack.gradle.util.mapToBoolean
+import slack.gradle.util.setDisallowChanges
 import slack.gradle.util.shutdown
 
 /**
@@ -151,7 +152,7 @@ constructor(
         }
         destinationFile.createNewFile()
         workQueue.submit(DownloadJarAction::class.java) {
-          this.dependencyJar.set(dependencyJar)
+          this.dependencyJar.setDisallowChanges(dependencyJar)
           this.destinationFile.set(destinationFile)
         }
       }

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/HasConfigurableValues.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/HasConfigurableValues.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.util
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+
+/*
+ * APIs adapted from `HasConfigurableValues.kt` in AGP. Copied for binary safety.
+ */
+
+internal fun ConfigurableFileCollection.fromDisallowChanges(vararg arg: Any) {
+  from(*arg)
+  disallowChanges()
+}
+
+internal fun <T> Property<T>.setDisallowChanges(value: T?) {
+  set(value)
+  disallowChanges()
+}
+
+internal fun <T> Property<T>.setDisallowChanges(value: Provider<out T>) {
+  set(value)
+  disallowChanges()
+}
+
+internal fun <T> ListProperty<T>.setDisallowChanges(value: Provider<out Iterable<T>>) {
+  set(value)
+  disallowChanges()
+}
+
+internal fun <T> ListProperty<T>.setDisallowChanges(value: Iterable<T>?) {
+  set(value)
+  disallowChanges()
+}
+
+internal fun <K, V> MapProperty<K, V>.setDisallowChanges(map: Provider<Map<K, V>>) {
+  set(map)
+  disallowChanges()
+}
+
+internal fun <K, V> MapProperty<K, V>.setDisallowChanges(map: Map<K, V>?) {
+  set(map)
+  disallowChanges()
+}
+
+internal fun <T> SetProperty<T>.setDisallowChanges(value: Provider<out Iterable<T>>) {
+  set(value)
+  disallowChanges()
+}
+
+internal fun <T> SetProperty<T>.setDisallowChanges(value: Iterable<T>?) {
+  set(value)
+  disallowChanges()
+}
+
+internal fun <T> ListProperty<T>.setDisallowChanges(
+  value: Provider<out Iterable<T>>?,
+  handleNullable: ListProperty<T>.() -> Unit
+) {
+  value?.let { set(value) } ?: handleNullable()
+  disallowChanges()
+}
+
+internal fun <K, V> MapProperty<K, V>.setDisallowChanges(
+  map: Provider<Map<K, V>>?,
+  handleNullable: MapProperty<K, V>.() -> Unit
+) {
+  map?.let { set(map) } ?: handleNullable()
+  disallowChanges()
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/PropertyUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/PropertyUtil.kt
@@ -99,7 +99,7 @@ private fun Project.startParameterProperties(key: String): Provider<String> {
     project.rootProject.getOrCreateExtra("slack.properties.provider.start-properties") {
       val startParameters = project.gradle.startParameter.projectProperties
       it.providers.of(StartParameterProperties::class.java) {
-        parameters.properties.set(startParameters)
+        parameters.properties.setDisallowChanges(startParameters)
       }
     }
   return provider.map { sneakyNull(it[key]) }
@@ -126,7 +126,9 @@ private fun Project.localPropertiesProvider(
 /** Returns a provider of a property _only_ contained in this project's local.properties. */
 internal fun Project.localProperty(key: String): Provider<String> {
   return localPropertiesProvider(key, "slack.properties.provider.local-properties") {
-    parameters.propertiesFile.set(project.layout.projectDirectory.file("local.properties"))
+    parameters.propertiesFile.setDisallowChanges(
+      project.layout.projectDirectory.file("local.properties")
+    )
   }
 }
 
@@ -136,7 +138,9 @@ internal fun Project.localProperty(key: String): Provider<String> {
 // providers.gradleProperty -_-. https://github.com/gradle/gradle/issues/13302
 internal fun Project.localGradleProperty(key: String): Provider<String> {
   return localPropertiesProvider(key, "slack.properties.provider.local-gradle-properties") {
-    parameters.propertiesFile.set(project.layout.projectDirectory.file("gradle.properties"))
+    parameters.propertiesFile.setDisallowChanges(
+      project.layout.projectDirectory.file("gradle.properties")
+    )
   }
 }
 

--- a/slack-plugin/src/main/kotlin/slack/stats/ModuleStats.kt
+++ b/slack-plugin/src/main/kotlin/slack/stats/ModuleStats.kt
@@ -64,6 +64,7 @@ import slack.gradle.namedLazy
 import slack.gradle.register
 import slack.gradle.util.JsonTools
 import slack.gradle.util.mapToBoolean
+import slack.gradle.util.setDisallowChanges
 
 public object ModuleStatsTasks {
   public const val AGGREGATOR_NAME: String = "aggregateModuleStats"
@@ -86,8 +87,10 @@ public object ModuleStatsTasks {
     val includeGenerated = rootProject.includeGenerated()
 
     rootProject.tasks.register<ModuleStatsAggregatorTask>(AGGREGATOR_NAME) {
-      outputFile.set(rootProject.layout.buildDirectory.file("reports/slack/moduleStats.json"))
-      this.includeGenerated.set(includeGenerated)
+      outputFile.setDisallowChanges(
+        rootProject.layout.buildDirectory.file("reports/slack/moduleStats.json")
+      )
+      this.includeGenerated.setDisallowChanges(includeGenerated)
     }
   }
 
@@ -113,8 +116,10 @@ public object ModuleStatsTasks {
         null
       } else {
         project.tasks.register<LocTask>("loc") {
-          srcsDir.set(project.layout.projectDirectory.dir("src/$mainSrcDir"))
-          outputFile.set(project.layout.buildDirectory.file("reports/slack/loc.json"))
+          srcsDir.setDisallowChanges(project.layout.projectDirectory.dir("src/$mainSrcDir"))
+          outputFile.setDisallowChanges(
+            project.layout.buildDirectory.file("reports/slack/loc.json")
+          )
         }
       }
 
@@ -126,13 +131,16 @@ public object ModuleStatsTasks {
     val moduleStatsCollector: Lazy<TaskProvider<ModuleStatsCollectorTask>> = lazy {
       val task =
         project.tasks.register<ModuleStatsCollectorTask>("moduleStats") {
-          modulePath.set(project.path)
+          modulePath.setDisallowChanges(project.path)
+          // TODO https://github.com/gradle/gradle/issues/25014
           buildFileProperty.set(project.buildFile)
           if (locTask != null) {
             locDataFiles.from(locTask.flatMap { it.outputFile })
           }
-          this.includeGenerated.set(includeGenerated)
-          outputFile.set(project.layout.buildDirectory.file("reports/slack/moduleStats.json"))
+          this.includeGenerated.setDisallowChanges(includeGenerated)
+          outputFile.setDisallowChanges(
+            project.layout.buildDirectory.file("reports/slack/moduleStats.json")
+          )
         }
 
       val aggregatorTask =
@@ -153,7 +161,9 @@ public object ModuleStatsTasks {
     val generatedSourcesAdded = AtomicBoolean()
     val addGeneratedSources = {
       if (locTask != null && generatedSourcesAdded.compareAndSet(false, true)) {
-        locTask.configure { generatedSrcsDir.set(project.layout.buildDirectory.dir("generated")) }
+        locTask.configure {
+          generatedSrcsDir.setDisallowChanges(project.layout.buildDirectory.dir("generated"))
+        }
       }
     }
 

--- a/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
+++ b/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
@@ -31,6 +31,7 @@ import slack.gradle.ciUnitTestAndroidVariant
 import slack.gradle.configureEach
 import slack.gradle.isActionsCi
 import slack.gradle.isCi
+import slack.gradle.util.setDisallowChanges
 import slack.gradle.util.synchronousEnvProperty
 
 /**
@@ -167,7 +168,7 @@ internal object UnitTests {
         maxForks(slackProperties).also { logger.debug("$LOG Setting maxParallelForks to $it") }
 
       // Denote flaky failures as <flakyFailure> instead of <failure> in JUnit test XML files
-      reports.junitXml.mergeReruns.set(true)
+      reports.junitXml.mergeReruns.setDisallowChanges(true)
 
       /*
        * Much of the below is to improve memory management on CI
@@ -237,9 +238,11 @@ internal object UnitTests {
         project.pluginManager.withPlugin("org.gradle.test-retry") {
           project.tasks.withType(Test::class.java).configureEach {
             retry {
-              failOnPassedAfterRetry.set(slackProperties.testRetryFailOnPassedAfterRetry)
-              maxFailures.set(slackProperties.testRetryMaxFailures)
-              maxRetries.set(slackProperties.testRetryMaxRetries)
+              failOnPassedAfterRetry.setDisallowChanges(
+                slackProperties.testRetryFailOnPassedAfterRetry
+              )
+              maxFailures.setDisallowChanges(slackProperties.testRetryMaxFailures)
+              maxRetries.setDisallowChanges(slackProperties.testRetryMaxRetries)
             }
           }
         }
@@ -247,9 +250,11 @@ internal object UnitTests {
         // TODO eventually expose if GE was enabled in settings via our own settings plugin?
         project.tasks.withType(Test::class.java).configureEach {
           geRetry {
-            failOnPassedAfterRetry.set(slackProperties.testRetryFailOnPassedAfterRetry)
-            maxFailures.set(slackProperties.testRetryMaxFailures)
-            maxRetries.set(slackProperties.testRetryMaxRetries)
+            failOnPassedAfterRetry.setDisallowChanges(
+              slackProperties.testRetryFailOnPassedAfterRetry
+            )
+            maxFailures.setDisallowChanges(slackProperties.testRetryMaxFailures)
+            maxRetries.setDisallowChanges(slackProperties.testRetryMaxRetries)
           }
         }
       }


### PR DESCRIPTION
This API helps us prevent misconfigured build files by ensuring properties we want to control are only set once and error if they're attempted to set again.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->