### PR TITLE
Add code owner pane to Skate plugin

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkatePluginSettings.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkatePluginSettings.kt
@@ -27,6 +27,7 @@ internal const val DEFAULT_TRANSLATOR_SOURCE_MODELS_PACKAGE_NAME = "slack.api.sc
 @VisibleForTesting internal const val DEFAULT_TRANSLATOR_FILE_NAME_SUFFIX = "Translator.kt"
 @VisibleForTesting internal const val DEFAULT_TRANSLATOR_ENUM_IDENTIFIER = "name"
 internal const val DEFAULT_PROJECT_GEN_CLI_COMMAND = "./slackw generate-project"
+internal const val DEFAULT_CODE_OWNER_FILE_PATH = "config/code-ownership/code_ownership.csv"
 
 /** Manages user-specific settings for the Skate plugin */
 @Service(Service.Level.PROJECT)
@@ -117,6 +118,18 @@ class SkatePluginSettings : SimplePersistentStateComponent<SkatePluginSettings.S
       state.tracingEndpoint = value
     }
 
+  var isCodeOwnerEnabled: Boolean
+    get() = state.isCodeOwnerEnabled
+    set(value) {
+      state.isCodeOwnerEnabled = value
+    }
+
+  var codeOwnerFilePath: String?
+    get() = state.codeOwnerFilePath ?: DEFAULT_CODE_OWNER_FILE_PATH
+    set(value) {
+      state.codeOwnerFilePath = value
+    }
+
   class State : BaseState() {
     var whatsNewFilePath by string()
     var isWhatsNewEnabled by property(true)
@@ -131,5 +144,7 @@ class SkatePluginSettings : SimplePersistentStateComponent<SkatePluginSettings.S
     var featureFlagFilePattern by string()
     var isTracingEnabled by property(true)
     var tracingEndpoint by string()
+    var codeOwnerFilePath by string()
+    var isCodeOwnerEnabled by property(true)
   }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerFileFetcher.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerFileFetcher.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.codeowners
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.slack.sgp.intellij.SkatePluginSettings
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * CodeOwnerFileFetcher is the interface for fetching the code owner csv file. It's structured like
+ * this so we can provide test/fake instances for use in unit tests.
+ */
+interface CodeOwnerFileFetcher {
+  fun getCodeOwnershipCsv(): File?
+}
+
+class CodeOwnerFileFetcherImpl(private val project: Project) : CodeOwnerFileFetcher {
+
+  private val logger = logger<CodeOwnerFileFetcherImpl>()
+
+  override fun getCodeOwnershipCsv(): File? {
+    val settings = project.service<SkatePluginSettings>()
+    val fs = LocalFileSystem.getInstance()
+    val path = Path.of(project.basePath ?: "", settings.codeOwnerFilePath)
+    logger.debug("getCodeOwnershipCsv path location: $path")
+    return fs.findFileByNioFile(path)?.toNioPath()?.toFile()
+  }
+}
+
+class FakeCodeOwnerFileFetcherImpl(private val path: String) : CodeOwnerFileFetcher {
+  override fun getCodeOwnershipCsv(): File? {
+    val fs = LocalFileSystem.getInstance()
+    return fs.findFileByNioFile(Path.of(path))?.toNioPath()?.toFile()
+  }
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerInfo.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerInfo.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.codeowners
+
+data class CodeOwnerInfo(
+  val team: String,
+  val packagePattern: String,
+  val codeOwnerLineNumber: Int
+)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.codeowners
+
+import com.intellij.openapi.diagnostic.logger
+import java.io.FileNotFoundException
+
+/**
+ * CodeOwnerRepository is responsible for reading and caching the code owners info from the csv
+ * specific via CodeOwnerFileHelper.getCodeOwnershipCsv(project). Invalid file formats or rows will
+ * be ignored.
+ */
+class CodeOwnerRepository(codeOwnerFileFetcher: CodeOwnerFileFetcher) {
+
+  private var codeOwnershipMap: Map<String, CodeOwnerInfo> = emptyMap()
+  private val logger = logger<CodeOwnerRepository>()
+
+  init {
+    val codeOwnershipFile = codeOwnerFileFetcher.getCodeOwnershipCsv()
+    if (codeOwnershipFile != null) {
+      try {
+        codeOwnershipMap =
+          codeOwnershipFile
+            .readLines()
+            .asSequence()
+            .mapIndexed { index, line -> parseCodeOwnerLineInfo(index, line) }
+            .filterNotNull()
+            .associateBy { codeOwnerInfo -> codeOwnerInfo.packagePattern }
+      } catch (fileNotFoundException: FileNotFoundException) {
+        logger.error(
+          "FileNotFoundException caught parsing code ownership file",
+          fileNotFoundException
+        )
+      }
+      logger.debug("Code ownership lines read into codeOwnershipMap: ${codeOwnershipMap.keys.size}")
+    }
+  }
+
+  fun getCodeOwnership(filePath: String): List<CodeOwnerInfo> {
+    return codeOwnershipMap.keys
+      .filter { filePattern -> Regex(pattern = filePattern).containsMatchIn(filePath) }
+      .map { codeOwnershipMap[it]!! }
+  }
+
+  private fun parseCodeOwnerLineInfo(index: Int, line: String): CodeOwnerInfo? {
+    val splitLine = line.split(",")
+    return if (splitLine.size == 2) {
+      CodeOwnerInfo(team = splitLine[1], packagePattern = splitLine[0], codeOwnerLineNumber = index)
+    } else {
+      null
+    }
+  }
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/CodeOwnerWidget.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/CodeOwnerWidget.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.ui
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.ListPopup
+import com.intellij.openapi.ui.popup.PopupStep
+import com.intellij.openapi.ui.popup.util.BaseListPopupStep
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.impl.status.EditorBasedWidget
+import com.slack.sgp.intellij.codeowners.CodeOwnerFileFetcherImpl
+import com.slack.sgp.intellij.codeowners.CodeOwnerInfo
+import com.slack.sgp.intellij.codeowners.CodeOwnerRepository
+
+const val CODE_OWNER_WIDGET_ID = "CodeOwnerWidget"
+
+/** CodeOwnerWidget is responsible for displaying and handling code owner widget functionality. */
+class CodeOwnerWidget(project: Project) :
+  EditorBasedWidget(project), StatusBarWidget.MultipleTextValuesPresentation {
+
+  init {
+    // Connect to message bus and listen for file editor changes.
+    val bus = ApplicationManager.getApplication().messageBus
+    val connection = bus.connect(this)
+    connection.subscribe(
+      FileEditorManagerListener.FILE_EDITOR_MANAGER,
+      object : FileEditorManagerListener {
+        override fun selectionChanged(event: FileEditorManagerEvent) {
+          this@CodeOwnerWidget.selectionChanged(event)
+        }
+      }
+    )
+  }
+
+  private var currentSelectedFile: VirtualFile? = null
+  private val codeOwnerFileFetcher = CodeOwnerFileFetcherImpl(project)
+  private val codeOwnersRepo = CodeOwnerRepository(codeOwnerFileFetcher)
+  private val logger = logger<CodeOwnerWidget>()
+
+  override fun ID() = CODE_OWNER_WIDGET_ID
+
+  override fun getPresentation(): StatusBarWidget.WidgetPresentation = this
+
+  override fun selectionChanged(event: FileEditorManagerEvent) {
+    // Set the current selected file from the FileEditorManagerEvent.newFile VirtualFile.
+    // We don't worry if it's null as that may be expected
+    // and will lead to the widget displaying "none" owners.
+    currentSelectedFile = event.newFile
+    myStatusBar.updateWidget(ID())
+  }
+
+  override fun getTooltipText() = "Click to show in code_ownership csv"
+
+  override fun getClickConsumer() = null
+
+  override fun getPopupStep(): ListPopup? {
+    val owners = getCurrentCodeOwnerInfo()
+    return when (owners.size) {
+      1 -> {
+        // for single owner navigate directly to their codeowner line
+        goToOwner(owners.first())
+        null
+      }
+      in 2..Int.MAX_VALUE -> {
+        // launch picker popup if more than 1 owner
+        JBPopupFactory.getInstance().createListPopup(MultiCodeOwnerPopupStep(owners))
+      }
+      else -> {
+        // no-op, do nothing if there's no owners
+        null
+      }
+    }
+  }
+
+  override fun getSelectedValue(): String {
+    val owners = getCurrentCodeOwnerInfo()
+    val first = owners.firstOrNull()
+    val numOthers = owners.size - 1
+
+    // Handle multiple/single/no owners scenarios
+    val widgetText =
+      when (owners.size) {
+        0 -> "Owner: none"
+        1 -> "Owner: ${first?.team}"
+        2 -> "Owners: ${first?.team} & 1 other"
+        in 3..Int.MAX_VALUE -> "Owners: ${first?.team} & $numOthers others"
+        else -> "Owners: Not available"
+      }
+    logger.debug("getSelectedValue computed value: $widgetText")
+    return widgetText
+  }
+
+  private fun getCurrentCodeOwnerInfo(): List<CodeOwnerInfo> {
+    val file = currentSelectedFile
+    if (file != null) {
+      logger.debug("getCurrentCodeOwnerInfo called w/ path: ${file.path}")
+      return codeOwnersRepo.getCodeOwnership(file.path)
+    }
+    return emptyList()
+  }
+
+  private fun goToOwner(ownerInfo: CodeOwnerInfo) {
+    val codeOwnersFile = codeOwnerFileFetcher.getCodeOwnershipCsv()
+    val virtualFile =
+      codeOwnersFile?.toPath()?.let { VirtualFileManager.getInstance().findFileByNioPath(it) }
+        ?: return
+    OpenFileDescriptor(project, virtualFile, ownerInfo.codeOwnerLineNumber, 0).navigate(true)
+  }
+
+  inner class MultiCodeOwnerPopupStep(private val owners: List<CodeOwnerInfo>) :
+    BaseListPopupStep<String>("Owners", owners.map { it.team }) {
+    override fun onChosen(selectedValue: String?, finalChoice: Boolean): PopupStep<*>? {
+      val selectedTeam = owners.firstOrNull { it.team == selectedValue }
+      if (selectedTeam != null) {
+        goToOwner(selectedTeam)
+      }
+      return super.onChosen(selectedValue, finalChoice)
+    }
+  }
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/CodeOwnerWidgetFactory.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/CodeOwnerWidgetFactory.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.ui
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import com.slack.sgp.intellij.SkatePluginSettings
+import com.slack.sgp.intellij.codeowners.CodeOwnerFileFetcherImpl
+
+class CodeOwnerWidgetFactory : StatusBarWidgetFactory {
+
+  private val logger = logger<CodeOwnerWidget>()
+
+  override fun getId() = CODE_OWNER_WIDGET_ID
+
+  override fun getDisplayName() = "Code Owners"
+
+  override fun isAvailable(project: Project): Boolean {
+    val isSettingEnabled = project.getService(SkatePluginSettings::class.java).isCodeOwnerEnabled
+    val isEnabled =
+      isSettingEnabled && CodeOwnerFileFetcherImpl(project).getCodeOwnershipCsv() != null
+    logger.debug("CodeOwnerWidgetFactory.isAvailable result: $isEnabled")
+    return isEnabled
+  }
+
+  override fun createWidget(project: Project) = CodeOwnerWidget(project)
+
+  override fun disposeWidget(widget: StatusBarWidget) = Disposer.dispose(widget)
+
+  override fun canBeEnabledOn(statusBar: StatusBar) = true
+}

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/SkateConfigUI.kt
@@ -40,6 +40,7 @@ internal class SkateConfigUI(
     enableProjectGenMenuAction()
     featureFlagSettings()
     tracingSettings()
+    codeOwnerSettings()
   }
 
   private fun Panel.whatsNewPanelSettings() {
@@ -146,6 +147,28 @@ internal class SkateConfigUI(
         setter = { settings.tracingEndpoint = it },
         errorMessageKey = "skate.configuration.tracingEndpoint.error",
         enabledCondition = tracingEnabledButton.selected,
+      )
+    }
+  }
+
+  private fun Panel.codeOwnerSettings() {
+    group(SkateBundle.message("skate.configuration.codeOwner.title")) {
+      lateinit var codeOwnerEnabledButton: Cell<JBCheckBox>
+
+      row {
+        codeOwnerEnabledButton =
+          checkBox(SkateBundle.message("skate.configuration.codeOwner.enabledDescription"))
+            .bindSelected(
+              getter = { settings.isCodeOwnerEnabled },
+              setter = { settings.isCodeOwnerEnabled = it }
+            )
+      }
+      bindAndValidateTextFieldRow(
+        titleMessageKey = "skate.configuration.codeOwnerFile.title",
+        getter = { settings.codeOwnerFilePath },
+        setter = { settings.codeOwnerFilePath = it },
+        errorMessageKey = "skate.configuration.codeOwnerFile.error",
+        enabledCondition = codeOwnerEnabledButton.selected,
       )
     }
   }

--- a/skate-plugin/src/main/resources/META-INF/plugin.xml
+++ b/skate-plugin/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,7 @@
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
+        <statusBarWidgetFactory implementation="com.slack.sgp.intellij.ui.CodeOwnerWidgetFactory" id="CodeOwnerWidget"/>
         <projectService
                 serviceInterface="com.slack.sgp.intellij.SkateProjectService"
                 serviceImplementation="com.slack.sgp.intellij.SkateProjectServiceImpl"/>

--- a/skate-plugin/src/main/resources/messages/skateBundle.properties
+++ b/skate-plugin/src/main/resources/messages/skateBundle.properties
@@ -16,3 +16,7 @@ skate.configuration.enableTracing.description=Enable sending plugin usage statis
 skate.configuration.tracing.title=Tracing
 skate.configuration.tracingEndpoint.title=Tracing API Endpoint
 skate.configuration.tracingEndpoint.error=API endpoint can't be empty
+skate.configuration.codeOwner.title=Code Owner
+skate.configuration.codeOwner.enabledDescription=Enable plugin to see team code ownership in status widget
+skate.configuration.codeOwnerFile.title=File path
+skate.configuration.codeOwnerFile.error=File path can't be empty

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepositoryTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepositoryTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.codeowners
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class CodeOwnerRepositoryTest : BasePlatformTestCase() {
+
+  fun testMissingFile() {
+    val underTest = createCodeOwnerRepository(FakeCodeOwnerFileFetcherImpl(path = "boguspath"))
+    assertThat(underTest.getCodeOwnership("any")).isEmpty()
+  }
+
+  fun testSingleMatchingResult() {
+    val underTest = createCodeOwnerRepository()
+    assertThat(underTest.getCodeOwnership("app/folder2/subfolder/foo.kt").size).isEqualTo(1)
+  }
+
+  fun testMultipleMatchingResult() {
+    val underTest = createCodeOwnerRepository()
+    assertThat(underTest.getCodeOwnership("app/folder3/subfolder/foo.kt").size).isEqualTo(2)
+  }
+
+  fun testNoResult() {
+    val underTest = createCodeOwnerRepository()
+    assertThat(underTest.getCodeOwnership("pathnotinfile")).isEmpty()
+  }
+
+  private fun createCodeOwnerRepository(
+    codeOwnerFileFetcher: CodeOwnerFileFetcher =
+      FakeCodeOwnerFileFetcherImpl("src/test/resources/test-code-ownership.csv")
+  ): CodeOwnerRepository {
+    return CodeOwnerRepository(codeOwnerFileFetcher)
+  }
+}

--- a/skate-plugin/src/test/resources/test-code-ownership.csv
+++ b/skate-plugin/src/test/resources/test-code-ownership.csv
@@ -1,0 +1,5 @@
+file_filter,team
+app/folder1/.*,Team 1
+app/folder2/.*,Team 1
+app/folder3/.*,Team 2
+app/folder3/subfolder/.*,Team 1


### PR DESCRIPTION
This PR adds a code owner widget to the bottom right status bar of Jetbrains IDEs.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->