### PR TITLE
Don't apply boms to core library desugaring's interface

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/Configurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/Configurations.kt
@@ -50,7 +50,6 @@ internal object Configurations {
         *ERROR_PRONE.toTypedArray(),
         *RUNTIME.toTypedArray(),
         COMPILE_ONLY,
-        CORE_LIBRARY_DESUGARING,
         "androidTestUtil",
         "lintChecks",
         "lintRelease"


### PR DESCRIPTION
Works around this issue: https://issuetracker.google.com/issues/301426678

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->