### PR TITLE
Make debug builds use consistent version codes/names on CI

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -77,9 +77,13 @@ public class SlackProperties private constructor(private val project: Project) {
   public val skipAndroidxCheck: Boolean
     get() = booleanProperty("slack.gradle.skipAndroidXCheck")
 
-  /** Default version code used for APK outputs. */
-  public val defaultVersionCode: Int
-    get() = intProperty("slack.gradle.defaultVersionCode", 90009999)
+  /** Version code used for debug APK outputs. */
+  public val debugVersionCode: Int
+    get() = intProperty("slack.gradle.debugVersionCode", 90009999)
+
+  /** User string used for debug APK outputs. */
+  public val debugUserString: String
+    get() = stringProperty("slack.gradle.debugVersionCode", "debug")
 
   /** Opt-in flag to enable snapshots repos, used for the dependencies build shadow job. */
   public val enableSnapshots: Boolean
@@ -90,8 +94,8 @@ public class SlackProperties private constructor(private val project: Project) {
     get() = booleanProperty("slack.gradle.config.enableMavenLocal")
 
   /**
-   * Flag to indicate that that this project should have no api dependencies, such as if it's solely
-   * an annotation processor.
+   * Flag to indicate that this project should have no api dependencies, such as if it's solely an
+   * annotation processor.
    */
   public val rakeNoApi: Boolean
     get() = booleanProperty("slack.gradle.config.rake.noapi")


### PR DESCRIPTION
Previously, we would use interpolations of CI build numbers and user names for version codes and version names of APKs, resulting in remote build cache misses for anything involving manifests and buildconfig. This optimizes the debug build happy path by ensuring all debug builds have the same values for both, while still using the original heuristics for any other build types.

For slack employees, you can see an example build scan comparison of where this issue arises here: https://gradle-enterprise.tinyspeck.com/c/4ywvch5rawiia/vklqqwvf3ei7s/task-inputs?cacheability=cacheable

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->