### PR TITLE
Enable robolectric native graphics by default

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
+++ b/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
@@ -195,6 +195,11 @@ internal object UnitTests {
         "-Xss1m", // Stack size
       )
 
+      // TODO would be nice to some day only conditionally apply robolectric args
+      // Enable Robolectric's new NATIVE graphics mode.
+      // https://github.com/robolectric/robolectric/releases/tag/robolectric-4.10-alpha-1
+      systemProperty("robolectric.graphicsMode", "NATIVE")
+
       if (slackProperties.testVerboseLogging) {
         // Add additional logging on Jenkins to help debug hanging or OOM-ing unit tests.
         testLogging {


### PR DESCRIPTION
We've been using this in the slack android repo for a few months now and it's going fine

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->