### PR TITLE
Improve support for com.android.test projects

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/GradleExt.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/GradleExt.kt
@@ -248,10 +248,13 @@ internal operator fun ExtensionContainer.set(key: String, value: Any) {
 internal val BuildType.ext: ExtraPropertiesExtension
   get() = (this as ExtensionAware).extensions.getByName("ext") as ExtraPropertiesExtension
 
-internal fun PluginManager.onFirst(pluginIds: Iterable<String>, body: AppliedPlugin.() -> Unit) {
+internal fun PluginManager.onFirst(
+  pluginIds: Iterable<String>,
+  body: AppliedPlugin.(id: String) -> Unit
+) {
   once {
     for (id in pluginIds) {
-      withPlugin(id) { onFirst { body() } }
+      withPlugin(id) { onFirst { body(id) } }
     }
   }
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
@@ -27,7 +27,6 @@ import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.provider.Provider
 import slack.gradle.tasks.CoreBootstrapTask
 import slack.stats.ModuleStatsTasks
-import slack.unittest.UnitTests
 
 /**
  * Simple base plugin over [StandardProjectConfigurations]. Eventually functionality from this will
@@ -44,12 +43,6 @@ internal class SlackBasePlugin : Plugin<Project> {
         target.getVersionsCatalogOrNull() ?: error("SGP requires use of version catalogs!")
       val slackTools = target.slackTools()
       StandardProjectConfigurations(slackProperties, versionCatalog, slackTools).applyTo(target)
-      UnitTests.configureSubproject(
-        target,
-        slackProperties,
-        slackTools.globalConfig.affectedProjects,
-        slackTools::logAvoidedTask
-      )
       CoreBootstrapTask.configureSubprojectBootstrapTasks(target)
 
       // Configure Gradle's test-retry plugin for insights on build scans on CI only

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -276,6 +276,15 @@ public class SlackProperties private constructor(private val project: Project) {
   public val lintIgnoreTestSources: Boolean
     get() = booleanProperty("sgp.lint.ignoreTestSources", false)
 
+  /**
+   * At the time of writing, AGP does not support running lint on `com.android.test` projects. This
+   * is a flag to eventually support this in the future.
+   *
+   * https://issuetracker.google.com/issues/208765813
+   */
+  public val enableLintInAndroidTestProjects: Boolean
+    get() = booleanProperty("sgp.lint.enableOnAndroidTestProjects", false)
+
   /** Flag to enable/disable KSP. */
   public val allowKsp: Boolean
     get() = booleanProperty("slack.allow-ksp")

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -1050,7 +1050,8 @@ internal class StandardProjectConfigurations(
         "java-library",
         "org.jetbrains.kotlin.jvm",
         "com.android.library",
-        "com.android.application"
+        "com.android.application",
+        "com.android.test",
       )
 
     private fun isKnownConfiguration(configurationName: String, knownNames: Set<String>): Boolean {

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -73,6 +73,7 @@ import slack.gradle.tasks.CheckManifestPermissionsTask
 import slack.gradle.util.booleanProperty
 import slack.gradle.util.configureKotlinCompilationTask
 import slack.gradle.util.setDisallowChanges
+import slack.unittest.UnitTests
 
 private const val LOG = "SlackPlugin:"
 private const val FIVE_MINUTES_MS = 300_000L
@@ -219,6 +220,15 @@ internal class StandardProjectConfigurations(
       }
 
       if (pluginId != "com.android.test") {
+        // Configure tests
+        UnitTests.configureSubproject(
+          project,
+          pluginId,
+          slackProperties,
+          slackTools.globalConfig.affectedProjects,
+          slackTools::logAvoidedTask
+        )
+
         slackProperties.versions.bundles.commonTest.ifPresent {
           dependencies.add("testImplementation", it)
         }

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -213,13 +213,15 @@ internal class StandardProjectConfigurations(
     checkAndroidXDependencies(slackProperties)
     configureAnnotationProcessors()
 
-    pluginManager.onFirst(JVM_PLUGINS) {
+    pluginManager.onFirst(JVM_PLUGINS) { pluginId ->
       slackProperties.versions.bundles.commonAnnotations.ifPresent {
         dependencies.add("implementation", it)
       }
 
-      slackProperties.versions.bundles.commonTest.ifPresent {
-        dependencies.add("testImplementation", it)
+      if (pluginId != "com.android.test") {
+        slackProperties.versions.bundles.commonTest.ifPresent {
+          dependencies.add("testImplementation", it)
+        }
       }
     }
 
@@ -597,14 +599,16 @@ internal class StandardProjectConfigurations(
         slackExtension.setAndroidExtension(this)
         commonBaseExtensionConfig(false)
         defaultConfig { targetSdk = sdkVersions.value.targetSdk }
-        LintTasks.configureSubProject(
-          project,
-          slackProperties,
-          slackTools.globalConfig.affectedProjects,
-          slackTools::logAvoidedTask,
-          this,
-          sdkVersions::value
-        )
+        if (slackProperties.enableLintInAndroidTestProjects) {
+          LintTasks.configureSubProject(
+            project,
+            slackProperties,
+            slackTools.globalConfig.affectedProjects,
+            slackTools::logAvoidedTask,
+            this,
+            sdkVersions::value
+          )
+        }
       }
     }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -40,6 +40,10 @@ internal object LintTasks {
   private const val COMPILE_CI_LINT_NAME = "compileCiLint"
   private const val LOG = "SlackLints:"
 
+  private fun Project.log(message: String) {
+    logger.debug("$LOG $message")
+  }
+
   fun configureRootProject(project: Project): TaskProvider<Task> =
     project.tasks.register(GLOBAL_CI_LINT_TASK_NAME) {
       group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -54,11 +58,11 @@ internal object LintTasks {
     commonExtension: CommonExtension<*, *, *, *, *>?,
     sdkVersions: (() -> SlackProperties.AndroidSdkProperties)?,
   ) {
-    project.logger.debug("$LOG Configuring lint tasks for project ${project.path}...")
+    project.log("Configuring lint tasks for project ${project.path}...")
     // Projects can opt out of creating the task with this property.
     val enabled = slackProperties.ciLintEnabled
     if (!enabled) {
-      project.logger.debug("$LOG Skipping creation of \"$CI_LINT_TASK_NAME\" task")
+      project.log("Skipping creation of \"$CI_LINT_TASK_NAME\" task")
       return
     }
 
@@ -73,12 +77,12 @@ internal object LintTasks {
         project.rootProject.tasks.named(GLOBAL_CI_LINT_TASK_NAME)
       } else {
         val taskPath = "${project.path}:$CI_LINT_TASK_NAME"
-        val log = "$LOG Skipping $taskPath because it is not affected."
+        val log = "Skipping $taskPath because it is not affected."
         onProjectSkipped(GLOBAL_CI_LINT_TASK_NAME, taskPath)
         if (slackProperties.debug) {
-          project.logger.lifecycle(log)
+          project.log(log)
         } else {
-          project.logger.debug(log)
+          project.log(log)
         }
         null
       }
@@ -87,7 +91,7 @@ internal object LintTasks {
     val applied = AtomicBoolean(false)
 
     if (commonExtension != null) {
-      project.logger.debug("$LOG Applying ciLint to Android project")
+      project.log("Applying ciLint to Android project")
       applyCommonLints()
       createAndroidCiLintTask(
         project,
@@ -103,7 +107,7 @@ internal object LintTasks {
           project.pluginManager.apply("com.android.lint")
           project.configure<Lint> { configureLint(project, slackProperties, null, false) }
           applyCommonLints()
-          project.logger.debug("$LOG Creating ciLint task")
+          project.log("Creating ciLint task")
           val ciLint =
             project.tasks.register(COMPILE_CI_LINT_NAME) {
               group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -124,7 +128,7 @@ internal object LintTasks {
     extension: CommonExtension<*, *, *, *, *>,
     sdkVersions: SlackProperties.AndroidSdkProperties,
   ) {
-    project.logger.debug("$LOG Configuring android lint tasks. isApp=${extension is AppExtension}")
+    project.log("Configuring android lint tasks. isApp=${extension is AppExtension}")
     extension.lint {
       configureLint(
         project,
@@ -134,7 +138,7 @@ internal object LintTasks {
       )
     }
 
-    project.logger.debug("$LOG Creating ciLint task")
+    project.log("Creating ciLint task")
     val ciLintTask =
       project.tasks.register(CI_LINT_TASK_NAME) { group = LifecycleBasePlugin.VERIFICATION_GROUP }
     globalTask?.configure { dependsOn(ciLintTask) }
@@ -144,7 +148,7 @@ internal object LintTasks {
         // Even if the task isn't created yet, we can do this by name alone and it will resolve at
         // task configuration time.
         variants.splitToSequence(',').forEach { variant ->
-          logger.debug("$LOG Using variant $variant for ciLint task")
+          logger.lifecycle("Using variant $variant for ciLint task")
           val lintTaskName = "lint${variant.capitalizeUS()}"
           dependsOn(lintTaskName)
         }
@@ -167,7 +171,7 @@ internal object LintTasks {
       }
     componentsExtension.onVariants { variant ->
       val lintTaskName = "lint${variant.name.capitalizeUS()}"
-      project.logger.debug("$LOG Adding $lintTaskName to ciLint task")
+      project.log("Adding $lintTaskName to ciLint task")
       ciLintTask.configure {
         // Even if the task isn't created yet, we can do this by name alone and it will resolve at
         // task configuration time.


### PR DESCRIPTION
- Don't enable lint on test projects as AGP doesn't support it yet. Left a flag to gate this as a toe-hold for the future.
- Don't configure unit tests on test projects as AGP doesn't configure any.
- Don't enable DAGP on test projects as it doesn't support it yet

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->