### PR TITLE
Includes source links in dokka docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -283,6 +283,17 @@ subprojects {
               .toURL()
           )
         }
+        sourceLink {
+          localDirectory.set(layout.projectDirectory.dir("src").asFile)
+          val relPath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
+          remoteUrl.set(
+            providers.gradleProperty("POM_SCM_URL")
+              .map { scmUrl ->
+                URI("$scmUrl/tree/main/$relPath/src").toURL()
+              }
+          )
+          remoteLineSuffix.set("#L")
+        }
       }
     }
 


### PR DESCRIPTION
Now they're clickable directly from the dokka docs (see the "source" link in the screenshot)

<img width="1512" alt="Screenshot 2023-11-21 at 12 45 21 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/1361086/b79127b5-4ac2-4421-b302-78d86bece2cd">


<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->