### PR TITLE
Use ExitOnOutOfMemoryError for OOMs

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
@@ -242,9 +242,9 @@ constructor(objects: ObjectFactory, providers: ProviderFactory) : DefaultTask() 
     val properties =
       mutableMapOf(
         "org.gradle.jvmargs" to
-          "-Duser.country=US -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError ${gradleArgs.args.joinToString(" ")}",
+          "-Duser.country=US -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError ${gradleArgs.args.joinToString(" ")}",
         SlackProperties.KOTLIN_DAEMON_ARGS_KEY to
-          "-Duser.country=US -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError ${kotlinArgs.args.joinToString(" ")}",
+          "-Duser.country=US -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError ${kotlinArgs.args.joinToString(" ")}",
       )
 
     // To reduce thermal throttling, we cap max workers on Intel mac devices


### PR DESCRIPTION
heap dumps by default take up people's space and aren't really actionable, we can debug these ad-hoc when they happen

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->