### PR TITLE
Don't include androidTest information about projects if it's not enabled

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -475,24 +475,27 @@ internal class StandardProjectConfigurations(
               slackExtension.androidHandler.featuresHandler.androidTestExcludeFromFladle.getOrElse(
                 false
               )
-          if (!excluded && isAffectedProject) {
-            computeAffectedProjectsTask.configure { androidTestProjects.add(projectPath) }
-            if (isLibraryVariant) {
-              (variant as LibraryVariant).androidTest?.artifacts?.get(SingleArtifact.APK)?.let {
-                apkArtifactsDir ->
-                // Wire this up to the aggregator
-                androidTestApksAggregator.configure { androidTestApkDirs.from(apkArtifactsDir) }
+          val isAndroidTestEnabled = variant is HasAndroidTest && variant.androidTest != null
+          if (isAndroidTestEnabled) {
+            if (!excluded && isAffectedProject) {
+              computeAffectedProjectsTask.configure { androidTestProjects.add(projectPath) }
+              if (isLibraryVariant) {
+                (variant as LibraryVariant).androidTest?.artifacts?.get(SingleArtifact.APK)?.let {
+                  apkArtifactsDir ->
+                  // Wire this up to the aggregator
+                  androidTestApksAggregator.configure { androidTestApkDirs.from(apkArtifactsDir) }
+                }
               }
-            }
-          } else {
-            val reason = if (excluded) "excluded" else "not affected"
-            val taskPath = "${projectPath}:androidTest"
-            val log = "$LOG Skipping $taskPath because it is $reason."
-            slackTools.logAvoidedTask(AndroidTestApksTask.NAME, taskPath)
-            if (slackProperties.debug) {
-              project.logger.lifecycle(log)
             } else {
-              project.logger.debug(log)
+              val reason = if (excluded) "excluded" else "not affected"
+              val taskPath = "${projectPath}:androidTest"
+              val log = "$LOG Skipping $taskPath because it is $reason."
+              slackTools.logAvoidedTask(AndroidTestApksTask.NAME, taskPath)
+              if (slackProperties.debug) {
+                project.logger.lifecycle(log)
+              } else {
+                project.logger.debug(log)
+              }
             }
           }
         }


### PR DESCRIPTION
This avoids a bug in skippy where we'd mistakenly mark an project as affected in android tests even if it wasn't actually enabled

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->