### PR TITLE
Don't configure KspTask in KotlinCompile tasks

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/util/kgpUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/kgpUtil.kt
@@ -15,6 +15,7 @@
  */
 package slack.gradle.util
 
+import com.google.devtools.ksp.gradle.KspTask
 import org.gradle.api.tasks.TaskContainer
 import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
@@ -31,6 +32,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  */
 internal fun TaskContainer.configureKotlinCompilationTask(
   includeKaptGenerateStubsTask: Boolean = false,
+  includeKspTask: Boolean = false,
   action: KotlinCompilationTask<*>.() -> Unit
 ) {
   withType(KotlinCompilationTask::class.java)
@@ -38,5 +40,6 @@ internal fun TaskContainer.configureKotlinCompilationTask(
     // standard kotlin compilation, which can lead to duplicates. SOOOO we skip configuration of
     // it here. Callers to this _can_ opt in to including it, but they must be explicit.
     .matching { includeKaptGenerateStubsTask || it !is KaptGenerateStubsTask }
+    .matching { includeKspTask || it !is KspTask }
     .configureEach { action() }
 }


### PR DESCRIPTION
Similar to stub gen, we don't actually want to configure these even though they extend kotlincompile because KSP applies their own mappings

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->