### PR TITLE
Allow CHANGELOG.md file to be read into skate plugin

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
@@ -29,8 +29,13 @@ interface SkateProjectService {
 class SkateProjectServiceImpl(private val project: Project) : SkateProjectService {
 
   override fun showWhatsNewWindow() {
-    val changeLogFile = VfsUtil.findRelativeFile(project.guessProjectDir(), "CHANGELOG.md")
-    val changeLogString = VfsUtil.loadText(changeLogFile!!)
+    // TODO
+    //  Make the file configurable?
+    //  Only show when changed
+    //  Only show latest changes
+    val projectDir = project.guessProjectDir() ?: return
+    val changeLogFile = VfsUtil.findRelativeFile(projectDir, "CHANGELOG.md") ?: return
+    val changeLogString = VfsUtil.loadText(changeLogFile)
     val toolWindowManager = ToolWindowManager.getInstance(project)
     toolWindowManager.invokeLater {
       val toolWindow =

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
@@ -16,6 +16,8 @@
 package com.slack.sgp.intellij
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowManager
 import java.util.function.Supplier
@@ -27,6 +29,8 @@ interface SkateProjectService {
 class SkateProjectServiceImpl(private val project: Project) : SkateProjectService {
 
   override fun showWhatsNewWindow() {
+    val changeLogFile = VfsUtil.findRelativeFile(project.guessProjectDir(), "CHANGELOG.md")
+    val changeLogString = VfsUtil.loadText(changeLogFile!!)
     val toolWindowManager = ToolWindowManager.getInstance(project)
     toolWindowManager.invokeLater {
       val toolWindow =
@@ -34,7 +38,7 @@ class SkateProjectServiceImpl(private val project: Project) : SkateProjectServic
           stripeTitle = Supplier { "What's New in Slack!" }
           anchor = ToolWindowAnchor.RIGHT
         }
-      WhatsNewPanelFactory().createToolWindowContent(toolWindow, project.name)
+      WhatsNewPanelFactory().createToolWindowContent(toolWindow, changeLogString)
       toolWindow.show()
     }
   }


### PR DESCRIPTION
This shows a CHANGELOG.md file from the root directory and displays it into the "What's New" Panel of the skate plugin. 

Also made it nullable safe.
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->