### PR TITLE
Update default local version code

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/ApkVersioningPlugin.kt
@@ -126,7 +126,7 @@ internal class ApkVersioningPlugin : Plugin<Project> {
 
 private object ApkVersioning {
 
-  const val DEFAULT_VERSION_CODE: Int = 9999
+  const val DEFAULT_VERSION_CODE: Int = 90009999
 }
 
 /**


### PR DESCRIPTION
I forgot to update the default version code for local build in #503. Before, devs usually get 30009999. This PR updates the version to be 90009999 to make it consistent with CI build number



<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->