### PR TITLE
Switch to using detached configurations for robolectric jar downloads

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/robolectric/Sdk.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/robolectric/Sdk.kt
@@ -52,6 +52,9 @@ internal sealed class Sdk : Comparable<Sdk> {
   /** The actual dependency jar to fetch. */
   abstract fun dependencyJar(): DependencyJar
 
+  /** The actual dependency coordinates to fetch. */
+  abstract val dependencyCoordinates: String
+
   /** Instances of `Sdk` are ordered by the API level they implement. */
   override fun compareTo(other: Sdk): Int {
     return apiLevel - other.apiLevel
@@ -71,9 +74,16 @@ internal data class DefaultSdk(
   private val requiredJavaVersion: Int,
   private val iVersion: Int
 ) : Sdk() {
-  override fun dependencyJar(): DependencyJar {
-    val version =
-      listOf(androidVersion, "robolectric", robolectricVersion, "i$iVersion").joinToString("-")
-    return DependencyJar("org.robolectric", "android-all-instrumented", version, null)
+  companion object {
+    private const val GROUP_ID = "org.robolectric"
+    private const val ARTIFACT_ID = "android-all-instrumented"
   }
+
+  private val version = "$androidVersion-robolectric-$robolectricVersion-i$iVersion"
+
+  override fun dependencyJar(): DependencyJar {
+    return DependencyJar(GROUP_ID, ARTIFACT_ID, version, null)
+  }
+
+  override val dependencyCoordinates = "$GROUP_ID:$ARTIFACT_ID:$version"
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/robolectric/UpdateRobolectricJarsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/robolectric/UpdateRobolectricJarsTask.kt
@@ -16,32 +16,19 @@
 package slack.gradle.tasks.robolectric
 
 import java.io.File
-import java.io.IOException
-import java.util.concurrent.TimeUnit
-import javax.inject.Inject
-import okhttp3.ConnectionPool
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okio.buffer
-import okio.sink
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.ProviderFactory
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.UntrackedTask
-import org.gradle.workers.WorkAction
-import org.gradle.workers.WorkParameters
-import org.gradle.workers.WorkerExecutor
-import slack.gradle.property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
+import slack.gradle.SlackProperties
+import slack.gradle.register
+import slack.gradle.robolectricJars
 import slack.gradle.tasks.BootstrapTask
-import slack.gradle.util.mapToBoolean
 import slack.gradle.util.setDisallowChanges
-import slack.gradle.util.shutdown
 
 /**
  * Updates the Robolectric android-all jars. Is declared as a task dependency of all
@@ -51,72 +38,30 @@ import slack.gradle.util.shutdown
  * existing ones.
  */
 @UntrackedTask(because = "State for this is handled elsewhere.")
-internal abstract class UpdateRobolectricJarsTask
-@Inject
-constructor(
-  private val workerExecutor: WorkerExecutor,
-  objects: ObjectFactory,
-  providers: ProviderFactory,
-) : DefaultTask(), BootstrapTask {
+internal abstract class UpdateRobolectricJarsTask : DefaultTask(), BootstrapTask {
 
-  @get:Internal
-  val forceReDownload =
-    objects
-      .property<Boolean>()
-      .convention(
-        providers
-          .environmentVariable("SLACK_FORCE_REDOWNLOAD_ROBOLECTRIC_JARS")
-          .mapToBoolean()
-          .orElse(false)
-      )
-
-  @get:Internal abstract val sdkVersions: ListProperty<Int>
-
-  @get:Internal abstract val instrumentedVersion: Property<Int>
+  /**
+   * This needs to use [InputFiles] and [PathSensitivity.ABSOLUTE] because the path to the jars
+   * really does matter here. Using [Classpath] is an error, as it looks only at content and not
+   * name or path, and we really do need to know the actual path to the artifact, even if its
+   * contents haven't changed.
+   */
+  @get:PathSensitive(PathSensitivity.ABSOLUTE)
+  @get:InputFiles
+  abstract val allJars: ListProperty<File>
 
   @get:Internal abstract val outputDir: DirectoryProperty
-
-  @get:Internal abstract val offline: Property<Boolean>
-
-  @get:Internal
-  internal val allSdks by lazy {
-    val iVersion = instrumentedVersion.get()
-    // Sourced from
-    // https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
-    listOf(
-        DefaultSdk(21, "5.0.2_r3", "r0", "REL", 8, iVersion),
-        DefaultSdk(22, "5.1.1_r9", "r2", "REL", 8, iVersion),
-        DefaultSdk(23, "6.0.1_r3", "r1", "REL", 8, iVersion),
-        DefaultSdk(24, "7.0.0_r1", "r1", "REL", 8, iVersion),
-        DefaultSdk(25, "7.1.0_r7", "r1", "REL", 8, iVersion),
-        DefaultSdk(26, "8.0.0_r4", "r1", "REL", 8, iVersion),
-        DefaultSdk(27, "8.1.0", "4611349", "REL", 8, iVersion),
-        DefaultSdk(28, "9", "4913185-2", "REL", 8, iVersion),
-        DefaultSdk(29, "10", "5803371", "REL", 9, iVersion),
-        DefaultSdk(30, "11", "6757853", "REL", 9, iVersion),
-        DefaultSdk(31, "12", "7732740", "REL", 9, iVersion),
-        DefaultSdk(32, "12.1", "8229987", "REL", 9, iVersion),
-        DefaultSdk(33, "13", "9030017", "Tiramisu", 9, iVersion),
-      )
-      .associateBy { it.apiLevel }
-  }
 
   init {
     group = "slack"
     description = "Downloads the Robolectric android-all jars."
   }
 
-  internal fun sdkFor(version: Int): Sdk {
-    return allSdks[version] ?: error("No robolectric jar coordinates found for $version.")
-  }
-
   @TaskAction
   fun download() {
-    val workQueue = workerExecutor.noIsolation()
     val destinationDir = outputDir.asFile.get()
-    val versions = sdkVersions.get()
 
-    logger.debug("$TAG Downloading robolectric jars")
+    logger.debug("$TAG Copying downloaded robolectric jars")
     destinationDir.apply {
       if (!exists()) {
         mkdirs()
@@ -126,87 +71,91 @@ constructor(
     // Track jars we currently have to which ones we try to download. At the end, we'll delete any
     // we don't want.
     val existingJars = jarsIn(destinationDir).associateByTo(LinkedHashMap(), File::getName)
-    val forceReDownload = forceReDownload.get()
-
-    for (version in versions) {
-      val sdk = sdkFor(version)
-      val dependencyJar = sdk.dependencyJar()
-      val jarName = dependencyJar.name
-      existingJars.remove(jarName)
-      val destinationFile = File(destinationDir, jarName)
-      val exists = destinationFile.exists()
-      if (exists && !forceReDownload) {
-        logger.debug("$TAG Skipping $jarName, already downloaded 👍.")
-        continue
+    for (jarToCopy in allJars.get()) {
+      existingJars.remove(jarToCopy.name)
+      val destinationFile = File(destinationDir, jarToCopy.name)
+      if (destinationFile.exists()) {
+        logger.debug("$TAG Skipping $jarToCopy, already copied 👍.")
       } else {
-        if (exists) {
-          logger.lifecycle("$TAG Re-downloading $jarName from Maven Central.")
-        } else {
-          logger.lifecycle("$TAG Downloading $jarName from Maven Central.")
-        }
-        if (offline.get()) {
-          throw IllegalStateException(
-            "Missing robolectric jar ${destinationFile.name} but can't" +
-              " download it because gradle is in offline mode."
-          )
-        }
-        destinationFile.createNewFile()
-        workQueue.submit(DownloadJarAction::class.java) {
-          this.dependencyJar.setDisallowChanges(dependencyJar)
-          this.destinationFile.set(destinationFile)
-        }
+        logger.lifecycle("$TAG Copying $jarToCopy to $destinationFile.")
+        jarToCopy.copyTo(destinationFile)
       }
     }
-
-    workQueue.await()
     existingJars.forEach { (name, file) ->
       logger.lifecycle("Deleting unused Robolectric jar '$name'")
       file.delete()
     }
   }
 
-  internal companion object {
+  companion object {
     private const val TAG = "[RobolectricJarsDownloadTask]"
 
     fun jarsIn(dir: File): Set<File> {
       return dir.listFiles().orEmpty().filterTo(LinkedHashSet()) { it.extension == "jar" }
     }
-  }
-}
 
-internal interface DownloadJarParameters : WorkParameters {
-  val dependencyJar: Property<DependencyJar>
-  val destinationFile: RegularFileProperty
-}
-
-internal abstract class DownloadJarAction : WorkAction<DownloadJarParameters> {
-  override fun execute() {
-    // Can't share this from SlackTools because there's a cyclical dependency between GlobalConfig
-    // (which creates this task) and SlackTools' availability
-    val client =
-      OkHttpClient.Builder().connectionPool(ConnectionPool(1, 5, TimeUnit.MINUTES)).build()
-    val dependencyJar = parameters.dependencyJar.get()
-    val destinationFile = parameters.destinationFile.asFile.get()
-    val url =
-      with(dependencyJar) {
-        "https://repo1.maven.org/maven2/${groupId.replace(".", "/")}/$artifactId/$version/$name"
-      }
-
-    val request = Request.Builder().url(url).build()
-
-    // TODO not possible to show progress here because Gradle:
-    //  https://github.com/gradle/gradle/issues/3654
-    //  Best we could do would be to create a separate task for each jar and show progress for each
-    client.newBuilder().build().newCall(request).execute().use { response ->
-      if (!response.isSuccessful) {
-        throw IOException("Unexpected code $response")
-      }
-      response.body.source().use { source ->
-        destinationFile.sink().buffer().use { sink -> sink.writeAll(source) }
+    fun register(
+      project: Project,
+      slackProperties: SlackProperties
+    ): TaskProvider<UpdateRobolectricJarsTask> {
+      return project.tasks.register<UpdateRobolectricJarsTask>("updateRobolectricJars") {
+        val iVersion = slackProperties.robolectricIVersion
+        for (sdkInt in slackProperties.robolectricTestSdks) {
+          // Create a new configuration
+          val sdk = sdkFor(sdkInt, iVersion)
+          // Add relevant dep
+          val depCoordinates = sdk.dependencyCoordinates
+          val configuration =
+            project.configurations.detachedConfiguration(
+              project.dependencies.create(depCoordinates)
+            )
+          logger.debug(
+            "Adding '$depCoordinates' to Robolectric jars in configuration '${configuration.name}'"
+          )
+          // Wire to jar classpath
+          this.allJars.addAll(configuration.artifactView())
+        }
+        val gradleUserHomeDir = project.gradle.gradleUserHomeDir
+        outputDir.setDisallowChanges(
+          project.layout.dir(project.provider { robolectricJars(gradleUserHomeDir) })
+        )
       }
     }
-
-    // TODO is this... necessary?
-    client.shutdown()
   }
 }
+
+private fun Configuration.artifactView(): Provider<Set<File>> {
+  return incoming
+    .artifactView {
+      attributes { attribute(Attribute.of("artifactType", String::class.java), "jar") }
+    }
+    .artifacts
+    .resolvedArtifacts
+    .map { it.asSequence().map { it.file }.toSet() }
+}
+
+private fun sdkFor(api: Int, iVersion: Int): DefaultSdk {
+  val sdk = SDKS[api] ?: error("No robolectric jar coordinates found for $api.")
+  return sdk.copy(iVersion = iVersion)
+}
+
+// Sourced from
+// https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+// TODO depend on it directly? compileOnly though
+private val SDKS =
+  listOf(
+      DefaultSdk(21, "5.0.2_r3", "r0", "REL", 8, -1),
+      DefaultSdk(22, "5.1.1_r9", "r2", "REL", 8, -1),
+      DefaultSdk(23, "6.0.1_r3", "r1", "REL", 8, -1),
+      DefaultSdk(24, "7.0.0_r1", "r1", "REL", 8, -1),
+      DefaultSdk(25, "7.1.0_r7", "r1", "REL", 8, -1),
+      DefaultSdk(26, "8.0.0_r4", "r1", "REL", 8, -1),
+      DefaultSdk(27, "8.1.0", "4611349", "REL", 8, -1),
+      DefaultSdk(28, "9", "4913185-2", "REL", 8, -1),
+      DefaultSdk(29, "10", "5803371", "REL", 9, -1),
+      DefaultSdk(30, "11", "6757853", "REL", 9, -1),
+      DefaultSdk(31, "12", "7732740", "REL", 9, -1),
+      DefaultSdk(32, "12.1", "8229987", "REL", 9, -1),
+      DefaultSdk(33, "13", "9030017", "Tiramisu", 9, -1),
+    )
+    .associateBy { it.apiLevel }


### PR DESCRIPTION
Few benefits
- It uses the same dependency resolution settings we have (i.e. artifactory repositories work out of the box)
- Lets gradle to the heavy lifting with both downloading and caching downloads
- Simpler setup for us with task up-to-date ness. Now we just always run the task but the most it every does is copy files. Extremely fast.

Resolves #423, resolves #422, resolves #424

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->