### PR TITLE
Fix NPE in codeowners widget

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/CodeOwnerWidget.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/CodeOwnerWidget.kt
@@ -67,9 +67,7 @@ class CodeOwnerWidget(project: Project) :
     // We don't worry if it's null as that may be expected
     // and will lead to the widget displaying "none" owners.
     currentSelectedFile = event.newFile
-    if (myStatusBar != null) {
-      myStatusBar.updateWidget(ID())
-    }
+    myStatusBar?.updateWidget(ID())
   }
 
   override fun getTooltipText() = "Click to show in code_ownership csv"

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/CodeOwnerWidget.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/ui/CodeOwnerWidget.kt
@@ -67,7 +67,9 @@ class CodeOwnerWidget(project: Project) :
     // We don't worry if it's null as that may be expected
     // and will lead to the widget displaying "none" owners.
     currentSelectedFile = event.newFile
-    myStatusBar.updateWidget(ID())
+    if (myStatusBar != null) {
+      myStatusBar.updateWidget(ID())
+    }
   }
 
   override fun getTooltipText() = "Click to show in code_ownership csv"


### PR DESCRIPTION
Fixes a NPE when `myStatusBar` is null (assuming not yet available or disabled) in codeowners widget update code.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->