### PR TITLE
Add resources DSL

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -65,6 +65,12 @@ By default, SGP disables androidTests in projects. These can be enabled via the 
 
 This is important for opting in tests to [AndroidTest APK Aggregation](/utilities/#androidtest-apk-aggregation).
 
+### Resources
+
+By default, we disable _Android_ resources (different from _Java_ resources) and libraries have to opt-in to using them.
+
+This can be enabled via the `resources()` feature, which will enable the relevant `BuildFeature` in the Android plugin and also takes a required `prefix` parameter that is used as the required `resourcePrefix` for that library's resources to avoid naming conflicts.
+
 ## Android Application Features
 
 ### Permission AllowList

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt
@@ -18,6 +18,7 @@
 package slack.gradle
 
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.gradle.LibraryExtension
 import com.squareup.anvil.plugin.AnvilExtension
 import dev.zacsweers.moshix.ir.gradle.MoshiPluginExtension
 import javax.inject.Inject
@@ -812,6 +813,20 @@ public abstract class AndroidFeaturesHandler @Inject constructor() {
     // Required for Robolectric to work.
     androidExtension!!.testOptions.unitTests.isIncludeAndroidResources = true
     robolectric.setDisallowChanges(true)
+  }
+
+  /**
+   * **LIBRARIES ONLY**
+   *
+   * Enables android resources in this library and enforces use of the given [prefix] for all
+   * resources.
+   */
+  public fun resources(prefix: String) {
+    val libraryExtension =
+      androidExtension as? LibraryExtension
+        ?: error("slack.android.features.resources() is only applicable in libraries!")
+    libraryExtension.resourcePrefix = prefix
+    libraryExtension.buildFeatures { androidResources = true }
   }
 }
 


### PR DESCRIPTION
This streamlines configuration of enabling `androidResources` and enforces use of a resource prefix to avoid conflicts.

May your avatars never be wrongly sized again.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->