### PR TITLE
Add tracing to Skate plugin

### DIFF
--- a/skate-plugin/README.md
+++ b/skate-plugin/README.md
@@ -30,4 +30,6 @@ We're sending analytics for almost all Skate features to track user usage. To se
 3. Make call to `SkateTraceReporter` to send up the traces
 
 ## Publishing
-Run `publish-skate` Github Action to publish to the configured repository.
+Run `publish-skate` Github Action to publish to the configured repository. 
+
+Behind the scene the action's running`./gradlew :skate-plugin:uploadPluginToArtifactory`

--- a/skate-plugin/README.md
+++ b/skate-plugin/README.md
@@ -30,6 +30,6 @@ We're sending analytics for almost all Skate features to track user usage. To se
 3. Make call to `SkateTraceReporter` to send up the traces
 
 ## Publishing
-Run `publish-skate` Github Action to publish to the configured repository. 
+Run `publish-skate` Github Action to publish to the configured repository.
 
 Behind the scene the action's running`./gradlew :skate-plugin:uploadPluginToArtifactory`

--- a/skate-plugin/README.md
+++ b/skate-plugin/README.md
@@ -1,0 +1,33 @@
+Skate Plugin
+=========================
+
+An Intellij plugin that helps to improve local developer productivity by surfacing useful information in the IDE.
+
+We use this at Slack for several for couple use cases:
+* Announce updates, latest changes and improvements through "What's New" panel
+* Annotate Feature Flag to help easily access its setup
+* Generate API model translators when migrating legacy API
+* Create new initial new subproject setup from `File` dropdown
+
+## Installation
+
+#### Artifactory
+1. Install `artifactory-authenticator` plugin from disk and authenticate with Artifactory
+2. Add custom plugin repository link from "Manage Plugin Repositories"
+3. Search "Skate" in the plugins marketplace and install it
+
+#### Local testing
+1. Build local version of the plugin with `./gradlew buildPlugin`
+2. Open IDE settings, then "Install Plugin from Disk..."
+
+## Implementation
+All registered plugin actions can be found in `skate.xml` config file
+
+## Tracing
+We're sending analytics for almost all Skate features to track user usage. To set this up,
+1. Register new feature event in `SkateTracingEvent`
+2. Use `SkateSpanBuilder` to create the span for event you want to track
+3. Make call to `SkateTraceReporter` to send up the traces
+
+## Publishing
+Run `publish-skate` Github Action to publish to the configured repository.

--- a/skate-plugin/README.md
+++ b/skate-plugin/README.md
@@ -3,11 +3,11 @@ Skate Plugin
 
 An Intellij plugin that helps to improve local developer productivity by surfacing useful information in the IDE.
 
-We use this at Slack for several for couple use cases:
+We use this at Slack for s several use cases:
 * Announce updates, latest changes and improvements through "What's New" panel
 * Annotate Feature Flag to help easily access its setup
 * Generate API model translators when migrating legacy API
-* Create new initial new subproject setup from `File` dropdown
+* Create initial new subproject setup from `File` dropdown
 
 ## Installation
 

--- a/skate-plugin/build.gradle.kts
+++ b/skate-plugin/build.gradle.kts
@@ -1,8 +1,9 @@
+
 import com.jetbrains.plugin.structure.base.utils.exists
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Paths
 import java.util.Locale
 import kotlin.io.path.readText
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   java
@@ -89,7 +90,10 @@ tasks
 // endregion
 
 dependencies {
+  implementation(libs.okhttp)
+  implementation(libs.okhttp.loggingInterceptor)
   implementation(libs.bugsnag) { exclude(group = "org.slf4j") }
+  implementation(project(mapOf("path" to ":tracing")))
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/skate-plugin/build.gradle.kts
+++ b/skate-plugin/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
   implementation(libs.okhttp)
   implementation(libs.okhttp.loggingInterceptor)
   implementation(libs.bugsnag) { exclude(group = "org.slf4j") }
-  implementation(project(mapOf("path" to ":tracing")))
+  implementation(projects.tracing)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/skate-plugin/build.gradle.kts
+++ b/skate-plugin/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import com.jetbrains.plugin.structure.base.utils.exists
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Paths

--- a/skate-plugin/build.gradle.kts
+++ b/skate-plugin/build.gradle.kts
@@ -89,10 +89,11 @@ tasks
 // endregion
 
 dependencies {
+  implementation(libs.bugsnag) { exclude(group = "org.slf4j") }
   implementation(libs.okhttp)
   implementation(libs.okhttp.loggingInterceptor)
-  implementation(libs.bugsnag) { exclude(group = "org.slf4j") }
   implementation(projects.tracing)
+
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkatePluginSettings.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkatePluginSettings.kt
@@ -104,6 +104,12 @@ class SkatePluginSettings : SimplePersistentStateComponent<SkatePluginSettings.S
       state.isTracingEnabled = value
     }
 
+  var tracingEndpoint: String?
+    get() = state.tracingEndpoint
+    set(value) {
+      state.tracingEndpoint = value
+    }
+
   class State : BaseState() {
     var whatsNewFilePath by string()
     var isWhatsNewEnabled by property(true)
@@ -116,5 +122,6 @@ class SkatePluginSettings : SimplePersistentStateComponent<SkatePluginSettings.S
     var featureFlagAnnotation by string()
     var featureFlagFilePattern by string()
     var isTracingEnabled by property(true)
+    var tracingEndpoint by string()
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkatePluginSettings.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkatePluginSettings.kt
@@ -98,6 +98,12 @@ class SkatePluginSettings : SimplePersistentStateComponent<SkatePluginSettings.S
       state.featureFlagFilePattern = value
     }
 
+  var isTracingEnabled: Boolean
+    get() = state.isTracingEnabled
+    set(value) {
+      state.isTracingEnabled = value
+    }
+
   class State : BaseState() {
     var whatsNewFilePath by string()
     var isWhatsNewEnabled by property(true)
@@ -109,5 +115,6 @@ class SkatePluginSettings : SimplePersistentStateComponent<SkatePluginSettings.S
     var featureFlagBaseUrl by string()
     var featureFlagAnnotation by string()
     var featureFlagFilePattern by string()
+    var isTracingEnabled by property(true)
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
@@ -22,9 +22,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowManager
-import com.slack.sgp.intellij.tracing.SkateMetricCollector
 import com.slack.sgp.intellij.ui.WhatsNewPanelFactory
-import java.time.Instant
 import java.util.function.Supplier
 
 interface SkateProjectService {

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
@@ -36,9 +36,6 @@ interface SkateProjectService {
  * New UI of the Skate Plugin
  */
 class SkateProjectServiceImpl(private val project: Project) : SkateProjectService {
-  private val skateMetricCollector = SkateMetricCollector()
-  private val startTimestamp = Instant.now()
-
   override fun showWhatsNewWindow() {
 
     val settings = project.service<SkatePluginSettings>()
@@ -53,25 +50,23 @@ class SkateProjectServiceImpl(private val project: Project) : SkateProjectServic
     // Don't show the tool window if the parsed changelog is blank
     // Changelog is parsed
     val parsedChangelog = ChangelogParser.readFile(changeLogString, changelogJournal.lastReadDate)
-    val isChangelogEmpty = parsedChangelog.changeLogString.isNullOrBlank()
-    if (!isChangelogEmpty) {
-      // Creating the tool window
-      val toolWindowManager = ToolWindowManager.getInstance(project)
-      toolWindowManager.invokeLater {
-        val toolWindow =
-          toolWindowManager.registerToolWindow(WHATS_NEW_PANEL_ID) {
-            stripeTitle = Supplier { "What's New in Slack!" }
-            anchor = ToolWindowAnchor.RIGHT
-          }
-        // The Disposable is necessary to prevent a substantial memory leak while working with
-        // MarkdownJCEFHtmlPanel
-        val parentDisposable = Disposer.newDisposable()
+    if (parsedChangelog.changeLogString.isNullOrBlank()) return
+    // Creating the tool window
+    val toolWindowManager = ToolWindowManager.getInstance(project)
+    toolWindowManager.invokeLater {
+      val toolWindow =
+        toolWindowManager.registerToolWindow(WHATS_NEW_PANEL_ID) {
+          stripeTitle = Supplier { "What's New in Slack!" }
+          anchor = ToolWindowAnchor.RIGHT
+        }
+      // The Disposable is necessary to prevent a substantial memory leak while working with
+      // MarkdownJCEFHtmlPanel
+      val parentDisposable = Disposer.newDisposable()
 
-        WhatsNewPanelFactory()
-          .createToolWindowContent(toolWindow, project, parsedChangelog, parentDisposable)
+      WhatsNewPanelFactory()
+        .createToolWindowContent(toolWindow, project, parsedChangelog, parentDisposable)
 
-        toolWindow.show()
-      }
+      toolWindow.show()
     }
   }
 

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListener.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListener.kt
@@ -27,7 +27,7 @@ import com.slack.sgp.intellij.tracing.SkateTracingEvent.EventType.SKATE_WHATS_NE
 import com.slack.sgp.intellij.util.isTracingEnabled
 import java.time.Instant
 
-/* Custom listener for tool window for whats new panel */
+/** Custom listener for WhatsNew Tool Window. */
 class WhatsNewToolWindowListener(private val project: Project) : ToolWindowManagerListener {
   //  Initial state of screen should be hidden
   private var wasVisible = false
@@ -37,22 +37,22 @@ class WhatsNewToolWindowListener(private val project: Project) : ToolWindowManag
     super.stateChanged(toolWindowManager)
     if (!project.isTracingEnabled()) return
 
-    val skateMetricCollector = SkateSpanBuilder()
+    val skateSpanBuilder = SkateSpanBuilder()
     val toolWindow = toolWindowManager.getToolWindow(WHATS_NEW_PANEL_ID) ?: return
     val isVisible = toolWindow.isVisible
     val visibilityChanged = visibilityChanged(isVisible)
 
     if (visibilityChanged) {
       if (isVisible) {
-        skateMetricCollector.addSpanTag("event", SkateTracingEvent(SKATE_WHATS_NEW_PANEL_OPENED))
+        skateSpanBuilder.addSpanTag("event", SkateTracingEvent(SKATE_WHATS_NEW_PANEL_OPENED))
       } else {
-        skateMetricCollector.addSpanTag("event", SkateTracingEvent(SKATE_WHATS_NEW_PANEL_CLOSED))
+        skateSpanBuilder.addSpanTag("event", SkateTracingEvent(SKATE_WHATS_NEW_PANEL_CLOSED))
       }
       SkateTraceReporter(project)
         .createPluginUsageTraceAndSendTrace(
           WHATS_NEW_PANEL_ID.replace('-', '_'),
           startTimestamp,
-          skateMetricCollector.getKeyValueList()
+          skateSpanBuilder.getKeyValueList()
         )
     }
   }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListener.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListener.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.slack.sgp.intellij.SkateProjectServiceImpl.Companion.WHATS_NEW_PANEL_ID
+import com.slack.sgp.intellij.tracing.SkateMetricCollector
+import com.slack.sgp.intellij.tracing.SkateMetricCollector.Companion.WhatsNewPanelAction
+import com.slack.sgp.intellij.tracing.SkateTraceReporter
+import com.slack.sgp.intellij.util.isTracingEnabled
+import java.time.Instant
+
+class WhatsNewToolWindowListener(private val project: Project) : ToolWindowManagerListener {
+  private var wasVisible = false
+  private val startTimestamp = Instant.now()
+
+  override fun stateChanged(toolWindowManager: ToolWindowManager) {
+    super.stateChanged(toolWindowManager)
+    if (!project.isTracingEnabled()) return
+    val skateMetricCollector = SkateMetricCollector()
+
+    val toolWindow = toolWindowManager.getToolWindow(WHATS_NEW_PANEL_ID) ?: return
+    val isVisible = toolWindow.isVisible
+    val visibilityChanged = isVisible != wasVisible
+    wasVisible = isVisible
+
+    if (visibilityChanged) {
+      if (isVisible) {
+        skateMetricCollector.addSpanTag("event", WhatsNewPanelAction.PANEL_OPENED.name)
+      } else {
+        skateMetricCollector.addSpanTag("event", WhatsNewPanelAction.PANEL_CLOSED.name)
+      }
+      skateMetricCollector.addSpanTag("project_name", project.name)
+      SkateTraceReporter()
+        .createPluginUsageTraceAndSendTrace(
+          WHATS_NEW_PANEL_ID.replace('-', '_'),
+          startTimestamp,
+          skateMetricCollector.getKeyValueList()
+        )
+    }
+  }
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListener.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListener.kt
@@ -15,7 +15,6 @@
  */
 package com.slack.sgp.intellij
 
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
@@ -27,18 +26,18 @@ import com.slack.sgp.intellij.util.isTracingEnabled
 import java.time.Instant
 
 class WhatsNewToolWindowListener(private val project: Project) : ToolWindowManagerListener {
+  //  Initial state of screen should be hidden
   private var wasVisible = false
   private val startTimestamp = Instant.now()
 
   override fun stateChanged(toolWindowManager: ToolWindowManager) {
     super.stateChanged(toolWindowManager)
     if (!project.isTracingEnabled()) return
-    val skateMetricCollector = SkateMetricCollector()
 
+    val skateMetricCollector = SkateMetricCollector()
     val toolWindow = toolWindowManager.getToolWindow(WHATS_NEW_PANEL_ID) ?: return
     val isVisible = toolWindow.isVisible
-    val visibilityChanged = isVisible != wasVisible
-    wasVisible = isVisible
+    val visibilityChanged = visibilityChanged(isVisible)
 
     if (visibilityChanged) {
       if (isVisible) {
@@ -54,5 +53,11 @@ class WhatsNewToolWindowListener(private val project: Project) : ToolWindowManag
           skateMetricCollector.getKeyValueList()
         )
     }
+  }
+
+  fun visibilityChanged(isVisible: Boolean): Boolean {
+    val visibilityChanged = isVisible != wasVisible
+    wasVisible = isVisible
+    return visibilityChanged
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListener.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListener.kt
@@ -25,6 +25,7 @@ import com.slack.sgp.intellij.tracing.SkateTraceReporter
 import com.slack.sgp.intellij.util.isTracingEnabled
 import java.time.Instant
 
+/* Custom listener for tool window for whats new panel */
 class WhatsNewToolWindowListener(private val project: Project) : ToolWindowManagerListener {
   //  Initial state of screen should be hidden
   private var wasVisible = false

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/featureflags/FeatureFlagAnnotator.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/featureflags/FeatureFlagAnnotator.kt
@@ -76,7 +76,7 @@ class UrlIntentionAction(
 ) : IntentionAction {
 
   private val startTimestamp = Instant.now()
-  private val skateMetricCollector = SkateSpanBuilder()
+  private val skateSpanBuilder = SkateSpanBuilder()
 
   override fun getText(): String = message
 
@@ -86,7 +86,7 @@ class UrlIntentionAction(
 
   override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
     BrowserUtil.browse(URI(url))
-    skateMetricCollector.addSpanTag("event", SkateTracingEvent(HOUSTON_FEATURE_FLAG_URL_CLICKED))
+    skateSpanBuilder.addSpanTag("event", SkateTracingEvent(HOUSTON_FEATURE_FLAG_URL_CLICKED))
     sendUsageTrace(project, project.isTracingEnabled())
   }
 
@@ -100,7 +100,7 @@ class UrlIntentionAction(
       .createPluginUsageTraceAndSendTrace(
         "feature_flag_annotator",
         startTimestamp,
-        skateMetricCollector.getKeyValueList()
+        skateSpanBuilder.getKeyValueList()
       )
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenMenuAction.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenMenuAction.kt
@@ -18,9 +18,10 @@ package com.slack.sgp.intellij.projectgen
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
-import com.slack.sgp.intellij.tracing.SkateMetricCollector
-import com.slack.sgp.intellij.tracing.SkateMetricCollector.Companion.ProjectGenAction
+import com.slack.sgp.intellij.tracing.SkateSpanBuilder
 import com.slack.sgp.intellij.tracing.SkateTraceReporter
+import com.slack.sgp.intellij.tracing.SkateTracingEvent
+import com.slack.sgp.intellij.tracing.SkateTracingEvent.EventType.PROJECT_GEN_OPENED
 import com.slack.sgp.intellij.util.isProjectGenMenuActionEnabled
 import com.slack.sgp.intellij.util.isTracingEnabled
 import com.slack.sgp.intellij.util.projectGenRunCommand
@@ -33,32 +34,31 @@ constructor(
   private val offline: Boolean = false
 ) : AnAction() {
 
-  private val skateMetricCollector = SkateMetricCollector()
+  private val skateMetricCollector = SkateSpanBuilder()
   private val startTimestamp = Instant.now()
 
   override fun actionPerformed(e: AnActionEvent) {
     val currentProject: Project = e.project ?: return
     val projectGenRunCommand = currentProject.projectGenRunCommand()
-    if (!currentProject.isProjectGenMenuActionEnabled()) {
-      skateMetricCollector.addSpanTag("event", ProjectGenAction.PROJECT_GEN_DISABLED.name)
-    } else {
-      executeProjectGenCommand(projectGenRunCommand, currentProject)
+    if (!currentProject.isProjectGenMenuActionEnabled()) return
+
+    executeProjectGenCommand(projectGenRunCommand, currentProject)
+
+    if (currentProject.isTracingEnabled()) {
+      sendUsageTrace(currentProject)
     }
-    sendUsageTrace(currentProject, currentProject.isTracingEnabled())
   }
 
   fun executeProjectGenCommand(command: String, project: Project) {
     val terminalCommand = TerminalCommand(command, project.basePath, PROJECT_GEN_TAB_NAME)
     terminalViewWrapper(project).executeCommand(terminalCommand)
-    skateMetricCollector.addSpanTag("event", ProjectGenAction.TERMINAL_OPENED.name)
+    skateMetricCollector.addSpanTag("event", SkateTracingEvent(PROJECT_GEN_OPENED))
   }
 
-  fun sendUsageTrace(project: Project, isTracingEnabled: Boolean) {
-    if (!isTracingEnabled) return
-    skateMetricCollector.addSpanTag("project_name", project.name)
-    SkateTraceReporter(offline)
+  fun sendUsageTrace(project: Project) {
+    SkateTraceReporter(project, offline)
       .createPluginUsageTraceAndSendTrace(
-        PROJECT_GEN_TRACE_NAME,
+        "project_generator",
         startTimestamp,
         skateMetricCollector.getKeyValueList()
       )
@@ -66,6 +66,5 @@ constructor(
 
   companion object {
     const val PROJECT_GEN_TAB_NAME: String = "ProjectGen"
-    const val PROJECT_GEN_TRACE_NAME: String = "project_gen"
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenMenuAction.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenMenuAction.kt
@@ -17,9 +17,7 @@ package com.slack.sgp.intellij.projectgen
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.slack.sgp.intellij.SkatePluginSettings
 import com.slack.sgp.intellij.tracing.SkateMetricCollector
 import com.slack.sgp.intellij.tracing.SkateMetricCollector.Companion.ProjectGenAction
 import com.slack.sgp.intellij.tracing.SkateTraceReporter

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenMenuAction.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenMenuAction.kt
@@ -34,7 +34,7 @@ constructor(
   private val offline: Boolean = false
 ) : AnAction() {
 
-  private val skateMetricCollector = SkateSpanBuilder()
+  private val skateSpanBuilder = SkateSpanBuilder()
   private val startTimestamp = Instant.now()
 
   override fun actionPerformed(e: AnActionEvent) {
@@ -52,7 +52,7 @@ constructor(
   fun executeProjectGenCommand(command: String, project: Project) {
     val terminalCommand = TerminalCommand(command, project.basePath, PROJECT_GEN_TAB_NAME)
     terminalViewWrapper(project).executeCommand(terminalCommand)
-    skateMetricCollector.addSpanTag("event", SkateTracingEvent(PROJECT_GEN_OPENED))
+    skateSpanBuilder.addSpanTag("event", SkateTracingEvent(PROJECT_GEN_OPENED))
   }
 
   fun sendUsageTrace(project: Project) {
@@ -60,7 +60,7 @@ constructor(
       .createPluginUsageTraceAndSendTrace(
         "project_generator",
         startTimestamp,
-        skateMetricCollector.getKeyValueList()
+        skateSpanBuilder.getKeyValueList()
       )
   }
 

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateMetricCollector.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateMetricCollector.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.tracing
+
+import com.slack.sgp.tracing.KeyValue
+import com.slack.sgp.tracing.model.TagBuilder
+import com.slack.sgp.tracing.model.tagBuilderImpl
+
+class SkateMetricCollector {
+  private val keyValueList: TagBuilder = tagBuilderImpl()
+
+  fun addSpanTag(key: String, value: String) {
+    keyValueList.apply { key tagTo value }
+  }
+
+  fun getKeyValueList(): List<KeyValue> {
+    return keyValueList.toList()
+  }
+
+  companion object {
+    enum class ProjectGenAction {
+      TERMINAL_OPENED,
+      PROJECT_GEN_DISABLED
+    }
+
+    enum class FeatureFlagAnnotatorAction {
+      HOUSTON_LINK_CLICKED
+    }
+
+    enum class WhatsNewPanelAction {
+      PANEL_OPENED,
+      PANEL_CLOSED
+    }
+  }
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateSpanBuilder.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateSpanBuilder.kt
@@ -17,10 +17,10 @@ package com.slack.sgp.intellij.tracing
 
 import com.slack.sgp.tracing.KeyValue
 import com.slack.sgp.tracing.model.TagBuilder
-import com.slack.sgp.tracing.model.tagBuilderImpl
+import com.slack.sgp.tracing.model.newTagBuilder
 
 class SkateSpanBuilder {
-  private val keyValueList: TagBuilder = tagBuilderImpl()
+  private val keyValueList: TagBuilder = newTagBuilder()
 
   fun addSpanTag(key: String, value: String) {
     keyValueList.apply { key tagTo value }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateSpanBuilder.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateSpanBuilder.kt
@@ -19,30 +19,27 @@ import com.slack.sgp.tracing.KeyValue
 import com.slack.sgp.tracing.model.TagBuilder
 import com.slack.sgp.tracing.model.tagBuilderImpl
 
-class SkateMetricCollector {
+class SkateSpanBuilder {
   private val keyValueList: TagBuilder = tagBuilderImpl()
 
   fun addSpanTag(key: String, value: String) {
     keyValueList.apply { key tagTo value }
   }
 
+  fun addSpanTag(key: String, value: SkateTracingEvent) {
+    keyValueList.apply { key tagTo value.type.name }
+  }
+
   fun getKeyValueList(): List<KeyValue> {
     return keyValueList.toList()
   }
+}
 
-  companion object {
-    enum class ProjectGenAction {
-      TERMINAL_OPENED,
-      PROJECT_GEN_DISABLED
-    }
-
-    enum class FeatureFlagAnnotatorAction {
-      HOUSTON_LINK_CLICKED
-    }
-
-    enum class WhatsNewPanelAction {
-      PANEL_OPENED,
-      PANEL_CLOSED
-    }
+class SkateTracingEvent(val type: EventType) {
+  enum class EventType {
+    PROJECT_GEN_OPENED,
+    HOUSTON_FEATURE_FLAG_URL_CLICKED,
+    SKATE_WHATS_NEW_PANEL_OPENED,
+    SKATE_WHATS_NEW_PANEL_CLOSED
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateTraceReporter.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateTraceReporter.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.tracing
+
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.extensions.PluginId
+import com.slack.sgp.tracing.KeyValue
+import com.slack.sgp.tracing.ListOfSpans
+import com.slack.sgp.tracing.model.buildSpan
+import com.slack.sgp.tracing.model.tagBuilderImpl
+import com.slack.sgp.tracing.reporter.SimpleTraceReporter
+import com.slack.sgp.tracing.reporter.TraceReporter
+import com.slack.sgp.tracing.reporter.TraceReporter.NoOpTraceReporter
+import java.time.Duration
+import java.time.Instant
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.apache.http.HttpException
+
+class SkateTraceReporter(private val offline: Boolean = false) : TraceReporter {
+
+  private val delegate by lazy {
+    val okHttpClient = lazy { OkHttpClient.Builder().build() }
+    val loggingInterceptor =
+      HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY }
+
+    val loggingClient = lazy {
+      okHttpClient.value.newBuilder().addInterceptor(loggingInterceptor).build()
+    }
+    if (offline) {
+      NoOpTraceReporter
+    } else {
+      SimpleTraceReporter(TRACING_ENDPOINT, loggingClient)
+    }
+  }
+
+  override suspend fun sendTrace(spans: ListOfSpans) {
+    try {
+      LOG.info(spans.toString())
+      delegate.sendTrace(spans)
+    } catch (httpException: HttpException) {
+      LOG.error("Uploading Skate plugin trace failed.", httpException)
+    }
+  }
+
+  fun createPluginUsageTraceAndSendTrace(
+    spanName: String,
+    startTimestamp: Instant,
+    spanDataMap: List<KeyValue>
+  ): ListOfSpans? {
+    if (spanDataMap.isEmpty()) {
+      LOG.debug("Skipping sending traces because span data is missing")
+      return null
+    }
+    val traceTags =
+      tagBuilderImpl().apply {
+        "service_name" tagTo SERVICE_NAME
+        "database" tagTo DATABASE_NAME
+      }
+    val span =
+      buildSpan(
+        name = spanName,
+        startTimestampMicros =
+          startTimestamp.toEpochMilli().toDuration(DurationUnit.MILLISECONDS).inWholeMicroseconds,
+        durationMicros =
+          Duration.between(startTimestamp, Instant.now())
+            .toMillis()
+            .toDuration(DurationUnit.MILLISECONDS)
+            .inWholeMicroseconds
+      ) {
+        try {
+          val skatePlugin = PluginManagerCore.getPlugin(PluginId.getId("com.slack.intellij.skate"))
+          if (skatePlugin != null) "skate_version" tagTo skatePlugin.version
+          "ide_version" tagTo ApplicationInfo.getInstance().fullVersion
+        } catch (nullPointerException: NullPointerException) {
+          LOG.warn("Failed to get IDE and Plugin version", nullPointerException)
+        }
+        "user" tagTo System.getenv("USER")
+        this.addAll(spanDataMap)
+      }
+    val spans = ListOfSpans(spans = listOf(span), tags = traceTags)
+    runBlocking { sendTrace(spans) }
+    return spans
+  }
+
+  companion object {
+    const val SERVICE_NAME: String = "lp_test_skate_plugin"
+    const val DATABASE_NAME: String = "itools"
+    const val TRACING_ENDPOINT: String = "https://slackb.com/traces/v1/list_of_spans/proto"
+    private val LOG: Logger = Logger.getInstance(SkateTraceReporter::class.java)
+  }
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateTraceReporter.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateTraceReporter.kt
@@ -102,7 +102,7 @@ class SkateTraceReporter(private val offline: Boolean = false) : TraceReporter {
   }
 
   companion object {
-    const val SERVICE_NAME: String = "lp_test_skate_plugin"
+    const val SERVICE_NAME: String = "skate_plugin"
     const val DATABASE_NAME: String = "itools"
     const val TRACING_ENDPOINT: String = "https://slackb.com/traces/v1/list_of_spans/proto"
     private val LOG: Logger = Logger.getInstance(SkateTraceReporter::class.java)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateTraceReporter.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/tracing/SkateTraceReporter.kt
@@ -24,7 +24,7 @@ import com.slack.sgp.intellij.util.tracingEndpoint
 import com.slack.sgp.tracing.KeyValue
 import com.slack.sgp.tracing.ListOfSpans
 import com.slack.sgp.tracing.model.buildSpan
-import com.slack.sgp.tracing.model.tagBuilderImpl
+import com.slack.sgp.tracing.model.newTagBuilder
 import com.slack.sgp.tracing.reporter.SimpleTraceReporter
 import com.slack.sgp.tracing.reporter.TraceReporter
 import com.slack.sgp.tracing.reporter.TraceReporter.NoOpTraceReporter
@@ -79,7 +79,7 @@ class SkateTraceReporter(private val project: Project, private val offline: Bool
       return null
     }
     val traceTags =
-      tagBuilderImpl().apply {
+      newTagBuilder().apply {
         "service_name" tagTo SERVICE_NAME
         "database" tagTo DATABASE_NAME
       }
@@ -96,7 +96,7 @@ class SkateTraceReporter(private val project: Project, private val offline: Bool
       ) {
         "skate_version" tagTo skatePluginVersion
         "ide_version" tagTo ideVersion
-        "user" tagTo System.getenv("USER")
+        System.getenv("USER").takeUnless { it.isBlank() }?.let { "user" tagTo it }
         "project_name" tagTo project.name
         this.addAll(spanDataMap)
       }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
@@ -40,6 +40,7 @@ internal class SkateConfigUI(
     choosePathRow()
     enableProjectGenMenuAction()
     featureFlagSettings()
+    enabledTracing()
   }
 
   private fun Panel.checkBoxRow() {
@@ -142,6 +143,16 @@ internal class SkateConfigUI(
           if (it.text.isBlank()) error(SkateBundle.message(errorMessageKey)) else null
         }
         .apply { enabledCondition?.let { enabledIf(it) } }
+    }
+  }
+
+  private fun Panel.enabledTracing() {
+    row(SkateBundle.message("skate.configuration.enableTracing.title")) {
+      checkBox(SkateBundle.message("skate.configuration.enableTracing.description"))
+        .bindSelected(
+          getter = { settings.isTracingEnabled },
+          setter = { settings.isTracingEnabled = it }
+        )
     }
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
@@ -40,7 +40,7 @@ internal class SkateConfigUI(
     choosePathRow()
     enableProjectGenMenuAction()
     featureFlagSettings()
-    enabledTracing()
+    tracingSettings()
   }
 
   private fun Panel.checkBoxRow() {
@@ -126,6 +126,26 @@ internal class SkateConfigUI(
     )
   }
 
+  private fun Panel.tracingSettings() {
+    lateinit var tracingEnabledButton: Cell<JBCheckBox>
+
+    row(SkateBundle.message("skate.configuration.enableTracing.title")) {
+      tracingEnabledButton =
+        checkBox(SkateBundle.message("skate.configuration.enableTracing.description"))
+          .bindSelected(
+            getter = { settings.isTracingEnabled },
+            setter = { settings.isTracingEnabled = it }
+          )
+    }
+    bindAndValidateTextFieldRow(
+      titleMessageKey = "skate.configuration.tracingEndpoint.title",
+      getter = { settings.tracingEndpoint },
+      setter = { settings.tracingEndpoint = it },
+      errorMessageKey = "skate.configuration.tracingEndpoint.description",
+      enabledCondition = tracingEnabledButton.selected
+    )
+  }
+
   private fun Panel.bindAndValidateTextFieldRow(
     titleMessageKey: String,
     getter: () -> String?,
@@ -143,16 +163,6 @@ internal class SkateConfigUI(
           if (it.text.isBlank()) error(SkateBundle.message(errorMessageKey)) else null
         }
         .apply { enabledCondition?.let { enabledIf(it) } }
-    }
-  }
-
-  private fun Panel.enabledTracing() {
-    row(SkateBundle.message("skate.configuration.enableTracing.title")) {
-      checkBox(SkateBundle.message("skate.configuration.enableTracing.description"))
-        .bindSelected(
-          getter = { settings.isTracingEnabled },
-          setter = { settings.isTracingEnabled = it }
-        )
     }
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/ProjectUtils.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/ProjectUtils.kt
@@ -30,5 +30,3 @@ fun Project.isTracingEnabled(): Boolean = settings().isTracingEnabled
 fun Project.isProjectGenMenuActionEnabled(): Boolean = settings().isProjectGenMenuActionEnabled
 
 fun Project.projectGenRunCommand(): String = settings().projectGenRunCommand
-
-

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/ProjectUtils.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/ProjectUtils.kt
@@ -24,3 +24,11 @@ fun Project.settings(): SkatePluginSettings = service<SkatePluginSettings>()
 fun Project.isLinkifiedFeatureFlagsEnabled(): Boolean = settings().isLinkifiedFeatureFlagsEnabled
 
 fun Project.featureFlagFilePattern(): String? = settings().featureFlagFilePattern
+
+fun Project.isTracingEnabled(): Boolean = settings().isTracingEnabled
+
+fun Project.isProjectGenMenuActionEnabled(): Boolean = settings().isProjectGenMenuActionEnabled
+
+fun Project.projectGenRunCommand(): String = settings().projectGenRunCommand
+
+

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/ProjectUtils.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/util/ProjectUtils.kt
@@ -30,3 +30,5 @@ fun Project.isTracingEnabled(): Boolean = settings().isTracingEnabled
 fun Project.isProjectGenMenuActionEnabled(): Boolean = settings().isProjectGenMenuActionEnabled
 
 fun Project.projectGenRunCommand(): String = settings().projectGenRunCommand
+
+fun Project.tracingEndpoint(): String? = settings().tracingEndpoint

--- a/skate-plugin/src/main/resources/META-INF/plugin.xml
+++ b/skate-plugin/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,11 @@
         <listener class="com.slack.sgp.intellij.ProjectOpenCloseListener"
                   topic="com.intellij.openapi.project.ProjectManagerListener"/>
     </applicationListeners>
+    <projectListeners>
+        <listener
+                class="com.slack.sgp.intellij.WhatsNewToolWindowListener"
+                topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
+    </projectListeners>
 
     <actions>
         <action id="com.slack.sgp.intellij.projectgen.ProjectGenMenuAction"

--- a/skate-plugin/src/main/resources/messages/skateBundle.properties
+++ b/skate-plugin/src/main/resources/messages/skateBundle.properties
@@ -13,9 +13,6 @@ skate.configuration.featureFlagBaseUrl.title=Base URL for feature flag linking. 
 skate.configuration.featureFlagAnnotation.title=Feature flag annotation's fully-qualified name (com.example.FeatureFlag)
 skate.configuration.featureFlagFieldEmpty.error=Field cannot be empty when feature flag linking is enabled
 skate.configuration.enableTracing.title=Enable Data Tracking
-skate.configuration.enableTracing.description=If enabled, allow sending plugin usage statistics to Slack
+skate.configuration.enableTracing.description=If enabled, allow sending plugin usage statistics to Slack Mobile DevXP
 skate.configuration.tracingEndpoint.title=Trace API Endpoint
-skate.configuration.tracingEndpoint.description=URL that accepts requests for sending tracing analytics
-
-
-
+skate.configuration.tracingEndpoint.description=URL endpoints that accepts requests for sending tracing analytics

--- a/skate-plugin/src/main/resources/messages/skateBundle.properties
+++ b/skate-plugin/src/main/resources/messages/skateBundle.properties
@@ -14,5 +14,8 @@ skate.configuration.featureFlagAnnotation.title=Feature flag annotation's fully-
 skate.configuration.featureFlagFieldEmpty.error=Field cannot be empty when feature flag linking is enabled
 skate.configuration.enableTracing.title=Enable Data Tracking
 skate.configuration.enableTracing.description=If enabled, allow sending plugin usage statistics to Slack
+skate.configuration.tracingEndpoint.title=Trace API Endpoint
+skate.configuration.tracingEndpoint.description=URL that accepts requests for sending tracing analytics
+
 
 

--- a/skate-plugin/src/main/resources/messages/skateBundle.properties
+++ b/skate-plugin/src/main/resources/messages/skateBundle.properties
@@ -12,3 +12,7 @@ skate.configuration.featureFlagFilePattern.title=Provide a regex pattern to iden
 skate.configuration.featureFlagBaseUrl.title=Base URL for feature flag linking. The flag key will be appended to the end of this
 skate.configuration.featureFlagAnnotation.title=Feature flag annotation's fully-qualified name (com.example.FeatureFlag)
 skate.configuration.featureFlagFieldEmpty.error=Field cannot be empty when feature flag linking is enabled
+skate.configuration.enableTracing.title=Enable Data Tracking
+skate.configuration.enableTracing.description=If enabled, allow sending plugin usage statistics to Slack
+
+

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/ProjectGenMenuActionTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/ProjectGenMenuActionTest.kt
@@ -34,7 +34,8 @@ class ProjectGenMenuActionTest : BasePlatformTestCase() {
 
   fun testCorrectArgumentsPassedIntoTerminalView() {
     val fakeTerminalViewWrapper = FakeTerminalViewWrapper()
-    val action = ProjectGenMenuAction { fakeTerminalViewWrapper }
+    val action =
+      ProjectGenMenuAction(terminalViewWrapper = { fakeTerminalViewWrapper }, offline = true)
 
     // Perform action
     myFixture.testAction(action)
@@ -47,7 +48,8 @@ class ProjectGenMenuActionTest : BasePlatformTestCase() {
 
   fun testTerminalViewNotRunningWhenActionDisabled() {
     val fakeTerminalViewWrapper = FakeTerminalViewWrapper()
-    val action = ProjectGenMenuAction { fakeTerminalViewWrapper }
+    val action =
+      ProjectGenMenuAction(terminalViewWrapper = { fakeTerminalViewWrapper }, offline = true)
     project.service<SkatePluginSettings>().isProjectGenMenuActionEnabled = false
 
     // Perform action

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/SkateTraceReporterTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/SkateTraceReporterTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij
+
+import com.google.common.truth.Truth.assertThat
+import com.slack.sgp.intellij.tracing.SkateTraceReporter
+import com.slack.sgp.intellij.tracing.SkateTraceReporter.Companion.DATABASE_NAME
+import com.slack.sgp.intellij.tracing.SkateTraceReporter.Companion.SERVICE_NAME
+import com.slack.sgp.tracing.KeyValue
+import com.slack.sgp.tracing.ValueType
+import com.slack.sgp.tracing.model.tagBuilderImpl
+import java.time.Instant
+import org.junit.Test
+
+class SkateTraceReporterTest {
+  @Test
+  fun testSpanCreatedWithCorrectTags() {
+    val traceTags =
+      tagBuilderImpl().apply {
+        "test_string" tagTo "test_value"
+        "test_boolean" tagTo true
+        "test_long" tagTo 10000000L
+        "test_double" tagTo "1.25"
+      }
+
+    val listOfSpans =
+      SkateTraceReporter(offline = true)
+        .createPluginUsageTraceAndSendTrace("fake_span_name", Instant.now(), traceTags)
+    val expectedTags =
+      mutableListOf(
+        KeyValue("service_name", ValueType.STRING, SERVICE_NAME),
+        KeyValue("database", ValueType.STRING, DATABASE_NAME)
+      )
+
+    assertThat(listOfSpans).isNotNull()
+    if (listOfSpans != null) {
+      assertThat(listOfSpans.tags).isEqualTo(expectedTags)
+      traceTags.forEach { assertThat(listOfSpans.spans.first().tags.contains(it)) }
+    }
+  }
+
+  @Test
+  fun testSpanNotCreatedWhenSpanDataIsEmpty() {
+    val listOfSpans =
+      SkateTraceReporter(offline = true)
+        .createPluginUsageTraceAndSendTrace("fake_span_name", Instant.now(), tagBuilderImpl())
+    assertThat(listOfSpans).isNull()
+  }
+}

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/SkateTraceReporterTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/SkateTraceReporterTest.kt
@@ -22,13 +22,13 @@ import com.slack.sgp.intellij.tracing.SkateTraceReporter.Companion.DATABASE_NAME
 import com.slack.sgp.intellij.tracing.SkateTraceReporter.Companion.SERVICE_NAME
 import com.slack.sgp.tracing.KeyValue
 import com.slack.sgp.tracing.ValueType
-import com.slack.sgp.tracing.model.tagBuilderImpl
+import com.slack.sgp.tracing.model.newTagBuilder
 import java.time.Instant
 
 class SkateTraceReporterTest : BasePlatformTestCase() {
   fun testSpanCreatedWithCorrectTags() {
     val traceTags =
-      tagBuilderImpl().apply {
+      newTagBuilder().apply {
         "test_string" tagTo "test_value"
         "test_boolean" tagTo true
         "test_long" tagTo 10000000L
@@ -50,13 +50,14 @@ class SkateTraceReporterTest : BasePlatformTestCase() {
         KeyValue("database", ValueType.STRING, DATABASE_NAME)
       )
 
-    val expectedSpanTags = tagBuilderImpl().apply {
-      "skate_version" tagTo "0.2.0"
-      "ide_version" tagTo "Studio Giraffe"
-      "user" tagTo System.getenv("USER")
-      "project_name" tagTo project.name
-      addAll(traceTags)
-    }
+    val expectedSpanTags =
+      newTagBuilder().apply {
+        "skate_version" tagTo "0.2.0"
+        "ide_version" tagTo "Studio Giraffe"
+        "user" tagTo System.getenv("USER")
+        "project_name" tagTo project.name
+        addAll(traceTags)
+      }
 
     assertThat(listOfSpans).isNotNull()
     if (listOfSpans != null) {
@@ -71,7 +72,7 @@ class SkateTraceReporterTest : BasePlatformTestCase() {
         .createPluginUsageTraceAndSendTrace(
           "fake_span_name",
           Instant.now(),
-          tagBuilderImpl(),
+          newTagBuilder(),
           "Studio Giraffe",
           "0.2.0"
         )
@@ -84,7 +85,7 @@ class SkateTraceReporterTest : BasePlatformTestCase() {
         .createPluginUsageTraceAndSendTrace(
           "fake_span_name",
           Instant.now(),
-          tagBuilderImpl(),
+          newTagBuilder(),
           "Studio Giraffe",
           ""
         )

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListenerTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/WhatsNewToolWindowListenerTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij
+
+import com.intellij.openapi.wm.*
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import junit.framework.TestCase
+
+class WhatsNewToolWindowListenerTest : BasePlatformTestCase() {
+
+  fun testVisibilityChangedFromInitialState() {
+    val whatsNewToolWindowListener = WhatsNewToolWindowListener(project)
+    val visibilityChanged = whatsNewToolWindowListener.visibilityChanged(true)
+    TestCase.assertEquals(visibilityChanged, true)
+  }
+
+  fun testVisibilityChangedFalseWhenStateRemains() {
+    val whatsNewToolWindowListener = WhatsNewToolWindowListener(project)
+    val visibilityChanged = whatsNewToolWindowListener.visibilityChanged(false)
+    TestCase.assertEquals(visibilityChanged, false)
+  }
+}

--- a/tracing/src/main/kotlin/com/slack/sgp/tracing/model/Spans.kt
+++ b/tracing/src/main/kotlin/com/slack/sgp/tracing/model/Spans.kt
@@ -35,6 +35,6 @@ public fun buildSpan(
     trace_id = traceId,
     start_timestamp_micros = startTimestampMicros,
     duration_micros = durationMicros,
-    tags = tagBuilderImpl().apply(addTags)
+    tags = newTagBuilder().apply(addTags)
   )
 }

--- a/tracing/src/main/kotlin/com/slack/sgp/tracing/model/TagBuilder.kt
+++ b/tracing/src/main/kotlin/com/slack/sgp/tracing/model/TagBuilder.kt
@@ -37,5 +37,5 @@ public interface TagBuilder : MutableList<KeyValue> {
     KeyValue(key = this, v_type = ValueType.BINARY, v_binary = value).also(::add)
 }
 
-public fun tagBuilderImpl(): TagBuilder =
+public fun newTagBuilder(): TagBuilder =
   object : TagBuilder, MutableList<KeyValue> by mutableListOf() {}

--- a/tracing/src/main/kotlin/com/slack/sgp/tracing/model/TagBuilder.kt
+++ b/tracing/src/main/kotlin/com/slack/sgp/tracing/model/TagBuilder.kt
@@ -37,5 +37,5 @@ public interface TagBuilder : MutableList<KeyValue> {
     KeyValue(key = this, v_type = ValueType.BINARY, v_binary = value).also(::add)
 }
 
-internal fun tagBuilderImpl(): TagBuilder =
+public fun tagBuilderImpl(): TagBuilder =
   object : TagBuilder, MutableList<KeyValue> by mutableListOf() {}


### PR DESCRIPTION
Add the first set of metrics to be tracked for Skate plugin, including

* Whats New Panel:
      * When the What's new panel opened / closed
* Feature Flag Annotator:
      * When user clicked on Houston link from feature flag annotation
 * Project Generator:
     * When the terminal opened and execute command to spin up ProjectGen UI

Noted that for the WhatsNewPanel, I added a custom `WhatsNewToolWindowListener` to subscribe to the event for the window opened/closed. I followed the set up described [here](https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html#defining-project-level-listeners) to set up the listener


Testing:
Example traces sent:
https://analytics.tinyspeck.com/v3/explore/1000000001135498


  

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->