### PR TITLE
Move debugprobes exclusion to release builds only

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -657,6 +657,11 @@ internal class StandardProjectConfigurations(
           logger.debug("$LOG AndroidTest for ${builder.name} enabled? $variantEnabled")
           builder.enableAndroidTest = variantEnabled
         }
+
+        onVariants(selector().withBuildType("release")) { variant ->
+          // Metadata for coroutines not relevant to release builds
+          variant.packaging.resources.excludes.add("DebugProbesKt.bin")
+        }
       }
       configure<BaseAppModuleExtension> {
         slackExtension.setAndroidExtension(this)
@@ -685,8 +690,6 @@ internal class StandardProjectConfigurations(
               "META-INF/DEPENDENCIES",
               "**/*.pro",
               "**/*.proto",
-              // Metadata for coroutines not relevant to release builds
-              "DebugProbesKt.bin",
               // Weird bazel build metadata brought in by Tink
               "build-data.properties",
               "LICENSE_*",


### PR DESCRIPTION
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->