### PR TITLE
Bump code-review workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,6 +1,13 @@
 # This workflow triggers a code review using the OpenAI GPT-3.5 Turbo model with a 16k context window
+name: Code Review
 
-on: [pull_request]
+on:
+  pull_request: # Filter out draft pull requests
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   code-review:
@@ -8,9 +15,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    if: ${{ github.actor != 'slack-oss-bot' }}
     steps:
-      - name: Trigger code review
-        uses: fxchen/code-review@v0.1.0-alpha
+      - uses: fxchen/code-review@v0.2.4-alpha
         with:
           model: 'gpt-3.5-turbo-16k'
           openai-key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Over the last day, I’ve made a few changes to how we’re prompting and including context to the github action.
Also I removed the “post errors by default” - so errors will not show up as comments.
In this workflow we also filter out `slack-oss-bot` similar to how we do in `kaldb` (I think this will filter correctly). Example comment: https://github.com/slackhq/kaldb/pull/588#issuecomment-1612152887

This addresses some of your comments from the earlier prototype!