### PR TITLE
Skate Plugin Settings Checkbox Enhancement

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
@@ -26,6 +26,10 @@ import com.slack.sgp.intellij.SkateBundle
 import com.slack.sgp.intellij.SkatePluginSettings
 import java.io.File
 
+/**
+ * This class represents the UI display of the Skate Plugin Settings. Right now, it allows users to
+ * choose a .md file and check if the panel should be displayed or not.
+ */
 internal class SkateConfigUI(
   private val settings: SkatePluginSettings,
   private val project: Project,
@@ -38,7 +42,9 @@ internal class SkateConfigUI(
 
   private fun Panel.checkBoxRow() {
     row(SkateBundle.message("skate.configuration.enableWhatsNew.title")) {
-      checkBox(SkateBundle.message("skate.configuration.enableWhatsNew.description"))
+      checkBox(
+          "<html>${SkateBundle.message("skate.configuration.enableWhatsNew.description")}</html>"
+        )
         .bindSelected(
           getter = { settings.isWhatsNewEnabled },
           setter = { settings.isWhatsNewEnabled = it }

--- a/skate-plugin/src/main/resources/messages/skateBundle.properties
+++ b/skate-plugin/src/main/resources/messages/skateBundle.properties
@@ -2,4 +2,4 @@ skate.configuration.title=Skate Settings
 skate.configuration.choosePath.title=Choose file
 skate.configuration.choosePath.dialog.title=Choose Changelog File
 skate.configuration.enableWhatsNew.title=Enable What's New Panel
-skate.configuration.enableWhatsNew.description=If enabled, shows the What's New Panel if there are new changes detected in a specified changelog file.
+skate.configuration.enableWhatsNew.description=If enabled, shows the What's New Panel if there are new changes detected <br> in a specified changelog file.


### PR DESCRIPTION
This is just a simple enhancement for the Skate Plugin Settings UI Panel.

Before, the checkbox text would not wrap and would require users to scroll horizontally:
<img width="986" alt="Screenshot 2023-07-07 at 4 23 09 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/67719108/69eb7eb8-3a05-4cef-af82-d99da7e6bbc3">

Now, the text is wrapped:
<img width="979" alt="Screenshot 2023-07-07 at 4 22 44 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/67719108/c64ec2ff-efc1-4ae2-ac0f-1870ff2dcb47">

This is just a simple enhancement for user readability, and I added documentation to the SkateConfigUI.kt file as well.
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->