### PR TITLE
Set kotlin module names

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -942,6 +942,11 @@ internal class StandardProjectConfigurations(
             // Potentially useful for static analysis or annotation processors
             javaParameters.set(true)
             freeCompilerArgs.addAll(KotlinBuildConfig.kotlinJvmCompilerArgs)
+
+            // Set the module name to a dashified version of the project path to ensure uniqueness
+            // in created .kotlin_module files
+            val pathProvider = project.provider { project.path.replace(":", "-") }
+            moduleName.set(pathProvider)
           }
         }
       }


### PR DESCRIPTION
Set the kotlin module name to a dashified version of the project path to ensure uniqueness  in created .kotlin_module files. This is particularly important for kotlin-reflect usages and anything else that introspects kotlin metadata

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->