### PR TITLE
Migrate to `AndroidPluginVersion` in `AgpHandler` APIs

### DIFF
--- a/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandler80.kt
+++ b/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandler80.kt
@@ -26,7 +26,8 @@ public class AgpHandler80 private constructor(override val agpVersion: AndroidPl
   public class Factory : AgpHandlerFactory {
     override val minVersion: AndroidPluginVersion = AndroidPluginVersion(8, 0, 0)
 
-    // This API is unfortunately internal
+    // TODO Remove once it's public
+    //  https://issuetracker.google.com/issues/297440098
     @Suppress("invisible_reference", "invisible_member")
     override val currentVersion: AndroidPluginVersion =
       com.android.build.api.extension.impl.CURRENT_AGP_VERSION

--- a/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandler80.kt
+++ b/agp-handlers/agp-handler-80/src/main/kotlin/slack/gradle/agphandler/v80/AgpHandler80.kt
@@ -15,26 +15,22 @@
  */
 package slack.gradle.agphandler.v80
 
+import com.android.build.api.AndroidPluginVersion
 import com.google.auto.service.AutoService
 import slack.gradle.agp.AgpHandler
 import slack.gradle.agp.AgpHandlerFactory
-import slack.gradle.agp.VersionNumber
 
-@AutoService(AgpHandlerFactory::class)
-public class AgpHandlerFactory80 : AgpHandlerFactory {
-  override val minVersion: VersionNumber = VersionNumber.parse("8.0.0")
+public class AgpHandler80 private constructor(override val agpVersion: AndroidPluginVersion) :
+  AgpHandler {
+  @AutoService(AgpHandlerFactory::class)
+  public class Factory : AgpHandlerFactory {
+    override val minVersion: AndroidPluginVersion = AndroidPluginVersion(8, 0, 0)
 
-  @Suppress("DEPRECATION")
-  override fun currentVersion(): String =
-    com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    // This API is unfortunately internal
+    @Suppress("invisible_reference", "invisible_member")
+    override val currentVersion: AndroidPluginVersion =
+      com.android.build.api.extension.impl.CURRENT_AGP_VERSION
 
-  override fun create(): AgpHandler {
-    return AgpHandler80()
+    override fun create(): AgpHandler = AgpHandler80(currentVersion)
   }
-}
-
-private class AgpHandler80 : AgpHandler {
-  @Suppress("DEPRECATION")
-  override val agpVersion: String
-    get() = com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
 }

--- a/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandler.kt
+++ b/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandler.kt
@@ -15,23 +15,14 @@
  */
 package slack.gradle.agp
 
+import com.android.build.api.AndroidPluginVersion
+
 /** An interface for handling different AGP versions via (mostly) version-agnostic APIs. */
 public interface AgpHandler {
-
   /** The current AGP version. */
-  public val agpVersion: String
+  public val agpVersion: AndroidPluginVersion
 }
 
-/**
- * Raw AGP [VersionNumber], which can include qualifiers like `-beta03`. Not usually what you want
- * in comparisons.
- */
-internal val AgpHandler.agpVersionNumberRaw: VersionNumber
-  get() = VersionNumber.parse(agpVersion)
-
-/**
- * Base AGP [VersionNumber], which won't include qualifiers like `-beta03`. Usually what you want in
- * comparisons.
- */
-public val AgpHandler.agpVersionNumber: VersionNumber
-  get() = agpVersionNumberRaw.baseVersion
+/** Returns a new [AndroidPluginVersion] with any preview information stripped. */
+public val AndroidPluginVersion.baseVersion: AndroidPluginVersion
+  get() = AndroidPluginVersion(major, minor, micro)

--- a/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandlerFactory.kt
+++ b/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/AgpHandlerFactory.kt
@@ -15,6 +15,8 @@
  */
 package slack.gradle.agp
 
+import com.android.build.api.AndroidPluginVersion
+
 /**
  * A basic factory interface for creating [AgpHandler] instances. These should be implemented and
  * contributed as a service loader via something like `@AutoService`.
@@ -23,9 +25,9 @@ package slack.gradle.agp
  * [currentVersion] and [create].
  */
 public interface AgpHandlerFactory {
-  public val minVersion: VersionNumber
+  public val minVersion: AndroidPluginVersion
   /** Attempts to get the current AGP version or throws and exception if it cannot. */
-  public fun currentVersion(): String
+  public val currentVersion: AndroidPluginVersion
 
   public fun create(): AgpHandler
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/AgpHandlers.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/AgpHandlers.kt
@@ -15,10 +15,10 @@
  */
 package slack.gradle
 
+import com.android.build.api.AndroidPluginVersion
 import java.util.ServiceLoader
 import slack.gradle.agp.AgpHandler
 import slack.gradle.agp.AgpHandlerFactory
-import slack.gradle.agp.VersionNumber
 
 internal object AgpHandlers {
   fun createHandler(): AgpHandler {
@@ -31,12 +31,12 @@ internal object AgpHandlers {
           // Filter out any factories that can't compute the AGP version, as
           // they're _definitely_ not compatible
           try {
-            FactoryData(VersionNumber.parse(factory.currentVersion()), factory)
+            FactoryData(factory.currentVersion, factory)
           } catch (t: Throwable) {
             null
           }
         }
-        .filter { (agpVersion, factory) -> agpVersion.baseVersion >= factory.minVersion }
+        .filter { (agpVersion, factory) -> agpVersion >= factory.minVersion }
         .maxByOrNull { (_, factory) -> factory.minVersion }
         ?.factory
         ?: error("Unrecognized AGP version!")
@@ -45,4 +45,7 @@ internal object AgpHandlers {
   }
 }
 
-private data class FactoryData(val agpVersion: VersionNumber, val factory: AgpHandlerFactory)
+private data class FactoryData(
+  val agpVersion: AndroidPluginVersion,
+  val factory: AgpHandlerFactory
+)


### PR DESCRIPTION
This is a new first-party API we can now use for this rather than string parsing

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->