### PR TITLE
Add new dagger flag to ignore provisioning keys

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -1235,8 +1235,10 @@ internal object AptOptionsConfigs {
         // New error messages. Feedback should go to https://github.com/google/dagger/issues/1769
         "dagger.experimentalDaggerErrorMessages" to "enabled",
         // Fast init mode for improved dagger perf on startup:
-        // https://dagger.dev/dev-guide/compiler-options.html
-        "dagger.fastInit" to "enabled"
+        // https://dagger.dev/dev-guide/compiler-options.html#fastinit-mode
+        "dagger.fastInit" to "enabled",
+        // https://dagger.dev/dev-guide/compiler-options#ignore-provision-key-wildcards
+        "dagger.ignoreProvisionKeyWildcards" to "ENABLED"
       )
   }
 


### PR DESCRIPTION
Part of Dagger 2.47 and prep for KSP support: https://dagger.dev/dev-guide/compiler-options#ignore-provision-key-wildcards

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->