### PR TITLE
Increase Kotlin daemon default memory percentage from `50` to `55`

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
@@ -90,8 +90,15 @@ public enum class BootstrapPropertiesMode {
 private val BYTES_PER_GB = 1024.0.pow(3)
 private const val NEW_SIZE_PERCENT = 0.67
 
-/** The ratio of Gradle jvm args memory to kotlin daemon memory. */
-private const val DEFAULT_GRADLE_MEMORY_PERCENT = 0.50f
+/**
+ * The ratio of Gradle jvm args memory to kotlin daemon memory.
+ * Based on a system configuration of 128 GiB memory at 55%, we should be getting the following
+ *   | Gradle xms: 51GB
+ *   | Gradle xmx: 51GB
+ *   | Kotlin Daemon xms: 41GB
+ *   | Kotlin Daemon xmx: 41GB
+ * */
+private const val DEFAULT_GRADLE_MEMORY_PERCENT = 0.55f
 
 /**
  * The core Bootstrap task that all bootstrap-applicable tasks can depend on. This task configures

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/BootstrapTask.kt
@@ -91,13 +91,10 @@ private val BYTES_PER_GB = 1024.0.pow(3)
 private const val NEW_SIZE_PERCENT = 0.67
 
 /**
- * The ratio of Gradle jvm args memory to kotlin daemon memory.
- * Based on a system configuration of 128 GiB memory at 55%, we should be getting the following
- *   | Gradle xms: 51GB
- *   | Gradle xmx: 51GB
- *   | Kotlin Daemon xms: 41GB
- *   | Kotlin Daemon xmx: 41GB
- * */
+ * The ratio of Gradle jvm args memory to kotlin daemon memory. Based on a system configuration of
+ * 128 GiB memory at 55%, we should be getting the following | Gradle xms: 51GB | Gradle xmx: 51GB |
+ * Kotlin Daemon xms: 41GB | Kotlin Daemon xmx: 41GB
+ */
 private const val DEFAULT_GRADLE_MEMORY_PERCENT = 0.55f
 
 /**


### PR DESCRIPTION
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->