### PR TITLE
Update AgpHandler 8.3 to alpha 13

### DIFF
--- a/agp-handlers/agp-handler-83/build.gradle.kts
+++ b/agp-handlers/agp-handler-83/build.gradle.kts
@@ -11,6 +11,6 @@ dependencies {
 
   implementation(libs.autoService.annotations)
 
-  compileOnly("com.android.tools.build:gradle:8.3.0-alpha08")
+  compileOnly("com.android.tools.build:gradle:8.3.0-alpha13")
   compileOnly(gradleApi())
 }

--- a/agp-handlers/agp-handler-83/src/main/kotlin/slack/gradle/agphandler/v83/AgpHandler83.kt
+++ b/agp-handlers/agp-handler-83/src/main/kotlin/slack/gradle/agphandler/v83/AgpHandler83.kt
@@ -42,13 +42,10 @@ public class AgpHandler83 private constructor(override val agpVersion: AndroidPl
           3,
           0,
         )
-        .alpha(5)
+        .alpha(13)
 
-    // TODO Remove once it's public
-    //  https://issuetracker.google.com/issues/297440098
-    @Suppress("invisible_reference", "invisible_member")
-    override val currentVersion: AndroidPluginVersion =
-      com.android.build.api.extension.impl.CURRENT_AGP_VERSION
+    override val currentVersion: AndroidPluginVersion
+      get() = AndroidPluginVersion.getCurrent()
 
     override fun create(): AgpHandler = AgpHandler83(currentVersion)
   }


### PR DESCRIPTION
This has a new API for the current AGP version, allowing us to move off the private API