### PR TITLE
Revamp lint handling to support KMP + incorporate some ideas from AndroidX

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import slack.gradle.agp.VersionNumber
 import slack.gradle.dependencies.DependencyDef
 import slack.gradle.dependencies.DependencyGroup
@@ -184,6 +185,9 @@ internal fun Project.getVersionsCatalogOrNull(name: String = "libs"): VersionCat
     null
   }
 }
+
+internal val Project.multiplatformExtension
+  get() = extensions.findByType(KotlinMultiplatformExtension::class.java)
 
 /** Returns a map of module identifiers to toml library reference aliases */
 internal fun VersionCatalog.identifierMap(): Map<String, String> {

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackGradleUtil.kt
@@ -15,6 +15,10 @@
  */
 package slack.gradle
 
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.TestAndroidComponentsExtension
 import com.google.common.base.CaseFormat
 import java.io.File
 import java.util.Locale
@@ -185,6 +189,17 @@ internal fun Project.getVersionsCatalogOrNull(name: String = "libs"): VersionCat
     null
   }
 }
+
+internal val Project.androidExtension: AndroidComponentsExtension<*, *, *>
+  get() =
+    androidExtensionNullable
+      ?: throw IllegalArgumentException("Failed to find any registered Android extension")
+
+internal val Project.androidExtensionNullable: AndroidComponentsExtension<*, *, *>?
+  get() =
+    extensions.findByType<LibraryAndroidComponentsExtension>()
+      ?: extensions.findByType<ApplicationAndroidComponentsExtension>()
+      ?: extensions.findByType<TestAndroidComponentsExtension>()
 
 internal val Project.multiplatformExtension
   get() = extensions.findByType(KotlinMultiplatformExtension::class.java)

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -264,10 +264,6 @@ public class SlackProperties private constructor(private val project: Project) {
   public val lintErrorsOnly: Boolean
     get() = booleanProperty("slack.lint.errors-only")
 
-  /** Flag to indicate that we're currently running a baseline update. */
-  public val lintUpdateBaselines: Boolean
-    get() = booleanProperty("slack.lint.update-baselines")
-
   /** File name to use for a project's lint baseline. */
   public val lintBaselineFileName: String
     get() = stringProperty("slack.lint.baseline-file-name", "lint-baseline.xml")

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -119,14 +119,14 @@ internal class StandardProjectConfigurations(
         slackProperties,
         versionCatalog
       )
-    project.applyCommonConfigurations()
+    project.applyCommonConfigurations(slackProperties)
     val jdkVersion = project.jdkVersion()
     val jvmTargetVersion = project.jvmTargetVersion()
     project.applyJvmConfigurations(jdkVersion, jvmTargetVersion, slackProperties, slackExtension)
     project.configureKotlinProjects(jdkVersion, jvmTargetVersion, slackProperties)
   }
 
-  private fun Project.applyCommonConfigurations() {
+  private fun Project.applyCommonConfigurations(slackProperties: SlackProperties) {
     if (globalProperties.autoApplySortDependencies) {
       if (project.buildFile.exists()) {
         val sortDependenciesIgnoreSet =
@@ -136,6 +136,12 @@ internal class StandardProjectConfigurations(
         }
       }
     }
+    LintTasks.configureSubProject2(
+      project,
+      slackProperties,
+      slackTools.globalConfig.affectedProjects,
+      slackTools::logAvoidedTask,
+    )
   }
 
   @Suppress("unused")
@@ -619,16 +625,6 @@ internal class StandardProjectConfigurations(
         slackExtension.setAndroidExtension(this)
         commonBaseExtensionConfig(false)
         defaultConfig { targetSdk = sdkVersions.value.targetSdk }
-        if (slackProperties.enableLintInAndroidTestProjects) {
-          LintTasks.configureSubProject(
-            project,
-            slackProperties,
-            slackTools.globalConfig.affectedProjects,
-            slackTools::logAvoidedTask,
-            this,
-            sdkVersions::value
-          )
-        }
       }
     }
 
@@ -670,14 +666,6 @@ internal class StandardProjectConfigurations(
           // TODO this won't work with SDK previews but will fix in a followup
           targetSdk = sdkVersions.value.targetSdk
         }
-        LintTasks.configureSubProject(
-          project,
-          slackProperties,
-          slackTools.globalConfig.affectedProjects,
-          slackTools::logAvoidedTask,
-          this,
-          sdkVersions::value
-        )
         packaging {
           resources.excludes +=
             setOf(
@@ -843,14 +831,6 @@ internal class StandardProjectConfigurations(
       configure<LibraryExtension> {
         slackExtension.setAndroidExtension(this)
         commonBaseExtensionConfig(true)
-        LintTasks.configureSubProject(
-          project,
-          slackProperties,
-          slackTools.globalConfig.affectedProjects,
-          slackTools::logAvoidedTask,
-          this,
-          sdkVersions::value
-        )
         if (isLibraryWithVariants) {
           buildTypes {
             getByName("debug") {
@@ -954,17 +934,6 @@ internal class StandardProjectConfigurations(
           slackTools.globalConfig.mergeDetektBaselinesTask,
         )
       }
-    }
-
-    pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-      LintTasks.configureSubProject(
-        project,
-        slackProperties,
-        slackTools.globalConfig.affectedProjects,
-        slackTools::logAvoidedTask,
-        null,
-        null
-      )
     }
 
     pluginManager.withPlugin("org.jetbrains.kotlin.android") {

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -136,7 +136,7 @@ internal class StandardProjectConfigurations(
         }
       }
     }
-    LintTasks.configureSubProject2(
+    LintTasks.configureSubProject(
       project,
       slackProperties,
       slackTools.globalConfig.affectedProjects,

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -66,7 +66,7 @@ internal object LintTasks {
       description = "Global lifecycle task to run all dependent lint tasks."
     }
 
-  fun configureSubProject2(
+  fun configureSubProject(
     project: Project,
     slackProperties: SlackProperties,
     affectedProjects: Set<String>?,

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -193,7 +193,7 @@ internal object LintTasks {
 
     // For Android projects, the Android Gradle Plugin is responsible for applying the lint plugin;
     // however, we need to apply it ourselves for non-Android projects.
-    apply(mapOf("plugin" to "com.android.lint"))
+    pluginManager.apply("com.android.lint")
 
     // Create task aliases matching those creates by AGP for Android projects, since those are what
     // developers expect to invoke. Redirect them to the "real" lint task.

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -359,9 +359,7 @@ internal object LintTasks {
     }
 
     // Synthesize source sets based on multiplatform source sets.
-    val javaExtension =
-      project.extensions.findByType(JavaPluginExtension::class.java)
-        ?: throw GradleException("Failed to find extension of type 'JavaPluginExtension'")
+    val javaExtension = project.extensions.getByType<JavaPluginExtension>()
     listOf("main" to "main", "test" to "test").forEach { (kmpCompilationName, targetSourceSetName)
       ->
       javaExtension.sourceSets.maybeCreate(targetSourceSetName).apply {

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -15,25 +15,41 @@
  */
 package slack.gradle.lint
 
-import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.Lint
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.api.variant.LibraryAndroidComponentsExtension
-import com.android.build.api.variant.TestAndroidComponentsExtension
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.TestExtension
-import java.util.concurrent.atomic.AtomicBoolean
+import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryPlugin
+import com.android.build.gradle.TestPlugin
+import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
+import com.android.build.gradle.internal.lint.LintModelWriterTask
+import com.android.build.gradle.internal.lint.VariantInputs
+import java.io.File
+import org.gradle.api.Action
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.plugins.AppliedPlugin
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.tooling.core.withClosure
 import slack.gradle.SlackProperties
+import slack.gradle.androidExtension
+import slack.gradle.androidExtensionNullable
 import slack.gradle.capitalizeUS
-import slack.gradle.configure
 import slack.gradle.getByType
+import slack.gradle.multiplatformExtension
 
+/**
+ * Common configuration for Android lint in projects.
+ *
+ * Much of this file adapts KMP art from AndroidX:
+ * https://github.com/androidx/androidx/blob/cb78132cc8288f85e0ff8f4c32ed58a61b05d7d8/buildSrc/private/src/main/kotlin/androidx/build/LintConfiguration.kt
+ */
 internal object LintTasks {
   private const val GLOBAL_CI_LINT_TASK_NAME = "globalCiLint"
   private const val CI_LINT_TASK_NAME = "ciLint"
@@ -50,26 +66,178 @@ internal object LintTasks {
       description = "Global lifecycle task to run all dependent lint tasks."
     }
 
-  fun configureSubProject(
+  fun configureSubProject2(
     project: Project,
     slackProperties: SlackProperties,
     affectedProjects: Set<String>?,
     onProjectSkipped: (String, String) -> Unit,
-    commonExtension: CommonExtension<*, *, *, *, *>?,
-    sdkVersions: (() -> SlackProperties.AndroidSdkProperties)?,
   ) {
-    project.log("Configuring lint tasks for project ${project.path}...")
+    project.log("Configuring lint tasks for project ${project.path}")
     // Projects can opt out of creating the task with this property.
     val enabled = slackProperties.ciLintEnabled
     if (!enabled) {
       project.log("Skipping creation of \"$CI_LINT_TASK_NAME\" task")
       return
     }
-
-    fun applyCommonLints() {
-      slackProperties.versions.bundles.commonLint.ifPresent {
-        project.dependencies.add("lintChecks", it)
+    val projectAllAction =
+      Action<Plugin<*>> {
+        when (this) {
+          is AppPlugin,
+          is LibraryPlugin ->
+            project.configureAndroidProjectForLint(
+              slackProperties,
+              affectedProjects,
+              onProjectSkipped
+            )
+          is TestPlugin -> {
+            if (slackProperties.enableLintInAndroidTestProjects) {
+              project.configureAndroidProjectForLint(
+                slackProperties,
+                affectedProjects,
+                onProjectSkipped
+              )
+            }
+          }
+          // Only configure non-multiplatform Java projects via JavaPlugin. Multiplatform
+          // projects targeting Java (e.g. `jvm { withJava() }`) are configured via
+          // KotlinBasePlugin.
+          is JavaPlugin ->
+            if (project.multiplatformExtension == null) {
+              project.configureNonAndroidProjectForLint(
+                slackProperties,
+                affectedProjects,
+                onProjectSkipped
+              )
+            }
+          // Only configure non-Android multiplatform projects via KotlinBasePlugin.
+          // Multiplatform projects targeting Android (e.g. `id("com.android.library")`) are
+          // configured via AppPlugin or LibraryPlugin.
+          is KotlinBasePlugin ->
+            if (
+              project.multiplatformExtension != null &&
+                !project.plugins.hasPlugin(AppPlugin::class.java) &&
+                !project.plugins.hasPlugin(LibraryPlugin::class.java)
+            ) {
+              project.configureNonAndroidProjectForLint(
+                slackProperties,
+                affectedProjects,
+                onProjectSkipped
+              )
+            }
+        }
       }
+    project.plugins.all(projectAllAction)
+  }
+
+  /** Android Lint configuration entry point for Android projects. */
+  private fun Project.configureAndroidProjectForLint(
+    slackProperties: SlackProperties,
+    affectedProjects: Set<String>?,
+    onProjectSkipped: (String, String) -> Unit,
+  ) =
+    androidExtension.finalizeDsl { extension ->
+      project.log("Applying ciLint to Android project")
+
+      project.log(
+        "Configuring android lint tasks. isApp=${extension is ApplicationAndroidComponentsExtension}"
+      )
+
+      project.log("Creating ciLint task")
+      val ciLintTask =
+        project.tasks.register(CI_LINT_TASK_NAME) { group = LifecycleBasePlugin.VERIFICATION_GROUP }
+
+      val ciLintVariants = slackProperties.ciLintVariants
+      if (ciLintVariants != null) {
+        ciLintTask.configure {
+          // Even if the task isn't created yet, we can do this by name alone and it will resolve at
+          // task configuration time.
+          ciLintVariants.splitToSequence(',').forEach { variant ->
+            logger.debug("Using variant $variant for ciLint task")
+            val lintTaskName = "lint${variant.capitalizeUS()}"
+            dependsOn(lintTaskName)
+          }
+        }
+      } else {
+        androidExtension.onVariants { variant ->
+          val lintTaskName = "lint${variant.name.capitalizeUS()}"
+          project.log("Adding $lintTaskName to ciLint task")
+          ciLintTask.configure {
+            // Even if the task isn't created yet, we can do this by name alone and it will resolve
+            // at
+            // task configuration time.
+            dependsOn(lintTaskName)
+          }
+        }
+      }
+
+      configureLint(
+        extension.lint,
+        ciLintTask,
+        slackProperties,
+        affectedProjects,
+        onProjectSkipped,
+        slackProperties.requireAndroidSdkProperties()
+      )
+    }
+
+  /** Android Lint configuration entry point for non-Android projects. */
+  private fun Project.configureNonAndroidProjectForLint(
+    slackProperties: SlackProperties,
+    affectedProjects: Set<String>?,
+    onProjectSkipped: (String, String) -> Unit,
+  ) = afterEvaluate {
+    // The lint plugin expects certain configurations and source sets which are only added by
+    // the Java and Android plugins. If this is a multiplatform project targeting JVM, we'll
+    // need to manually create these configurations and source sets based on their multiplatform
+    // JVM equivalents.
+    addSourceSetsForMultiplatformAfterEvaluate()
+
+    // For Android projects, the Android Gradle Plugin is responsible for applying the lint plugin;
+    // however, we need to apply it ourselves for non-Android projects.
+    apply(mapOf("plugin" to "com.android.lint"))
+
+    // Create task aliases matching those creates by AGP for Android projects, since those are what
+    // developers expect to invoke. Redirect them to the "real" lint task.
+    val lintTask = tasks.named("lint")
+    tasks.register("lintDebug") {
+      dependsOn(lintTask)
+      enabled = false
+    }
+    tasks.register("lintRelease") {
+      dependsOn(lintTask)
+      enabled = false
+    }
+
+    project.log("Creating ciLint task")
+    val ciLint =
+      project.tasks.register(COMPILE_CI_LINT_NAME) {
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        dependsOn("lint")
+      }
+
+    // For Android projects, we can run lint configuration last using `DslLifecycle.finalizeDsl`;
+    // however, we need to run it using `Project.afterEvaluate` for non-Android projects.
+    configureLint(
+      project.extensions.getByType(),
+      ciLint,
+      slackProperties,
+      affectedProjects,
+      onProjectSkipped
+    )
+  }
+
+  private fun Project.configureLint(
+    lint: Lint,
+    ciLintTask: TaskProvider<*>,
+    slackProperties: SlackProperties,
+    affectedProjects: Set<String>?,
+    onProjectSkipped: (String, String) -> Unit,
+    androidSdkVersions: SlackProperties.AndroidSdkProperties? = null,
+  ) {
+    val isMultiplatform = project.multiplatformExtension != null
+
+    slackProperties.versions.bundles.commonLint.ifPresent {
+      project.dependencies.add("lintChecks", it)
     }
 
     val globalTask =
@@ -87,128 +255,196 @@ internal object LintTasks {
         null
       }
 
-    // We only want to create tasks once, but a project might apply multiple plugins.
-    val applied = AtomicBoolean(false)
-
-    if (commonExtension != null) {
-      project.log("Applying ciLint to Android project")
-      applyCommonLints()
-      createAndroidCiLintTask(
-        project,
-        globalTask,
-        slackProperties,
-        commonExtension,
-        sdkVersions!!.invoke()
-      )
-    } else {
-      val javaKotlinLibraryHandler = { _: AppliedPlugin ->
-        if (applied.compareAndSet(false, true)) {
-          // Enable linting on pure JVM projects
-          project.pluginManager.apply("com.android.lint")
-          project.configure<Lint> { configureLint(project, slackProperties, null, false) }
-          applyCommonLints()
-          project.log("Creating ciLint task")
-          val ciLint =
-            project.tasks.register(COMPILE_CI_LINT_NAME) {
-              group = LifecycleBasePlugin.VERIFICATION_GROUP
-              dependsOn("lint")
-            }
-          globalTask?.configure { dependsOn(ciLint) }
-        }
-      }
-      project.pluginManager.withPlugin("java-library", javaKotlinLibraryHandler)
-      project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm", javaKotlinLibraryHandler)
-    }
-  }
-
-  private fun createAndroidCiLintTask(
-    project: Project,
-    globalTask: TaskProvider<*>?,
-    slackProperties: SlackProperties,
-    extension: CommonExtension<*, *, *, *, *>,
-    sdkVersions: SlackProperties.AndroidSdkProperties,
-  ) {
-    project.log("Configuring android lint tasks. isApp=${extension is AppExtension}")
-    extension.lint {
-      configureLint(
-        project,
-        slackProperties,
-        sdkVersions,
-        checkDependencies = extension is AppExtension
-      )
-    }
-
-    project.log("Creating ciLint task")
-    val ciLintTask =
-      project.tasks.register(CI_LINT_TASK_NAME) { group = LifecycleBasePlugin.VERIFICATION_GROUP }
     globalTask?.configure { dependsOn(ciLintTask) }
 
-    slackProperties.ciLintVariants?.let { variants ->
-      ciLintTask.configure {
-        // Even if the task isn't created yet, we can do this by name alone and it will resolve at
-        // task configuration time.
-        variants.splitToSequence(',').forEach { variant ->
-          logger.debug("Using variant $variant for ciLint task")
-          val lintTaskName = "lint${variant.capitalizeUS()}"
-          dependsOn(lintTaskName)
-        }
-      }
-      return // nothing else to do!
+    afterEvaluate { addSourceSetsForAndroidMultiplatformAfterEvaluate() }
+
+    lint.apply {
+      // Skip lintVital tasks on assemble. We explicitly run lintRelease for libraries.
+      checkReleaseBuilds = false
     }
 
-    val componentsExtension =
-      when (extension) {
-        is AppExtension -> {
-          project.extensions.getByType<ApplicationAndroidComponentsExtension>()
-        }
-        is LibraryExtension -> {
-          project.extensions.getByType<LibraryAndroidComponentsExtension>()
-        }
-        is TestExtension -> {
-          project.extensions.getByType<TestAndroidComponentsExtension>()
-        }
-        else -> error("No AndroidComponentsExtension found for project ${project.path}")
+    // Lint is configured entirely in finalizeDsl so that individual projects cannot easily
+    // disable individual checks in the DSL for any reason.
+    lint.apply {
+      ignoreWarnings = slackProperties.lintErrorsOnly
+
+      // Run lint on tests. Uses top-level lint.xml to specify checks.
+      ignoreTestSources = slackProperties.lintIgnoreTestSources
+      checkTestSources = slackProperties.lintCheckTestSources
+
+      textReport = true
+      xmlReport = true
+      htmlReport = true
+      sarifReport = true
+
+      // Format text output for convenience.
+      explainIssues = true
+      noLines = false
+      quiet = true
+
+      // We run lint on each library, so we don't want transitive checking of each dependency
+      checkDependencies = false
+
+      fatal.add("VisibleForTests")
+
+      if (isMultiplatform) {
+        // Disable classfile-based checks because lint cannot find the class files for
+        // multiplatform projects and `SourceSet.java.classesDirectory` is not configurable.
+        // This is not ideal, but it's better than having no lint checks at all.
+        disable.add("LintError")
       }
-    componentsExtension.onVariants { variant ->
-      val lintTaskName = "lint${variant.name.capitalizeUS()}"
-      project.log("Adding $lintTaskName to ciLint task")
-      ciLintTask.configure {
-        // Even if the task isn't created yet, we can do this by name alone and it will resolve at
-        // task configuration time.
-        dependsOn(lintTaskName)
+
+      // Disable dependency checks that suggest to change them. We want libraries to be
+      // intentional with their dependency version bumps.
+      disable.add("KtxExtensionAvailable")
+      disable.add("GradleDependency")
+
+      // These store qualified gradle caches in their paths and always change in baselines
+      disable += "ObsoleteLintCustomCheck"
+
+      // Explicitly disable StopShip check (see b/244617216)
+      disable.add("StopShip")
+
+      fatal.add("Assert")
+      fatal.add("NewApi")
+      fatal.add("ObsoleteSdkInt")
+      fatal.add("NoHardKeywords")
+      fatal.add("UnusedResources")
+      fatal.add("KotlinPropertyAccess")
+      fatal.add("LambdaLast")
+
+      // Too many Kotlin features require synthetic accessors - we want to rely on R8 to
+      // remove these accessors
+      disable.add("SyntheticAccessor")
+
+      // Only check for missing translations in finalized (beta and later) modules.
+      fatal.add("MissingTranslation")
+
+      if (androidExtensionNullable is ApplicationAndroidComponentsExtension) {
+        checkDependencies = true
+      }
+
+      androidSdkVersions?.let { sdkVersions ->
+        if (sdkVersions.minSdk >= 28) {
+          // Lint doesn't understand AppComponentFactory
+          // https://issuetracker.google.com/issues/243267012
+          disable += "Instantiatable"
+        }
+      }
+
+      lintConfig = project.rootProject.layout.projectDirectory.file("config/lint/lint.xml").asFile
+
+      baseline =
+        project.objects
+          .fileProperty()
+          .fileValue(File(project.projectDir, slackProperties.lintBaselineFileName))
+          .get()
+          .asFile
+    }
+  }
+
+  /**
+   * If the project is using multiplatform, adds configurations and source sets expected by the lint
+   * plugin, which allows it to configure itself when running against a non-Android multiplatform
+   * project.
+   *
+   * The version of lint that we're using does not directly support Kotlin multiplatform, but we can
+   * synthesize the necessary configurations and source sets from existing `jvm` configurations and
+   * `kotlinSourceSets`, respectively.
+   *
+   * This method *must* run after evaluation.
+   */
+  private fun Project.addSourceSetsForMultiplatformAfterEvaluate() {
+    val kmpTargets = project.multiplatformExtension?.targets ?: return
+
+    // Synthesize target configurations based on multiplatform configurations.
+    val kmpApiElements = kmpTargets.map { it.apiElementsConfigurationName }
+    val kmpRuntimeElements = kmpTargets.map { it.runtimeElementsConfigurationName }
+    listOf(kmpRuntimeElements to "runtimeElements", kmpApiElements to "apiElements").forEach {
+      (kmpConfigNames, targetConfigName) ->
+      project.configurations.maybeCreate(targetConfigName).apply {
+        kmpConfigNames
+          .mapNotNull { configName -> project.configurations.findByName(configName) }
+          .forEach { config -> extendsFrom(config) }
+      }
+    }
+
+    // Synthesize source sets based on multiplatform source sets.
+    val javaExtension =
+      project.extensions.findByType(JavaPluginExtension::class.java)
+        ?: throw GradleException("Failed to find extension of type 'JavaPluginExtension'")
+    listOf("main" to "main", "test" to "test").forEach { (kmpCompilationName, targetSourceSetName)
+      ->
+      javaExtension.sourceSets.maybeCreate(targetSourceSetName).apply {
+        kmpTargets
+          .mapNotNull { target -> target.compilations.findByName(kmpCompilationName) }
+          .flatMap { compilation -> compilation.kotlinSourceSets }
+          .flatMap { sourceSet -> sourceSet.kotlin.srcDirs }
+          .forEach { srcDirs -> java.srcDirs += srcDirs }
       }
     }
   }
 
-  private fun Lint.configureLint(
-    project: Project,
-    slackProperties: SlackProperties,
-    androidSdkVersions: SlackProperties.AndroidSdkProperties?,
-    checkDependencies: Boolean,
-  ) {
-    lintConfig = project.rootProject.layout.projectDirectory.file("config/lint/lint.xml").asFile
-    sarifReport = true
-    // This check is _never_ up to date and makes network requests!
-    disable += "NewerVersionAvailable"
-    // These store qualified gradle caches in their paths and always change in baselines
-    disable += "ObsoleteLintCustomCheck"
+  /**
+   * If the project is using multiplatform targeted to Android, adds source sets directly to lint
+   * tasks, which allows it to run against Android multiplatform projects.
+   *
+   * Lint is not aware of MPP, and MPP doesn't configure Lint. There is no built-in API to adjust
+   * the default Lint task's sources, so we use this hack to manually add sources for MPP source
+   * sets. In the future, with the new Kotlin Project Model
+   * (https://youtrack.jetbrains.com/issue/KT-42572) and an AGP / MPP integration plugin, this will
+   * no longer be needed. See also b/195329463.
+   */
+  private fun Project.addSourceSetsForAndroidMultiplatformAfterEvaluate() {
+    val multiplatformExtension = project.multiplatformExtension ?: return
+    multiplatformExtension.targets.findByName("android") ?: return
 
-    androidSdkVersions?.let { sdkVersions ->
-      if (sdkVersions.minSdk >= 28) {
-        // Lint doesn't understand AppComponentFactory
-        // https://issuetracker.google.com/issues/243267012
-        disable += "Instantiatable"
+    val androidMain =
+      multiplatformExtension.sourceSets.findByName("androidMain")
+        ?: throw GradleException("Failed to find source set with name 'androidMain'")
+
+    // Get all the source sets androidMain transitively / directly depends on.
+    val dependencySourceSets = androidMain.withClosure(KotlinSourceSet::dependsOn)
+
+    /** Helper function to add the missing sourcesets to this [VariantInputs] */
+    fun VariantInputs.addSourceSets() {
+      // Each variant has a source provider for the variant (such as debug) and the 'main'
+      // variant. The actual files that Lint will run on is both of these providers
+      // combined - so we can just add the dependencies to the first we see.
+      val sourceProvider = sourceProviders.get().firstOrNull() ?: return
+      dependencySourceSets.forEach { sourceSet ->
+        sourceProvider.javaDirectories.withChangesAllowed {
+          from(sourceSet.kotlin.sourceDirectories)
+        }
       }
     }
 
-    ignoreWarnings = slackProperties.lintErrorsOnly
-    absolutePaths = false
-    this.checkDependencies = checkDependencies
+    // Add the new sources to the lint analysis tasks.
+    project.tasks.withType(AndroidLintAnalysisTask::class.java).configureEach {
+      variantInputs.addSourceSets()
+    }
 
-    ignoreTestSources = slackProperties.lintIgnoreTestSources
-    checkTestSources = slackProperties.lintCheckTestSources
+    // Also configure the model writing task, so that we don't run into mismatches between
+    // analyzed sources in one module and a downstream module
+    project.tasks.withType(LintModelWriterTask::class.java).configureEach {
+      variantInputs.addSourceSets()
+    }
+  }
 
-    baseline = project.objects.fileProperty().fileValue(File(project.projectDir, slackProperties.lintBaselineFileName))
-      .get().asFile
+  /**
+   * Lint uses [ConfigurableFileCollection.disallowChanges] during initialization, which prevents
+   * modifying the file collection separately (there is no time to configure it before AGP has
+   * initialized and disallowed changes). This uses reflection to temporarily allow changes, and
+   * apply [block].
+   */
+  private fun ConfigurableFileCollection.withChangesAllowed(
+    block: ConfigurableFileCollection.() -> Unit
+  ) {
+    val disallowChanges = this::class.java.getDeclaredField("disallowChanges")
+    disallowChanges.isAccessible = true
+    disallowChanges.set(this, false)
+    block()
+    disallowChanges.set(this, true)
   }
 }

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -211,7 +211,7 @@ internal object LintTasks {
     val ciLint =
       tasks.register(COMPILE_CI_LINT_NAME) {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
-        dependsOn("lint")
+        dependsOn(lintTask)
       }
 
     // For Android projects, we can run lint configuration last using `DslLifecycle.finalizeDsl`;
@@ -256,14 +256,12 @@ internal object LintTasks {
 
     afterEvaluate { addSourceSetsForAndroidMultiplatformAfterEvaluate() }
 
-    lint.apply {
-      // Skip lintVital tasks on assemble. We explicitly run lintRelease for libraries.
-      checkReleaseBuilds = false
-    }
-
     // Lint is configured entirely in finalizeDsl so that individual projects cannot easily
     // disable individual checks in the DSL for any reason.
     lint.apply {
+      // Skip lintVital tasks on assemble. We explicitly run lintRelease for libraries.
+      checkReleaseBuilds = false
+
       ignoreWarnings = slackProperties.lintErrorsOnly
 
       // Run lint on tests. Uses top-level lint.xml to specify checks.

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -163,8 +163,7 @@ internal object LintTasks {
           log("Adding $lintTaskName to ciLint task")
           ciLintTask.configure {
             // Even if the task isn't created yet, we can do this by name alone and it will resolve
-            // at
-            // task configuration time.
+            // at task configuration time.
             dependsOn(lintTaskName)
           }
         }

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -192,9 +192,6 @@ internal object LintTasks {
     disable += "NewerVersionAvailable"
     // These store qualified gradle caches in their paths and always change in baselines
     disable += "ObsoleteLintCustomCheck"
-    // https://groups.google.com/g/lint-dev/c/Bj0-I1RIPyU/m/mlP5Jpe4AQAJ
-    enable += "ImplicitSamInstance"
-    error += "ImplicitSamInstance"
 
     androidSdkVersions?.let { sdkVersions ->
       if (sdkVersions.minSdk >= 28) {

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -23,7 +23,6 @@ import com.android.build.gradle.TestPlugin
 import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
 import com.android.build.gradle.internal.lint.LintModelWriterTask
 import com.android.build.gradle.internal.lint.VariantInputs
-import java.io.File
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -330,12 +329,7 @@ internal object LintTasks {
 
       lintConfig = rootProject.layout.projectDirectory.file("config/lint/lint.xml").asFile
 
-      baseline =
-        objects
-          .fileProperty()
-          .fileValue(File(projectDir, slackProperties.lintBaselineFileName))
-          .get()
-          .asFile
+      baseline = project.layout.projectDirectory.file(slackProperties.lintBaselineFileName).asFile
     }
   }
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -208,15 +208,7 @@ internal object LintTasks {
     ignoreTestSources = slackProperties.lintIgnoreTestSources
     checkTestSources = slackProperties.lintCheckTestSources
 
-    val lintBaselineFile = slackProperties.lintBaselineFileName
-
-    // Lint is weird in that it will generate a new baseline file and fail the build if a new
-    // one was generated, even if empty.
-    // If we're updating baselines, always take the baseline so that we populate it if absent.
-    project.layout.projectDirectory
-      .file(lintBaselineFile)
-      .asFile
-      .takeIf { it.exists() || slackProperties.lintUpdateBaselines }
-      ?.let { baseline = it }
+    baseline = project.objects.fileProperty().fileValue(File(project.projectDir, slackProperties.lintBaselineFileName))
+      .get().asFile
   }
 }


### PR DESCRIPTION
This revamps lint handling in the project to add support for KMP projects (resolves #559) and also incorporates some neat/helpful things I learned from the AndroidX repo's [LintConfiguration](https://github.com/androidx/androidx/blob/cb78132cc8288f85e0ff8f4c32ed58a61b05d7d8/buildSrc/private/src/main/kotlin/androidx/build/LintConfiguration.kt).

This also cleans up a couple old things around handling baseline files and a hidden detector we couldn't use anymore.

Tested this with the CatchUp project: https://github.com/ZacSweers/CatchUp/pull/1032

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->