### PR TITLE
Enable lint on test sources by default

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -264,6 +264,14 @@ public class SlackProperties private constructor(private val project: Project) {
   public val lintBaselineFileName: String
     get() = stringProperty("slack.lint.baseline-file-name", "lint-baseline.xml")
 
+  /** Flag to control whether or not lint checks test sources. */
+  public val lintCheckTestSources: Boolean
+    get() = booleanProperty("sgp.lint.checkTestSources", true)
+
+  /** Flag to control whether or not lint checks ignores test sources. */
+  public val lintIgnoreTestSources: Boolean
+    get() = booleanProperty("sgp.lint.ignoreTestSources", false)
+
   /** Flag to enable/disable KSP. */
   public val allowKsp: Boolean
     get() = booleanProperty("slack.allow-ksp")

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -204,6 +204,9 @@ internal object LintTasks {
     absolutePaths = false
     this.checkDependencies = checkDependencies
 
+    ignoreTestSources = slackProperties.lintIgnoreTestSources
+    checkTestSources = slackProperties.lintCheckTestSources
+
     val lintBaselineFile = slackProperties.lintBaselineFileName
 
     // Lint is weird in that it will generate a new baseline file and fail the build if a new


### PR DESCRIPTION
Apparently this is not enabled by default 🤦‍♂️

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->