### PR TITLE
WIP Add option to use relative paths in android test APKs

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -18,6 +18,7 @@ package slack.gradle
 import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import slack.gradle.tasks.AndroidTestApksTask
 import slack.gradle.util.booleanProperty
 import slack.gradle.util.booleanProvider
 import slack.gradle.util.getOrCreateExtra
@@ -232,6 +233,10 @@ public class SlackProperties private constructor(private val project: Project) {
       booleanProperty(
         "slack.test.verboseLogging",
       ) || verboseLogging
+
+  /** Flag to control writing relative paths in [AndroidTestApksTask]. */
+  public val useRelativePathsInAndroidTestApksFile: Provider<Boolean>
+    get() = project.booleanProvider("slack.test.androidTestApks.useRelativePaths", false)
 
   /**
    * Flag to enable kapt in tests. By default these are disabled due to this undesirable (but

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -355,7 +355,7 @@ internal class SlackRootPlugin : Plugin<Project> {
       }
     }
 
-    AndroidTestApksTask.register(project)
+    AndroidTestApksTask.register(project, slackProperties)
   }
 
   private fun isStable(version: String): Boolean {


### PR DESCRIPTION
This allows them to be generated in one machine and usable in another

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->