### PR TITLE
Improve unit test OOM handling

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
+++ b/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
@@ -222,13 +222,13 @@ internal object UnitTests {
             else -> project.rootProject.projectDir.absolutePath
           }
         jvmArgs(
-          "-XX:+HeapDumpOnOutOfMemoryError",
+          "-XX:+HeapDumpOnOutOfMemoryError", // Produce a heap dump when an OOM occurs
+          "-XX:+CrashOnOutOfMemoryError", // Produce a crash report when an OOM occurs
           "-XX:+UseGCOverheadLimit",
           "-XX:GCHeapFreeLimit=10",
           "-XX:GCTimeLimit=20",
           "-XX:HeapDumpPath=$workspaceDir/fs_oom_err_pid<pid>.hprof",
-          "-XX:OnError=cat $workspaceDir/fs_oom.log",
-          "-XX:OnOutOfMemoryError=cat $workspaceDir/fs_oom_err_pid<pid>.hprof",
+          "-XX:ErrorFile=$workspaceDir/fs_oom_err_pid<pid>.log",
         )
       }
     }


### PR DESCRIPTION
- Write a crash log on failure via CrashOnOutOfMemoryError
- Don't try to cat the log and hprof files
- Write crash log to same location

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->