### PR TITLE
Improve Skate changelog parsing logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ tasks.withType<Detekt>().configureEach {
 
 val ktfmtVersion = libs.versions.ktfmt.get()
 
-val externalFiles = listOf("SkateErrorHandler").map { "src/**/$it.kt" }
+val externalFiles = listOf("SkateErrorHandler", "MemoizedSequence").map { "src/**/$it.kt" }
 
 allprojects {
   apply(plugin = "com.diffplug.spotless")

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/MemoizedSequence.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/MemoizedSequence.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.util
+
+// Adapted from
+// https://github.com/google/ksp/blob/main/common-util/src/main/kotlin/com/google/devtools/ksp/MemoizedSequence.kt
+// TODO: garbage collect underlying sequence after exhaust.
+class MemoizedSequence<T>(sequence: Sequence<T>) : Sequence<T> {
+
+  private val cache = arrayListOf<T>()
+
+  private val iter: Iterator<T> by lazy { sequence.iterator() }
+
+  private inner class CachedIterator() : Iterator<T> {
+    var idx = 0
+
+    override fun hasNext(): Boolean {
+      return idx < cache.size || iter.hasNext()
+    }
+
+    override fun next(): T {
+      if (idx == cache.size) {
+        cache.add(iter.next())
+      }
+      val value = cache[idx]
+      idx += 1
+      return value
+    }
+  }
+
+  override fun iterator(): Iterator<T> {
+    return CachedIterator()
+  }
+}
+
+fun <T> Sequence<T>.memoized(): Sequence<T> {
+  return MemoizedSequence(this)
+}

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/ChangeLogParserTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/ChangeLogParserTest.kt
@@ -21,9 +21,9 @@ import org.junit.Test
 
 class ChangeLogParserTest {
   @Test
-  fun `no entries and null changelogstring`() {
+  fun `no entries and null changelog string`() {
     val (changeLogString, latestEntry) = ChangelogParser.readFile("", null)
-    assertThat(changeLogString).isEmpty()
+    assertThat(changeLogString).isNull()
     assertThat(latestEntry).isEqualTo(LocalDate.now())
   }
 
@@ -34,10 +34,8 @@ class ChangeLogParserTest {
       Changelog
       =========
 
-      0.9.17
-      ------
-
-      _2023-07-07_
+      2023-07-07
+      ----------
 
       - Don't register `RakeDependencies` task on platform projects.
       - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
@@ -54,13 +52,11 @@ class ChangeLogParserTest {
   }
 
   @Test
-  fun `mutliple entries, and no previous entries`() {
+  fun `multiple entries, and no previous entries`() {
     val input =
       """
-      0.9.15
-      ------
-
-      _2023-06-29_
+      2023-06-29
+      ----------
 
       - Switch Robolectric jar downloads to use detached configurations.
         - This lets Gradle do the heavy lifting of caching the downloaded jars and also allows downloading them from a configured repository setup. This also simplifies the up-to-date checks.
@@ -68,21 +64,57 @@ class ChangeLogParserTest {
       - API kdocs are published at https://slackhq.github.io/slack-gradle-plugin/api/0.x/.
       - Update `kotlin-cli-util` to 1.2.2.
 
-      0.9.14
-      ------
-
-      _2023-06-25_
+      2023-06-25
+      ----------
 
       * Fix compose compiler config not applying to android projects.
       """
         .trimIndent()
+
+    val expected =
+      """
+      2023-06-29
+      ----------
+
+      - Switch Robolectric jar downloads to use detached configurations.
+        - This lets Gradle do the heavy lifting of caching the downloaded jars and also allows downloading them from a configured repository setup. This also simplifies the up-to-date checks.
+      - Docs are now published on https://slackhq.github.io/slack-gradle-plugin. This is a work in progress.
+      - API kdocs are published at https://slackhq.github.io/slack-gradle-plugin/api/0.x/.
+      - Update `kotlin-cli-util` to 1.2.2.
+      """
+        .trimIndent()
+
+    val expectedDate = LocalDate.of(2023, 6, 29)
+    val (changeLogString, latestEntry) = ChangelogParser.readFile(input, null)
+    assertThat(changeLogString).isEqualTo(expected)
+    assertThat(latestEntry).isEqualTo(expectedDate)
+  }
+
+  @Test
+  fun `multiple entries and match is in the middle`() {
+    val input =
+      """
+      2023-06-29
+      ----------
+
+      - Switch Robolectric jar downloads to use detached configurations.
+        - This lets Gradle do the heavy lifting of caching the downloaded jars and also allows downloading them from a configured repository setup. This also simplifies the up-to-date checks.
+      - Docs are now published on https://slackhq.github.io/slack-gradle-plugin. This is a work in progress.
+      - API kdocs are published at https://slackhq.github.io/slack-gradle-plugin/api/0.x/.
+      - Update `kotlin-cli-util` to 1.2.2.
+
+      2023-06-25
+      ----------
+
+      * Fix compose compiler config not applying to android projects.
+      """
+        .trimIndent()
+
     val expectedDate = LocalDate.of(2023, 6, 29)
     val expectedString =
       """
-      0.9.15
-      ------
-
-      _2023-06-29_
+      2023-06-29
+      ----------
 
       - Switch Robolectric jar downloads to use detached configurations.
         - This lets Gradle do the heavy lifting of caching the downloaded jars and also allows downloading them from a configured repository setup. This also simplifies the up-to-date checks.
@@ -103,10 +135,8 @@ class ChangeLogParserTest {
       Changelog
       =========
 
-      0.9.17
-      ------
-
-      _2023-07-07_
+      2023-07-07
+      ----------
 
       - Don't register `RakeDependencies` task on platform projects.
       - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
@@ -114,10 +144,8 @@ class ChangeLogParserTest {
       - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
         - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
 
-      0.9.16
-      ------
-
-      _2023-06-30_
+      2023-06-30
+      ----------
 
       - Enable lint on test sources by default.
       - Account for all version catalogs in `DependencyRake`.
@@ -126,7 +154,7 @@ class ChangeLogParserTest {
         .trimIndent()
     val expectedDate = LocalDate.of(2023, 7, 7)
     val (changeLogString, latestEntry) = ChangelogParser.readFile(input, LocalDate.of(2023, 7, 7))
-    assertThat(changeLogString).isEmpty()
+    assertThat(changeLogString).isNull()
     assertThat(latestEntry).isEqualTo(expectedDate)
   }
 
@@ -137,10 +165,8 @@ class ChangeLogParserTest {
       Changelog
       =========
 
-      0.9.17
-      ------
-
-      _2023-07-07_
+      2023-07-16
+      ----------
 
       - Don't register `RakeDependencies` task on platform projects.
       - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
@@ -148,19 +174,32 @@ class ChangeLogParserTest {
       - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
         - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
 
-      0.9.16
-      ------
-
-      _2023-06-30_
+      2023-06-30
+      ----------
 
       - Enable lint on test sources by default.
       - Account for all version catalogs in `DependencyRake`.
       - Update Guava to `32.1.0-jre`.
       """
         .trimIndent()
-    val expectedDate = LocalDate.of(2023, 7, 15)
+    val expected =
+      """
+      Changelog
+      =========
+
+      2023-07-16
+      ----------
+
+      - Don't register `RakeDependencies` task on platform projects.
+      - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
+      - Add Dependency Rake usage to its doc.
+      - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
+        - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
+    """
+        .trimIndent()
+    val expectedDate = LocalDate.of(2023, 7, 16)
     val (changeLogString, latestEntry) = ChangelogParser.readFile(input, LocalDate.of(2023, 7, 15))
-    assertThat(changeLogString).isEmpty()
+    assertThat(changeLogString).isEqualTo(expected)
     assertThat(latestEntry).isEqualTo(expectedDate)
   }
 
@@ -171,10 +210,8 @@ class ChangeLogParserTest {
         Changelog
         =========
 
-        0.9.17
-        ------
-
-        _2023-07-07_
+        2023-07-07
+        ----------
 
         - Don't register `RakeDependencies` task on platform projects.
         - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
@@ -182,19 +219,15 @@ class ChangeLogParserTest {
         - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
           - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
 
-        0.9.16
-        ------
-
-        _2023-06-30_
+        2023-06-30
+        ----------
 
         - Enable lint on test sources by default.
         - Account for all version catalogs in `DependencyRake`.
         - Update Guava to `32.1.0-jre`.
 
-        0.9.15
-        ------
-
-        _2023-06-29_
+        2023-06-29
+        ----------
 
         - Switch Robolectric jar downloads to use detached configurations.
           - This lets Gradle do the heavy lifting of caching the downloaded jars and also allows downloading them from a configured repository setup. This also simplifies the up-to-date checks.
@@ -210,10 +243,8 @@ class ChangeLogParserTest {
         Changelog
         =========
 
-        0.9.17
-        ------
-
-        _2023-07-07_
+        2023-07-07
+        ----------
 
         - Don't register `RakeDependencies` task on platform projects.
         - Fix configuration cache for Dependency Rake. Note that DAGP doesn't yet support it.
@@ -221,10 +252,8 @@ class ChangeLogParserTest {
         - Add missing identifiers aggregation for Dependency Rake. This makes it easier to find and add missing identifiers to version catalogs that dependency rake expects.
           - `./gradlew aggregateMissingIdentifiers -Pslack.gradle.config.enableAnalysisPlugin=true --no-configuration-cache`
 
-        0.9.16
-        ------
-
-        _2023-06-30_
+        2023-06-30
+        ----------
 
         - Enable lint on test sources by default.
         - Account for all version catalogs in `DependencyRake`.
@@ -244,9 +273,6 @@ class ChangeLogParserTest {
       """
       Changelog
       =========
-
-      0.9.17
-      ------
 
       2023-07-07
 


### PR DESCRIPTION
This PR rewrites changelog parser logic to use a sequence instead

This makes the changelog parser logic a bit more robust and lazy, while also fixing some specific issues around parsing dates (previously it assumed dates were italicized).

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->