### PR TITLE
Add Tests for Different Changelog Format with Non-Italicized Dates

### DIFF
--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/ChangelogParserNoItalicsTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/ChangelogParserNoItalicsTest.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij
+
+import com.google.common.truth.Truth
+import java.time.LocalDate
+import org.junit.Test
+
+class ChangelogParserNoItalicsTest {
+  @Test
+  fun `no entries and null changelogstring`() {
+    val (changeLogString, latestEntry) = ChangelogParser.readFile("", null)
+    Truth.assertThat(changeLogString).isEmpty()
+    Truth.assertThat(latestEntry).isEqualTo(LocalDate.now())
+  }
+
+  @Test
+  fun `one entry, no previous entries`() {
+    val input =
+      """
+      Changelog
+      =========
+
+      0.9.17
+      ------
+
+      2023-07-07
+
+      - Don't register `RakeDependencies` task on platform projects.
+      - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
+      - Add Dependency Rake usage to its doc.
+      - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
+        - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
+      """
+        .trimIndent()
+
+    val expectedDate = LocalDate.of(2023, 7, 7)
+    val (changeLogString, latestEntry) = ChangelogParser.readFile(input, null)
+    Truth.assertThat(changeLogString).isEqualTo(input)
+    Truth.assertThat(latestEntry).isEqualTo(expectedDate)
+  }
+
+  @Test
+  fun `mutliple entries, and no previous entries`() {
+    val input =
+      """
+      0.9.15
+      ------
+
+      2023-06-29
+
+      - Switch Robolectric jar downloads to use detached configurations.
+        - This lets Gradle do the heavy lifting of caching the downloaded jars and also allows downloading them from a configured repository setup. This also simplifies the up-to-date checks.
+      - Docs are now published on https://slackhq.github.io/slack-gradle-plugin. This is a work in progress.
+      - API kdocs are published at https://slackhq.github.io/slack-gradle-plugin/api/0.x/.
+      - Update `kotlin-cli-util` to 1.2.2.
+
+      0.9.14
+      ------
+
+      2023-06-25
+
+      * Fix compose compiler config not applying to android projects.
+      """
+        .trimIndent()
+    val expectedDate = LocalDate.of(2023, 6, 29)
+    val expectedString =
+      """
+      0.9.15
+      ------
+
+      2023-06-29
+
+      - Switch Robolectric jar downloads to use detached configurations.
+        - This lets Gradle do the heavy lifting of caching the downloaded jars and also allows downloading them from a configured repository setup. This also simplifies the up-to-date checks.
+      - Docs are now published on https://slackhq.github.io/slack-gradle-plugin. This is a work in progress.
+      - API kdocs are published at https://slackhq.github.io/slack-gradle-plugin/api/0.x/.
+      - Update `kotlin-cli-util` to 1.2.2.
+      """
+        .trimIndent()
+    val (changeLogString, latestEntry) = ChangelogParser.readFile(input, LocalDate.of(2023, 6, 25))
+    Truth.assertThat(changeLogString).isEqualTo(expectedString)
+    Truth.assertThat(latestEntry).isEqualTo(expectedDate)
+  }
+
+  @Test
+  fun `multiple entries, where the previous is the same as the latest`() {
+    val input =
+      """
+      Changelog
+      =========
+
+      0.9.17
+      ------
+
+      2023-07-07
+
+      - Don't register `RakeDependencies` task on platform projects.
+      - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
+      - Add Dependency Rake usage to its doc.
+      - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
+        - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
+
+      0.9.16
+      ------
+
+      2023-06-30
+
+      - Enable lint on test sources by default.
+      - Account for all version catalogs in `DependencyRake`.
+      - Update Guava to `32.1.0-jre`.
+      """
+        .trimIndent()
+    val expectedDate = LocalDate.of(2023, 7, 7)
+    val (changeLogString, latestEntry) = ChangelogParser.readFile(input, LocalDate.of(2023, 7, 7))
+    Truth.assertThat(changeLogString).isEmpty()
+    Truth.assertThat(latestEntry).isEqualTo(expectedDate)
+  }
+
+  @Test
+  fun `test with a previous entry not in the change log`() {
+    val input =
+      """
+      Changelog
+      =========
+
+      0.9.17
+      ------
+
+      2023-07-07
+
+      - Don't register `RakeDependencies` task on platform projects.
+      - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
+      - Add Dependency Rake usage to its doc.
+      - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
+        - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
+
+      0.9.16
+      ------
+
+      2023-06-30
+
+      - Enable lint on test sources by default.
+      - Account for all version catalogs in `DependencyRake`.
+      - Update Guava to `32.1.0-jre`.
+      """
+        .trimIndent()
+    val expectedDate = LocalDate.of(2023, 7, 15)
+    val (changeLogString, latestEntry) = ChangelogParser.readFile(input, LocalDate.of(2023, 7, 15))
+    Truth.assertThat(changeLogString).isEmpty()
+    Truth.assertThat(latestEntry).isEqualTo(expectedDate)
+  }
+
+  @Test
+  fun `multiple entries, previous entry matches but not the latest`() {
+    val input =
+      """
+        Changelog
+        =========
+
+        0.9.17
+        ------
+
+        2023-07-07
+
+        - Don't register `RakeDependencies` task on platform projects.
+        - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
+        - Add Dependency Rake usage to its doc.
+        - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
+          - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
+
+        0.9.16
+        ------
+
+        2023-06-30
+
+        - Enable lint on test sources by default.
+        - Account for all version catalogs in `DependencyRake`.
+        - Update Guava to `32.1.0-jre`.
+
+        0.9.15
+        ------
+
+        2023-06-29
+
+        - Switch Robolectric jar downloads to use detached configurations.
+          - This lets Gradle do the heavy lifting of caching the downloaded jars and also allows downloading them from a configured repository setup. This also simplifies the up-to-date checks.
+        - Docs are now published on https://slackhq.github.io/slack-gradle-plugin. This is a work in progress.
+        - API kdocs are published at https://slackhq.github.io/slack-gradle-plugin/api/0.x/.
+        - Update `kotlin-cli-util` to 1.2.2.
+        """
+        .trimIndent()
+
+    val expectedDate = LocalDate.of(2023, 7, 7)
+    val expectedString =
+      """
+        Changelog
+        =========
+
+        0.9.17
+        ------
+
+        2023-07-07
+
+        - Don't register `RakeDependencies` task on platform projects.
+        - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
+        - Add Dependency Rake usage to its doc.
+        - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
+          - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
+
+        0.9.16
+        ------
+
+        2023-06-30
+
+        - Enable lint on test sources by default.
+        - Account for all version catalogs in `DependencyRake`.
+        - Update Guava to `32.1.0-jre`.
+        """
+        .trimIndent()
+
+    val (changeLogString, latestEntry) = ChangelogParser.readFile(input, LocalDate.of(2023, 6, 29))
+
+    Truth.assertThat(changeLogString).isEqualTo(expectedString)
+    Truth.assertThat(latestEntry).isEqualTo(expectedDate)
+  }
+}


### PR DESCRIPTION
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->

This is related to a previous [PR](https://github.com/slackhq/slack-gradle-plugin/pull/491) that was just merged, about different formatting with italicized / non italicized entry dates. I created test cases in `ChangelogParserNoItalicsTest.kt` that are now passing because of the pushed change. 

Here are the current tests in a different [file](https://github.com/slackhq/slack-gradle-plugin/blob/main/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/ChangeLogParserTest.kt), but the new tests are in this change.

This is to account for the different possible local date formats found in markdown files.
![Screenshot 2023-07-27 at 1 08 34 PM](https://github.com/slackhq/slack-gradle-plugin/assets/67719108/f8ed62ef-317a-4cf5-80b4-cdeb7967c9be)
![Screenshot 2023-07-27 at 1 08 17 PM](https://github.com/slackhq/slack-gradle-plugin/assets/67719108/7db645f3-5bfe-423c-84bb-0a8d4834a5e2)

Here is the side by side comparison of the tests, just removing the "_" to see if the parser is able to still work with a different local date format:
![Screenshot 2023-07-27 at 2 59 02 PM](https://github.com/slackhq/slack-gradle-plugin/assets/67719108/a6f55a4e-7556-48c9-a842-4e89b9bd0f53)
![Screenshot 2023-07-27 at 2 59 12 PM](https://github.com/slackhq/slack-gradle-plugin/assets/67719108/c0e0f252-bbc0-4833-a27f-93551c422c2a)

