### PR TITLE
Only comment once per PR and use common ancestor for git diff

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.actor != 'slack-oss-bot' }}
     steps:
       - name: Trigger code review
-        uses: fxchen/code-review@v0.2.5-alpha
+        uses: fxchen/code-review@v0.2.6-alpha
         with:
           model: 'gpt-3.5-turbo-16k'
           openai-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.actor != 'slack-oss-bot' }}
     steps:
       - name: Trigger code review
-        uses: fxchen/code-review@v0.2.6-alpha
+        uses: fxchen/code-review@v0.2.7-alpha
         with:
           model: 'gpt-3.5-turbo-16k'
           openai-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -2,12 +2,9 @@
 name: Code Review
 
 on:
-  pull_request: # Filter out draft pull requests
+  pull_request:
     types:
       - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 jobs:
   code-review:


### PR DESCRIPTION
Modify workflow to once per PR, remove thumbs up, and find common ancestor for the diff (https://github.com/fxchen/code-review/pull/33/files)