### PR TITLE
Revert "Simplify detekt baseline handling"

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/GlobalConfig.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/GlobalConfig.kt
@@ -18,12 +18,15 @@ package slack.gradle
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.toolchain.JvmVendorSpec
+import slack.gradle.tasks.detektbaseline.MergeDetektBaselinesTask
 import slack.gradle.tasks.robolectric.UpdateRobolectricJarsTask
+import slack.gradle.util.setDisallowChanges
 
 /** Registry of global configuration info. */
 public class GlobalConfig
 private constructor(
   internal val updateRobolectricJarsTask: TaskProvider<UpdateRobolectricJarsTask>?,
+  internal val mergeDetektBaselinesTask: TaskProvider<MergeDetektBaselinesTask>?,
   internal val kotlinDaemonArgs: List<String>,
   internal val errorProneCheckNamesAsErrors: List<String>,
   internal val affectedProjects: Set<String>?,
@@ -36,8 +39,21 @@ private constructor(
       val globalSlackProperties = SlackProperties(project)
       val robolectricJarsDownloadTask =
         project.createRobolectricJarsDownloadTask(globalSlackProperties)
+      val mergeDetektBaselinesTask =
+        if (
+          project.gradle.startParameter.taskNames.any { it == MergeDetektBaselinesTask.TASK_NAME }
+        ) {
+          project.tasks.register<MergeDetektBaselinesTask>(MergeDetektBaselinesTask.TASK_NAME) {
+            outputFile.setDisallowChanges(
+              project.layout.projectDirectory.file("config/detekt/baseline.xml")
+            )
+          }
+        } else {
+          null
+        }
       return GlobalConfig(
         updateRobolectricJarsTask = robolectricJarsDownloadTask,
+        mergeDetektBaselinesTask = mergeDetektBaselinesTask,
         kotlinDaemonArgs = globalSlackProperties.kotlinDaemonArgs.split(" "),
         errorProneCheckNamesAsErrors =
           globalSlackProperties.errorProneCheckNamesAsErrors?.split(":").orEmpty(),

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -493,9 +493,9 @@ public class SlackProperties private constructor(private val project: Project) {
   /** Detekt config files, evaluated from rootProject.file(...). */
   public val detektConfigs: List<String>?
     get() = optionalStringProperty("slack.detekt.configs")?.split(",")
-  /** Detekt baseline file, evaluated from project.layout.projectDirectory.file(...). */
-  public val detektBaselineFileName: String?
-    get() = optionalStringProperty("slack.detekt.baselineFileName", blankIsNull = true)
+  /** Detekt baseline file, evaluated from rootProject.layout.projectDirectory.file(...). */
+  public val detektBaseline: String?
+    get() = optionalStringProperty("slack.detekt.baseline", blankIsNull = true)
   /** Enables full detekt mode (with type resolution). Off by default due to performance issues. */
   public val enableFullDetekt: Boolean
     get() = booleanProperty("slack.detekt.full")

--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -931,6 +931,7 @@ internal class StandardProjectConfigurations(
           slackProperties,
           slackTools.globalConfig.affectedProjects,
           actualJvmTarget,
+          slackTools.globalConfig.mergeDetektBaselinesTask,
         )
       }
     }

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/detektbaseline/Baseline.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/detektbaseline/Baseline.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.tasks.detektbaseline
+
+import java.io.BufferedWriter
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.xml.parsers.DocumentBuilderFactory
+import org.apache.commons.text.StringEscapeUtils
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
+
+internal typealias FindingsIdList = Set<String>
+
+internal fun Path.exists(): Boolean = Files.exists(this)
+
+internal fun Path.isFile(): Boolean = Files.isRegularFile(this)
+
+internal data class Baseline(
+  val manuallySuppressedIssues: FindingsIdList,
+  val currentIssues: FindingsIdList
+) {
+
+  fun writeTo(path: Path) {
+    // There are fancy DOM writing APIs out there, but we don't need it here for this simple stuff.
+    Files.newOutputStream(path).bufferedWriter().use { writer ->
+      writer.apply {
+        write("<?xml version=\"1.0\" ?>")
+        newLine()
+        write("<SmellBaseline>")
+        newLine()
+        manuallySuppressedIssues.writeTo(writer, "ManuallySuppressedIssues")
+        newLine()
+        currentIssues.writeTo(writer, "CurrentIssues")
+        newLine()
+        write("</SmellBaseline>")
+        newLine()
+      }
+    }
+  }
+
+  companion object {
+    fun load(baselineFile: Path): Baseline {
+      require(baselineFile.exists()) { "Baseline file does not exist." }
+      require(baselineFile.isFile()) { "Baseline file is not a regular file." }
+      val builderFactory = DocumentBuilderFactory.newInstance()
+      val docBuilder = builderFactory.newDocumentBuilder()
+      val doc = docBuilder.parse(Files.newInputStream(baselineFile).buffered())
+      val element = doc.documentElement
+      val manuallySuppressed =
+        element.getSingleElementByTag("ManuallySuppressedIssues").parseIdValues()
+      val currentIssues = element.getSingleElementByTag("CurrentIssues").parseIdValues()
+      return Baseline(manuallySuppressed, currentIssues)
+    }
+  }
+}
+
+private fun Element.getSingleElementByTag(tagName: String): Element {
+  return getElementsByTagName(tagName).asSequence().filterIsInstance<Element>().single()
+}
+
+private fun Element.parseIdValues(): Set<String> {
+  return getElementsByTagName("ID").asSequence().mapTo(LinkedHashSet(), Node::getTextContent)
+}
+
+private fun NodeList.asSequence(): Sequence<Node> {
+  return (0 until length).asSequence().map(::item)
+}
+
+private fun Set<String>.writeTo(writer: BufferedWriter, tag: String) {
+  with(writer) {
+    if (isEmpty()) {
+      write("  <$tag/>")
+    } else {
+      write("  <$tag>")
+      newLine()
+      joinTo(writer, separator = "\n") { "    <ID>${StringEscapeUtils.escapeXml11(it)}</ID>" }
+      newLine()
+      write("  </$tag>")
+    }
+  }
+}

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/detektbaseline/MergeDetektBaselinesTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/detektbaseline/MergeDetektBaselinesTask.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.tasks.detektbaseline
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import slack.gradle.tasks.detektbaseline.MergeDetektBaselinesTask.Companion.TASK_NAME
+
+/**
+ * Collects all generated baselines and merges them into one global one. Temporary until detekt
+ * supports this as a first party tool: https://github.com/arturbosch/detekt/issues/1589.
+ *
+ * This is only configured to run when the [TASK_NAME] task name is passed in, as detekt currently
+ * reuses the `baseline` argument for both the input file to regular detekt tasks and output file of
+ * its create tasks. Since we don't want the create tasks to overwrite each other into the same
+ * output task, we dynamically configure this as needed. When [TASK_NAME] is specified, all detekt
+ * baselines are pointed to an intermediate output file in that project's build directory and the
+ * misc "detektBaseline" tasks are wired to have their outputs to be inputs to this task's
+ * [baselineFiles].
+ *
+ * Usage:
+ *
+ * ./gradlew detektBaseline detektBaselineMerge
+ */
+@CacheableTask
+internal abstract class MergeDetektBaselinesTask : DefaultTask() {
+
+  init {
+    description = " Collects all generated detekt baselines and merges them into one global one."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+  }
+
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:InputFiles
+  @get:SkipWhenEmpty
+  abstract val baselineFiles: ConfigurableFileCollection
+
+  @get:OutputFile abstract val outputFile: RegularFileProperty
+
+  @TaskAction
+  fun merge() {
+    val merged =
+      baselineFiles
+        .filter { it.exists() }
+        .map { Baseline.load(it.toPath()) }
+        .reduce { acc, baseline ->
+          acc.copy(
+            currentIssues = acc.currentIssues + baseline.currentIssues,
+            manuallySuppressedIssues =
+              acc.manuallySuppressedIssues + baseline.manuallySuppressedIssues
+          )
+        }
+    val sorted =
+      merged.copy(
+        currentIssues = merged.currentIssues.toSortedSet(),
+        manuallySuppressedIssues = merged.manuallySuppressedIssues.toSortedSet()
+      )
+
+    sorted.writeTo(outputFile.asFile.get().toPath())
+  }
+
+  companion object {
+    const val TASK_NAME = "detektBaselineMerge"
+  }
+}


### PR DESCRIPTION
Reverts slackhq/slack-gradle-plugin#627. We actually need to do a bit more thinking on this as it would prevent us from running detekt as a commit hook