### PR TITLE
Don't show "What's New" Panel if no Changelog text is present

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
@@ -47,6 +47,7 @@ class SkateProjectServiceImpl(private val project: Project) : SkateProjectServic
     val changeLogString = VfsUtil.loadText(changeLogFile)
 
     // Don't show the tool window if the parsed changelog is blank
+    // Changelog is parsed
     val parsedChangelog = ChangelogParser.readFile(changeLogString, changelogJournal.lastReadDate)
     if (parsedChangelog.changeLogString.isNullOrBlank()) return
 
@@ -65,7 +66,7 @@ class SkateProjectServiceImpl(private val project: Project) : SkateProjectServic
       val parentDisposable = Disposer.newDisposable()
 
       WhatsNewPanelFactory()
-        .createToolWindowContent(toolWindow, project, changeLogString, parentDisposable)
+        .createToolWindowContent(toolWindow, project, parsedChangelog, parentDisposable)
 
       toolWindow.show()
     }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
@@ -36,14 +36,21 @@ interface SkateProjectService {
 class SkateProjectServiceImpl(private val project: Project) : SkateProjectService {
 
   override fun showWhatsNewWindow() {
-    // TODO
-    //  Only show when changed
-    //  Only show latest changes
+
     val settings = project.service<SkatePluginSettings>()
+    val changelogJournal = project.service<ChangelogJournal>()
+
     if (!settings.isWhatsNewEnabled) return
     val projectDir = project.guessProjectDir() ?: return
+
     val changeLogFile = VfsUtil.findRelativeFile(projectDir, settings.whatsNewFilePath) ?: return
     val changeLogString = VfsUtil.loadText(changeLogFile)
+
+    // Don't show the tool window if the parsed changelog is blank
+    val parsedChangelog = ChangelogParser.readFile(changeLogString, changelogJournal.lastReadDate)
+    if (parsedChangelog.changeLogString.isNullOrBlank()) return
+
+    // Creating the tool window
     val toolWindowManager = ToolWindowManager.getInstance(project)
 
     toolWindowManager.invokeLater {

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
@@ -38,7 +38,7 @@ internal class SkateConfigUI(
 
   private fun Panel.checkBoxRow() {
     row(SkateBundle.message("skate.configuration.enableWhatsNew.title")) {
-      checkBox("skate.configuration.enableWhatsNew.description")
+      checkBox(SkateBundle.message("skate.configuration.enableWhatsNew.description"))
         .bindSelected(
           getter = { settings.isWhatsNewEnabled },
           setter = { settings.isWhatsNewEnabled = it }

--- a/skate-plugin/src/main/resources/META-INF/plugin.xml
+++ b/skate-plugin/src/main/resources/META-INF/plugin.xml
@@ -32,7 +32,6 @@
         <projectService serviceImplementation="com.slack.sgp.intellij.SkatePluginSettings"/>
         <projectConfigurable instance="com.slack.sgp.intellij.SkateConfig"/>
         <errorHandler implementation="com.slack.sgp.intellij.SkateErrorHandler"/>
-
     </extensions>
 
     <applicationListeners>

--- a/skate-plugin/src/main/resources/META-INF/plugin.xml
+++ b/skate-plugin/src/main/resources/META-INF/plugin.xml
@@ -28,9 +28,11 @@
         <projectService
                 serviceInterface="com.slack.sgp.intellij.SkateProjectService"
                 serviceImplementation="com.slack.sgp.intellij.SkateProjectServiceImpl"/>
+        <projectService serviceImplementation="com.slack.sgp.intellij.ChangelogJournal"/>
         <projectService serviceImplementation="com.slack.sgp.intellij.SkatePluginSettings"/>
         <projectConfigurable instance="com.slack.sgp.intellij.SkateConfig"/>
         <errorHandler implementation="com.slack.sgp.intellij.SkateErrorHandler"/>
+
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
Before this change, if there were no new entries a panel would still appear in the IDE:
<img width="1398" alt="Screenshot 2023-07-19 at 4 32 55 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/67719108/479fdec2-3495-4192-9492-d3cb4d01912c">

Now if there is no text, the panel just simply won't show up (the xml file is open to show that a last date entry was stored) and there will be no tool window registered: 
<img width="1397" alt="Screenshot 2023-07-19 at 4 06 31 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/67719108/3b9dc61e-59a7-4ee5-9ac2-550b9ad3b157">

I also realized that in another PR I may have accidentally merged a change with the settings:
<img width="998" alt="Screenshot 2023-07-19 at 4 03 23 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/67719108/3118e400-7535-49ff-942a-2c05036100b9">

So I reverted that to what it was originally (I am still looking into the wrap text so that will be in another PR):
<img width="899" alt="Screenshot 2023-07-19 at 4 30 55 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/67719108/241819ab-39f2-4260-b62b-fe3985ab082a">


<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->