### PR TITLE
Remove `-Xproper-ieee754-comparisons`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,7 +127,6 @@ data class KotlinBuildConfig(val kotlin: String) {
    */
   val kotlinCompilerArgs: List<String> =
     listOf(
-      "-Xproper-ieee754-comparisons",
       // Enhance not null annotated type parameter's types to definitely not null types (@NotNull T
       // => T & Any)
       "-Xenhance-type-parameter-types-to-def-not-null",


### PR DESCRIPTION
This is enabled by the progressive flag anyway and ~seemingly~ enabled by default in K2.

Ref: https://youtrack.jetbrains.com/issue/KT-22723/Inconsistent-behavior-of-floating-point-number-comparisons#focus=Change-27-2959679.0-0

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->