### PR TITLE
Model translator generation

### DIFF
--- a/skate-plugin/build.gradle.kts
+++ b/skate-plugin/build.gradle.kts
@@ -17,7 +17,10 @@ repositories { mavenCentral() }
 
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
-intellij { plugins.add("org.intellij.plugins.markdown") }
+intellij {
+  plugins.add("org.intellij.plugins.markdown")
+  plugins.add("org.jetbrains.kotlin")
+}
 
 fun isGitHash(hash: String): Boolean {
   if (hash.length != 40) {

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkatePluginSettings.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkatePluginSettings.kt
@@ -20,6 +20,11 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import org.jetbrains.annotations.VisibleForTesting
+
+@VisibleForTesting
+internal const val DEFAULT_TRANSLATOR_SOURCE_MODELS_PACKAGE_NAME = "slack.api.schemas"
+@VisibleForTesting internal const val DEFAULT_TRANSLATOR_FILE_NAME_SUFFIX = "Translator.kt"
 
 /** Manages user-specific settings for the Skate plugin */
 @Service(Service.Level.PROJECT)
@@ -38,8 +43,22 @@ class SkatePluginSettings : SimplePersistentStateComponent<SkatePluginSettings.S
       state.isWhatsNewEnabled = value
     }
 
+  var translatorSourceModelsPackageName: String
+    get() = state.translatorSourceModelsPackageName ?: DEFAULT_TRANSLATOR_SOURCE_MODELS_PACKAGE_NAME
+    set(value) {
+      state.translatorSourceModelsPackageName = value
+    }
+
+  var translatorFileNameSuffix: String
+    get() = state.translatorFileNameSuffix ?: DEFAULT_TRANSLATOR_FILE_NAME_SUFFIX
+    set(value) {
+      state.translatorFileNameSuffix = value
+    }
+
   class State : BaseState() {
     var whatsNewFilePath by string()
     var isWhatsNewEnabled by property(true)
+    var translatorSourceModelsPackageName by string()
+    var translatorFileNameSuffix by string()
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/GenerateTranslatorBodyAction.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/GenerateTranslatorBodyAction.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.modeltranslator
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.slack.sgp.intellij.SkateBundle
+import com.slack.sgp.intellij.modeltranslator.helper.TranslatorHelper
+import com.slack.sgp.intellij.modeltranslator.model.TranslatorBundle
+
+class GenerateTranslatorBodyAction(private val bundle: TranslatorBundle) : IntentionAction {
+  override fun getText() = SkateBundle.message("skate.modelTranslator.description")
+
+  override fun getFamilyName() = text
+
+  override fun isAvailable(project: Project, editor: Editor?, psiFile: PsiFile?) = true
+
+  override fun startInWriteAction() = true
+
+  override fun invoke(project: Project, editor: Editor?, psiFile: PsiFile?) {
+    val body = TranslatorHelper.generateBody(bundle)
+    if (body != null) {
+      bundle.element.bodyBlockExpression?.replace(body) ?: LOG.warn("Body block expression is null")
+    } else {
+      LOG.warn("Generated body is null")
+    }
+  }
+
+  companion object {
+    private val LOG: Logger = Logger.getInstance(GenerateTranslatorBodyAction::class.java)
+  }
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/TranslatorAnnotator.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/TranslatorAnnotator.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.modeltranslator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.psi.PsiElement
+import com.slack.sgp.intellij.SkateBundle
+import com.slack.sgp.intellij.modeltranslator.helper.TranslatorHelper
+
+class TranslatorAnnotator : Annotator {
+  override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+    val bundle = TranslatorHelper.extractBundle(element)
+
+    if (bundle != null)
+      holder
+        .newAnnotation(
+          HighlightSeverity.WEAK_WARNING,
+          SkateBundle.message("skate.modelTranslator.description")
+        )
+        .range(bundle.functionHeaderRange)
+        .needsUpdateOnTyping(true)
+        .withFix(GenerateTranslatorBodyAction(bundle))
+        .create()
+  }
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/helper/TranslatorHelper.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/helper/TranslatorHelper.kt
@@ -92,7 +92,15 @@ object TranslatorHelper {
     }
   }
 
-  /** Generates and returns the model translator body using the [bundle] information. */
+  /**
+   * Generates and returns the model translator body using the [bundle] information.
+   *
+   * Example:
+   * ```
+   * { return Call(id = id, title = title.toDomainModel(), dateStart = dateStart,
+   * dateEnded = dateEnd, actions = actions.map { it.toDomainModel() }) }
+   * ```
+   */
   fun generateBody(bundle: TranslatorBundle): KtBlockExpression? {
     val (sourceModel, destinationModel, element, importDirectives) = bundle
 

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/helper/TranslatorHelper.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/helper/TranslatorHelper.kt
@@ -214,7 +214,12 @@ object TranslatorHelper {
   }
 
   private fun String.isPlatformType(): Boolean {
-    return !contains(DOT) || contains("java.lang.") || contains("kotlin.")
+    return !contains(DOT) ||
+      contains("java.lang.") ||
+      contains("kotlin.") ||
+      contains("kotlinx.") ||
+      contains("android.") ||
+      contains("androidx.")
   }
 
   private fun getTopMostParent(model: String): String? {

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/helper/TranslatorHelper.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/helper/TranslatorHelper.kt
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.modeltranslator.helper
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiParameter
+import com.intellij.psi.PsiType
+import com.intellij.psi.search.GlobalSearchScope
+import com.slack.sgp.intellij.modeltranslator.model.TranslatorBundle
+import com.slack.sgp.intellij.util.snakeToCamelCase
+import org.jetbrains.kotlin.idea.quickfix.createFromUsage.callableBuilder.getReturnTypeReference
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+
+object TranslatorHelper {
+  private const val API_PACKAGE_NAME = "slack.api.schemas"
+  private const val DOT = "."
+  private const val FILENAME_SUFFIX = "Translator.kt"
+  private const val TRANSLATOR_FUNC_CALL = ".toDomainModel()"
+  private const val UNKNOWN_ENUM_VALUE = "UNKNOWN"
+  private const val JSON_NAME_ASSIGNMENT = "(name = \""
+  private const val JSON_ANNOTATION_NAME = "Json"
+
+  /**
+   * Extracts a bundle containing the necessary information to annotate and generate the model
+   * translator if [element] has the header of one and doesn't contain a return statement.
+   */
+  fun extractBundle(element: PsiElement): TranslatorBundle? {
+    if (element.containingFile.name.endsWith(FILENAME_SUFFIX) && element is KtNamedFunction) {
+
+      val sourceModel = element.receiverTypeReference?.text ?: return null
+      val sourceModelTopMostParent = getTopMostParent(sourceModel)
+
+      val importDirectives = element.containingKtFile.importDirectives
+      val sourceModelImport = importDirectives.findImport(sourceModelTopMostParent, sourceModel)
+
+      if (
+        !(sourceModelImport?.importedFqName?.asString() ?: sourceModel).startsWith(API_PACKAGE_NAME)
+      )
+        return null
+
+      val bodyExpression = element.bodyBlockExpression
+      if (
+        bodyExpression == null || bodyExpression.findDescendantOfType<KtReturnExpression>() != null
+      )
+        return null
+
+      val destinationModelRef = element.getReturnTypeReference()
+      val destinationModel = destinationModelRef?.text ?: return null
+
+      return TranslatorBundle(
+        sourceModel,
+        destinationModel,
+        element,
+        importDirectives,
+        TextRange.create(element.startOffset, destinationModelRef.endOffset)
+      )
+    } else {
+      return null
+    }
+  }
+
+  /** Generates and returns the model translator body using the [bundle] information. */
+  fun generateBody(bundle: TranslatorBundle): KtBlockExpression? {
+    val (sourceModel, destinationModel, element, importDirectives) = bundle
+
+    val destinationModelTopMostParent = getTopMostParent(destinationModel)
+
+    val destinationModelImport =
+      importDirectives.findImport(destinationModelTopMostParent, destinationModel)
+    val destinationModelFqImport =
+      destinationModelImport?.importedFqName?.asString() ?: destinationModel
+    val destinationModelFqName =
+      if (destinationModelTopMostParent != null)
+        "$destinationModelFqImport.${element.getReturnTypeReference()?.nameForReceiverLabel()}"
+      else destinationModelFqImport
+
+    val project = element.project
+    val modelClass =
+      JavaPsiFacade.getInstance(project)
+        .findClass(destinationModelFqName, GlobalSearchScope.projectScope(project))
+    if (modelClass != null) {
+      val bodyBlock =
+        KtPsiFactory(project)
+          .createBlock(
+            if (modelClass.isEnum) {
+              generateEnumBody(modelClass, sourceModel, destinationModel)
+            } else {
+              generateClassBody(modelClass, destinationModel)
+            }
+          )
+      return bodyBlock
+    }
+    return null
+  }
+
+  private fun List<KtImportDirective>.findImport(
+    modelTopMostParent: String?,
+    model: String
+  ): KtImportDirective? {
+    return firstOrNull {
+      val id = it.importedName?.identifier
+      id == (modelTopMostParent ?: model)
+    }
+  }
+
+  private fun generateEnumBody(
+    modelClass: PsiClass,
+    sourceModel: String,
+    destinationModel: String
+  ): String {
+    val lineSeparator = System.lineSeparator()
+    val whenBlock =
+      modelClass.fields.reversed().joinToString(lineSeparator) {
+        if (it.name != UNKNOWN_ENUM_VALUE) "$sourceModel.${it.name} -> $destinationModel.${it.name}"
+        else "else -> $destinationModel.${it.name}"
+      }
+    return "return when(this) {$lineSeparator$whenBlock$lineSeparator}"
+  }
+
+  private fun generateClassBody(modelClass: PsiClass, destinationModel: String): String {
+    val primaryConstructor = modelClass.constructors[0]
+    val params = primaryConstructor.parameterList.parameters
+
+    val core = generateAssignments(params)
+
+    return "return ${destinationModel}($core)"
+  }
+
+  private fun generateAssignments(params: Array<PsiParameter>): String {
+    return params.joinToString(", ") { param ->
+      val annotations = param.annotations
+
+      val value = getJsonName(annotations) ?: param.name
+
+      val (isKnownType, isInCollection) = param.type.extractTypeInfo()
+      "${param.name} = ${value.snakeToCamelCase()}${maybeCallToDomainModel(isKnownType, isInCollection)}"
+    }
+  }
+
+  private fun getJsonName(annotations: Array<out PsiAnnotation>): String? {
+    val hasJsonAnnotation =
+      annotations.findAnnotation(JSON_ANNOTATION_NAME) { it is KtConstructorCalleeExpression } !=
+        null
+    return if (hasJsonAnnotation) {
+      annotations
+        .findAnnotation(JSON_NAME_ASSIGNMENT) { it is KtValueArgumentList }
+        ?.let {
+          val name = it.findChild { child -> child is KtValueArgumentList }
+          name?.text?.substringAfter(JSON_NAME_ASSIGNMENT)?.substringBefore("\"")
+        }
+    } else {
+      null
+    }
+  }
+
+  private fun Array<out PsiAnnotation>.findAnnotation(
+    prefix: String,
+    predicate: (PsiElement) -> Boolean
+  ): PsiAnnotation? {
+    return firstOrNull {
+      val element = it.findChild(predicate)
+      element?.text?.startsWith(prefix) == true
+    }
+  }
+
+  private fun PsiAnnotation.findChild(predicate: (PsiElement) -> Boolean): PsiElement? {
+    return nameReferenceElement?.children?.firstOrNull(predicate)
+  }
+
+  private fun maybeCallToDomainModel(isKnownType: Boolean, isInCollection: Boolean): String {
+    return if (!isKnownType) {
+      if (isInCollection) ".map { it$TRANSLATOR_FUNC_CALL }" else TRANSLATOR_FUNC_CALL
+    } else {
+      ""
+    }
+  }
+
+  private fun PsiType.extractTypeInfo(): TypeInfo {
+    val type = canonicalText
+    val (innerType, isInCollection) =
+      if (type.contains("<")) {
+        type.substringAfter("<").substringBefore(">") to true
+      } else {
+        type to false
+      }
+
+    return TypeInfo(isKnownType = innerType.isPlatformType(), isInCollection = isInCollection)
+  }
+
+  private fun String.isPlatformType(): Boolean {
+    return !contains(DOT) || contains("java.lang.") || contains("kotlin.")
+  }
+
+  private fun getTopMostParent(model: String): String? {
+    return if (model.contains(DOT) && model.first().isUpperCase()) model.split(DOT).getOrNull(0)
+    else null
+  }
+}
+
+private data class TypeInfo(val isKnownType: Boolean, val isInCollection: Boolean)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/model/TranslatorBundle.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/model/TranslatorBundle.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.modeltranslator.model
+
+import com.intellij.openapi.util.TextRange
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+data class TranslatorBundle(
+  val sourceModel: String,
+  val destinationModel: String,
+  val element: KtNamedFunction,
+  val importDirectives: List<KtImportDirective>,
+  val functionHeaderRange: TextRange
+)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/model/TranslatorBundle.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/modeltranslator/model/TranslatorBundle.kt
@@ -19,6 +19,16 @@ import com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+/**
+ * Contains the necessary information to annotate and generate a model translator.
+ *
+ * @property sourceModel The model to translate from.
+ * @property destinationModel The model to translate to.
+ * @property element The translator function.
+ * @property importDirectives The list of imports in the translator file.
+ * @property functionHeaderRange The text range from the begging of the translator function until
+ *   the end of the [destinationModel].
+ */
 data class TranslatorBundle(
   val sourceModel: String,
   val destinationModel: String,

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/StringExtensions.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/StringExtensions.kt
@@ -15,8 +15,8 @@
  */
 package com.slack.sgp.intellij.util
 
-private val pattern = "_[a-z0-9]".toRegex()
+import com.google.common.base.CaseFormat
 
 fun String.snakeToCamelCase(): String {
-  return replace(pattern) { it.value.last().uppercase() }
+  return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, this)
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/StringExtensions.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/StringExtensions.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.util
+
+private val pattern = "_[a-z0-9]".toRegex()
+
+fun String.snakeToCamelCase(): String {
+  return replace(pattern) { it.value.last().uppercase() }
+}

--- a/skate-plugin/src/main/resources/META-INF/plugin.xml
+++ b/skate-plugin/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,7 @@
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
     <depends>org.intellij.plugins.markdown</depends>
+    <depends>org.jetbrains.kotlin</depends>
 
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->

--- a/skate-plugin/src/main/resources/META-INF/plugin.xml
+++ b/skate-plugin/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,7 @@
                 serviceImplementation="com.slack.sgp.intellij.SkateProjectServiceImpl"/>
         <projectConfigurable instance="com.slack.sgp.intellij.SkateConfig"/>
         <errorHandler implementation="com.slack.sgp.intellij.SkateErrorHandler"/>
+        <annotator language="kotlin" implementationClass="com.slack.sgp.intellij.modeltranslator.TranslatorAnnotator"/>
     </extensions>
 
     <applicationListeners>

--- a/skate-plugin/src/main/resources/messages/skateBundle.properties
+++ b/skate-plugin/src/main/resources/messages/skateBundle.properties
@@ -3,3 +3,4 @@ skate.configuration.choosePath.title=Choose file
 skate.configuration.choosePath.dialog.title=Choose Changelog File
 skate.configuration.enableWhatsNew.title=Enable What's New Panel
 skate.configuration.enableWhatsNew.description=If enabled, shows the What's New Panel if there are new changes detected in a specified changelog file.
+skate.modelTranslator.description=Generate translator body

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/modeltranslator/TranslatorAnnotatorTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/modeltranslator/TranslatorAnnotatorTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.modeltranslator
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import com.slack.sgp.intellij.SkateBundle
+
+class TranslatorAnnotatorTest : LightJavaCodeInsightFixtureTestCase() {
+
+  private val warningDescription = SkateBundle.message("skate.modelTranslator.description")
+
+  override fun getTestDataPath(): String {
+    return "src/test/testData"
+  }
+
+  fun testAnnotator() {
+    myFixture.configureByFiles("CallTranslator.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertTranslatorWarning(translatorWarning)
+  }
+
+  fun testAnnotator_NestedSource() {
+    myFixture.configureByFiles("ActionTranslator.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertTranslatorWarning(translatorWarning)
+  }
+
+  fun testAnnotator_FqNameSource() {
+    myFixture.configureByFiles("FullyQualifiedCallTranslator.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertTranslatorWarning(translatorWarning)
+  }
+
+  fun testAnnotator_ImportAlias() {
+    myFixture.configureByFiles("ImportAliasCallTranslator.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertTranslatorWarning(translatorWarning)
+  }
+
+  fun testAnnotator_WrongFileName() {
+    myFixture.configureByFiles("CallExtensions.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertThat(translatorWarning).isNull()
+  }
+
+  fun testAnnotator_NoTranslator() {
+    myFixture.configureByFiles("Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertThat(translatorWarning).isNull()
+  }
+
+  fun testAnnotator_SourceHasWrongPackageName() {
+    myFixture.configureByFiles("CallObjectsTranslator.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertThat(translatorWarning).isNull()
+  }
+
+  fun testAnnotator_NoDestination() {
+    myFixture.configureByFiles("CallObjectTranslator.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertThat(translatorWarning).isNull()
+  }
+
+  fun testAnnotator_NoBodyExpression() {
+    myFixture.configureByFiles("SingleLineCallTranslator.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertThat(translatorWarning).isNull()
+  }
+
+  fun testAnnotator_HasReturnExpression() {
+    myFixture.configureByFiles("NullableCallTranslator.kt", "Call.kt")
+
+    val translatorWarning =
+      myFixture.doHighlighting().firstOrNull { it.severity == HighlightSeverity.WEAK_WARNING }
+    assertThat(translatorWarning).isNull()
+  }
+
+  private fun assertTranslatorWarning(translatorWarning: HighlightInfo?) {
+    assertThat(translatorWarning).isNotNull()
+    assertThat(translatorWarning!!.description).isEqualTo(warningDescription)
+  }
+}

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/modeltranslator/TranslatorHelperTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/modeltranslator/TranslatorHelperTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.modeltranslator
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import com.slack.sgp.intellij.modeltranslator.helper.TranslatorHelper
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
+
+private const val ASSIGNMENTS =
+  "id = id, dateStart = dateStart, dateEnded = dateEnd, activeParticipantCount = activeParticipantCount, title = title.toDomainModel(), customTitle = customTitle, outgoingToUser = outgoing.toDomainModel(), incomingFromUser = incoming.toDomainModel(), activeParticipants = activeParticipants, actions = actions.map { it.toDomainModel() }, retryText = retryText.toDomainModel()"
+
+class TranslatorHelperTest : LightJavaCodeInsightFixtureTestCase() {
+  override fun getTestDataPath(): String {
+    return "src/test/testData"
+  }
+
+  fun testGenerateBody_Enum() {
+    myFixture.configureByFiles("ActionTranslator.kt", "Call.kt")
+
+    val body = generateBody()
+
+    assertThat(body).isNotNull()
+    assertThat(body!!.text)
+      .isEqualTo(
+        """
+        {
+        return when(this) {
+        CallObject.Action.RETRY -> Call.Action.RETRY
+        CallObject.Action.DECLINE -> Call.Action.DECLINE
+        CallObject.Action.JOIN -> Call.Action.JOIN
+        else -> Call.Action.UNKNOWN
+        }
+        }
+        """
+          .trimIndent()
+      )
+  }
+
+  fun testGenerateBody_Enum_FqNameDestination() {
+    myFixture.configureByFiles("FullyQualifiedActionTranslator.kt", "Call.kt")
+
+    val body = generateBody()
+
+    assertThat(body).isNotNull()
+    assertThat(body!!.text)
+      .isEqualTo(
+        """
+        {
+        return when(this) {
+        slack.api.schemas.CallObject.Action.RETRY -> slack.model.Call.Action.RETRY
+        slack.api.schemas.CallObject.Action.DECLINE -> slack.model.Call.Action.DECLINE
+        slack.api.schemas.CallObject.Action.JOIN -> slack.model.Call.Action.JOIN
+        else -> slack.model.Call.Action.UNKNOWN
+        }
+        }
+        """
+          .trimIndent()
+      )
+  }
+
+  fun testGenerateBody_Model() {
+    myFixture.configureByFiles("CallTranslator.kt", "Call.kt")
+
+    val body = generateBody()
+
+    assertThat(body).isNotNull()
+    assertThat(body!!.text)
+      .isEqualTo(
+        """
+        {
+        return Call($ASSIGNMENTS)
+        }
+        """
+          .trimIndent()
+      )
+  }
+
+  fun testGenerateBody_Model_FqNameDestination() {
+    myFixture.configureByFiles("FullyQualifiedCallTranslator.kt", "Call.kt")
+
+    val body = generateBody()
+
+    assertThat(body).isNotNull()
+    assertThat(body!!.text)
+      .isEqualTo(
+        """
+        {
+        return slack.model.Call($ASSIGNMENTS)
+        }
+        """
+          .trimIndent()
+      )
+  }
+
+  fun testGenerateBody_Model_ImportAlias() {
+    myFixture.configureByFiles("ImportAliasCallTranslator.kt", "Call.kt")
+
+    val body = generateBody()
+
+    assertThat(body).isNotNull()
+    assertThat(body!!.text)
+      .isEqualTo(
+        """
+        {
+        return DomainCall($ASSIGNMENTS)
+        }
+        """
+          .trimIndent()
+      )
+  }
+
+  private fun getNamedFunction() = file.findDescendantOfType<KtNamedFunction>()!!
+
+  private fun generateBody(): KtBlockExpression? {
+    return TranslatorHelper.generateBody(TranslatorHelper.extractBundle(getNamedFunction())!!)
+  }
+}

--- a/skate-plugin/src/test/testData/ActionTranslator.kt
+++ b/skate-plugin/src/test/testData/ActionTranslator.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import slack.api.schemas.CallObject
+import slack.model.Call
+
+fun CallObject.Action.toDomainModel(): Call.Action {
+  TODO()
+}

--- a/skate-plugin/src/test/testData/Call.kt
+++ b/skate-plugin/src/test/testData/Call.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import kotlin.Int
+import kotlin.String
+
+@JsonClass(generateAdapter = true)
+data class Call(
+  val id: String,
+  @Json(name = "date_start") val dateStart: String,
+  @Json(name = "date_end") val dateEnded: String? = null,
+  @Json(name = "active_participant_count") val activeParticipantCount: Int = 0,
+  val title: Title? = null,
+  @Json(name = "custom_title") val customTitle: String? = null,
+  @Json(name = "outgoing") val outgoingToUser: CallUser? = null,
+  @Json(name = "incoming") val incomingFromUser: CallUser? = null,
+  @Json(name = "active_participants") val activeParticipants: List<String>,
+  val actions: List<Action>? = null,
+  @Json(name = "retry_text") val retryText: RetryText? = null
+) {
+  @JsonClass(generateAdapter = false)
+  enum class Action {
+    UNKNOWN,
+    @Json(name = "join") JOIN,
+    @Json(name = "decline") DECLINE,
+    @Json(name = "retry") RETRY
+  }
+
+  @JsonClass(generateAdapter = false)
+  enum class RetryText {
+    UNKNOWN,
+    @Json(name = "call_back") CALL_BACK,
+    @Json(name = "call_again") CALL_AGAIN
+  }
+
+  @JsonClass(generateAdapter = false)
+  enum class Title {
+    UNKNOWN,
+    @Json(name = "custom") CUSTOM,
+    @Json(name = "incoming_ringing") INCOMING_RINGING,
+    @Json(name = "outgoing_ringing") OUTGOING_RINGING,
+    @Json(name = "active") ACTIVE,
+    @Json(name = "ended") ENDED,
+    @Json(name = "missed") MISSED,
+    @Json(name = "declined") DECLINED
+  }
+}

--- a/skate-plugin/src/test/testData/CallExtensions.kt
+++ b/skate-plugin/src/test/testData/CallExtensions.kt
@@ -16,6 +16,6 @@
 import slack.api.schemas.CallObject
 import slack.model.Call
 
-fun CallObject.toDomainModel(): Call? {
-  return null
+fun CallObject.toDomainModel(): Call {
+  TODO()
 }

--- a/skate-plugin/src/test/testData/CallExtensions.kt
+++ b/skate-plugin/src/test/testData/CallExtensions.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import slack.api.schemas.CallObject
+import slack.model.Call
+
+fun CallObject.toDomainModel(): Call? {
+  return null
+}

--- a/skate-plugin/src/test/testData/CallObjectTranslator.kt
+++ b/skate-plugin/src/test/testData/CallObjectTranslator.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import slack.api.schemas.CallObject
+
+fun CallObject.toDomainModel() {
+  TODO()
+}

--- a/skate-plugin/src/test/testData/CallObjectsTranslator.kt
+++ b/skate-plugin/src/test/testData/CallObjectsTranslator.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import slack.api.CallObject
+import slack.model.Call
+
+fun CallObject.toDomainModel(): Call {
+  TODO()
+}

--- a/skate-plugin/src/test/testData/CallTranslator.kt
+++ b/skate-plugin/src/test/testData/CallTranslator.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import slack.api.schemas.CallObject
+import slack.model.Call
+
+fun CallObject.toDomainModel(): Call {
+  TODO()
+}

--- a/skate-plugin/src/test/testData/FullyQualifiedActionTranslator.kt
+++ b/skate-plugin/src/test/testData/FullyQualifiedActionTranslator.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example
+
+fun slack.api.schemas.CallObject.Action.toDomainModel(): slack.model.Call.Action {
+  TODO()
+}

--- a/skate-plugin/src/test/testData/FullyQualifiedCallTranslator.kt
+++ b/skate-plugin/src/test/testData/FullyQualifiedCallTranslator.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example
+fun slack.api.schemas.CallObject.toDomainModel(): slack.model.Call {
+  TODO()
+}

--- a/skate-plugin/src/test/testData/ImportAliasCallTranslator.kt
+++ b/skate-plugin/src/test/testData/ImportAliasCallTranslator.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import slack.api.schemas.CallObject as ApiCall
+import slack.model.Call as DomainCall
+
+fun ApiCall.toDomainModel(): DomainCall {
+  TODO()
+}

--- a/skate-plugin/src/test/testData/NullableCallTranslator.kt
+++ b/skate-plugin/src/test/testData/NullableCallTranslator.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import slack.api.schemas.CallObject
+import slack.model.Call
+
+fun CallObject.toDomainModel(): Call? {
+  return null
+}

--- a/skate-plugin/src/test/testData/SingleLineCallTranslator.kt
+++ b/skate-plugin/src/test/testData/SingleLineCallTranslator.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import slack.api.schemas.CallObject
+import slack.model.Call
+
+fun CallObject.toDomainModel(): Call = TODO()


### PR DESCRIPTION
This adds model translator generation to Skate Plugin. It's meant to assist in writing translators to convert API models to domain models by generating a first implementation that can be iterated on after, eliminating the need for doing the tedious repetitive steps.


https://github.com/slackhq/slack-gradle-plugin/assets/3355288/b1938e8f-dea7-414d-9fb2-ab9b91fbba6b

