### PR TITLE
Use one version code for all apks

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
@@ -129,7 +129,7 @@ internal class ApkVersioningPlugin : Plugin<Project> {
           val mappedVersionCodeProvider =
             versionCodeProvider.map { rawCode ->
               @Suppress("MagicNumber")
-              ApkVersioning.VERSION_CODES.getValue(variantOutput.abiString) * 10000000 + rawCode
+              ApkVersioning.VERSION_CODE * 10000000 + rawCode
             }
           variantOutput.versionCode.setDisallowChanges(mappedVersionCodeProvider)
         }
@@ -142,16 +142,7 @@ private object ApkVersioning {
 
   const val DEFAULT_VERSION_CODE: Int = 9999
 
-  // Override version code based on the ABI
-  // https://androidbycode.wordpress.com/2015/06/30/android-ndk-version-code-scheme-for-publishing-apks-per-architecture/
-  val VERSION_CODES: Map<String?, Int> =
-    mapOf(
-      null to 0, // Universal APK for CI
-      "arm64-v8a" to 3,
-      "armeabi-v7a" to 2,
-      "x86" to 8,
-      "x86_64" to 9
-    )
+  const val VERSION_CODE: Int = 9
 }
 
 /**

--- a/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
@@ -18,8 +18,6 @@
 package slack.gradle
 
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.api.variant.FilterConfiguration
-import com.android.build.api.variant.VariantOutput
 import com.android.build.gradle.AppPlugin
 import java.util.Properties
 import org.gradle.api.DefaultTask

--- a/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
@@ -47,11 +47,6 @@ import slack.gradle.util.setDisallowChanges
 @Suppress("unused")
 internal class ApkVersioningPlugin : Plugin<Project> {
 
-  private val VariantOutput.abiString: String?
-    get() {
-      return filters.find { it.filterType == FilterConfiguration.FilterType.ABI }?.identifier
-    }
-
   @Suppress("LongMethod")
   override fun apply(project: Project) {
     project.plugins.withType(AppPlugin::class.java) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
@@ -117,14 +117,7 @@ internal class ApkVersioningPlugin : Plugin<Project> {
         // Have to iterate outputs because of APK splits.
         variant.outputs.forEach { variantOutput ->
           variantOutput.versionName.setDisallowChanges(mappedVersionNameProvider)
-
-          // Reuse the same task and just remap its value as needed
-          val mappedVersionCodeProvider =
-            versionCodeProvider.map { rawCode ->
-              @Suppress("MagicNumber")
-              ApkVersioning.VERSION_CODE * 10000000 + rawCode
-            }
-          variantOutput.versionCode.setDisallowChanges(mappedVersionCodeProvider)
+          variantOutput.versionCode.setDisallowChanges(versionCodeProvider)
         }
       }
     }
@@ -134,8 +127,6 @@ internal class ApkVersioningPlugin : Plugin<Project> {
 private object ApkVersioning {
 
   const val DEFAULT_VERSION_CODE: Int = 9999
-
-  const val VERSION_CODE: Int = 9
 }
 
 /**


### PR DESCRIPTION
We can move away from having separate version code for each build type now that we're publishing app bundle

This change should also help resolve issues with AGP 8.1 upgrade



<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->