### PR TITLE
Remove strict kt file checking

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -496,10 +496,6 @@ public class SlackProperties private constructor(private val project: Project) {
   public val strictMode: Boolean
     get() = booleanProperty("slack.strict", defaultValue = false)
 
-  /** Specific toggle for validating the presence of `.kt` files in Kotlin projects. */
-  public val strictValidateKtFilePresence: Boolean
-    get() = booleanProperty("slack.strict.validateKtFiles", defaultValue = true)
-
   /** Specific toggle for validating manifests in androidTest sources. */
   public val strictValidateAndroidTestManifest: Boolean
     get() = booleanProperty("slack.strict.validateAndroidTestManifests", defaultValue = true)

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackRootPlugin.kt
@@ -39,10 +39,12 @@ import slack.gradle.tasks.InstallCommitHooksTask
 import slack.gradle.tasks.KtLintDownloadTask
 import slack.gradle.tasks.KtfmtDownloadTask
 import slack.gradle.tasks.SortDependenciesDownloadTask
-import slack.gradle.util.*
 import slack.gradle.util.JsonTools
+import slack.gradle.util.Thermals
+import slack.gradle.util.ThermalsData
 import slack.gradle.util.gitExecProvider
 import slack.gradle.util.gitVersionProvider
+import slack.gradle.util.setDisallowChanges
 import slack.stats.ModuleStatsTasks
 import slack.unittest.UnitTests
 


### PR DESCRIPTION
This is no longer necessary with the new kotlin IC. Includes a couple other cleanups opportunistically

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->