### PR TITLE
Broaden anvil KSP support controls

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -16,8 +16,10 @@
 package slack.gradle
 
 import java.io.File
+import java.util.Locale
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import slack.gradle.anvil.AnvilMode
 import slack.gradle.artifacts.SgpArtifact
 import slack.gradle.util.PropertyResolver
 import slack.gradle.util.getOrCreateExtra
@@ -312,10 +314,6 @@ internal constructor(
   public val allowDaggerKsp: Boolean
     get() = booleanProperty("slack.ksp.allow-dagger")
 
-  /** Flag to enable/disable Anvil KSP. Requires [allowDaggerKsp]. */
-  public val allowAnvilKsp: Boolean
-    get() = booleanProperty("slack.ksp.allow-anvil")
-
   /** Variants that should be disabled in a given subproject. */
   public val disabledVariants: String?
     get() = optionalStringProperty("slack.disabledVariants")
@@ -586,10 +584,20 @@ internal constructor(
 
   /**
    * Force-disables Anvil regardless of `SlackExtension.dagger()` settings, useful for K2 testing
-   * where Anvil is unsuspported
+   * where Anvil is unsupported.
    */
   public val disableAnvilForK2Testing: Boolean
     get() = resolver.booleanValue("sgp.anvil.forceDisable", defaultValue = false)
+
+  /**
+   * Defines the [AnvilMode] to use with this compilation. See the docs on that class for more
+   * details.
+   */
+  public val anvilMode: AnvilMode
+    get() =
+      resolver.stringValue("sgp.anvil.mode", defaultValue = AnvilMode.K1.name).let {
+        AnvilMode.valueOf(it.lowercase(Locale.US))
+      }
 
   /** Defines a required vendor for JDK toolchains. */
   public val jvmVendor: Provider<String>

--- a/slack-plugin/src/main/kotlin/slack/gradle/anvil/AnvilMode.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/anvil/AnvilMode.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.gradle.anvil
+
+public enum class AnvilMode(
+  public val useKspFactoryGen: Boolean,
+  public val useKspComponentGen: Boolean,
+  public val languageVersionOverride: String?,
+) {
+  /**
+   * Anvil support for K1.
+   * - `AnalysisHandlerExtension`
+   * - KAPT3 component gen
+   */
+  K1(false, false, null),
+  /**
+   * Anvil support for K2. Same as [K1] but it forces Anvil-integrated kotlin compilations to
+   * language version 1.9.
+   */
+  K2_COMPAT(false, false, "1.9"),
+  /**
+   * Anvil support for K2.
+   * - KSP factory gen
+   * - KAPT4 component gen
+   */
+  K2_KAPT(true, false, null),
+  /**
+   * Anvil support for K2.
+   * - KSP factory gen
+   * - KSP component gen
+   */
+  K2_KSP(true, true, null),
+}


### PR DESCRIPTION
This adds a new `AnvilMode` enum + property so we can better test anvil under different scenarios (K1/K2 and kapt/ksp)

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->