### PR TITLE
Add sync action on successful project gen

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenMenuAction.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenMenuAction.kt
@@ -35,7 +35,7 @@ class ProjectGenMenuAction @JvmOverloads constructor(private val offline: Boolea
   override fun actionPerformed(e: AnActionEvent) {
     val currentProject: Project = e.project ?: return
     if (!currentProject.isProjectGenMenuActionEnabled()) return
-    ProjectGenWindow(currentProject).show()
+    ProjectGenWindow(currentProject, e).show()
 
     if (currentProject.isTracingEnabled()) {
       sendUsageTrace(currentProject)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenPresenter.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenPresenter.kt
@@ -36,6 +36,7 @@ import slack.tooling.projectgen.TextElement
 internal class ProjectGenPresenter(
   private val rootDir: String,
   private val onDismissDialog: () -> Unit,
+  private val onSync: () -> Unit,
 ) : Presenter<ProjectGenScreen.State> {
   private val path =
     TextElement(
@@ -145,6 +146,7 @@ internal class ProjectGenPresenter(
     ) { event ->
       when (event) {
         ProjectGenScreen.Event.Quit -> onDismissDialog()
+        ProjectGenScreen.Event.Sync -> onSync()
         ProjectGenScreen.Event.Reset -> {
           showDoneDialog = false
           showErrorDialog = false

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenScreen.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenScreen.kt
@@ -34,6 +34,8 @@ internal object ProjectGenScreen : Screen {
   sealed interface Event : CircuitUiEvent {
     object Generate : Event
 
+    object Sync : Event
+
     object Quit : Event
 
     object Reset : Event

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenUi.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenUi.kt
@@ -60,7 +60,7 @@ internal fun ProjectGen(state: ProjectGenScreen.State, modifier: Modifier = Modi
   if (state.showDoneDialog) {
     StatusDialog(
       text = "Project generated successfully!",
-      confirmButtonText = "Quit and Sync",
+      confirmButtonText = "Close and Sync",
       onQuit = { state.eventSink(ProjectGenScreen.Event.Quit) },
       onConfirm = { state.eventSink(ProjectGenScreen.Event.Sync) },
     )
@@ -181,7 +181,7 @@ private fun StatusDialog(
   (AlertDialog(
     onDismissRequest = { onQuit() },
     confirmButton = { Button(onClick = { onConfirm() }) { Text(confirmButtonText) } },
-    dismissButton = { Button(onClick = { onQuit() }) { Text("Quit") } },
+    dismissButton = { Button(onClick = { onQuit() }) { Text("Close") } },
     text = { Text(text) },
   ))
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenUi.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenUi.kt
@@ -59,16 +59,18 @@ private const val INDENT_SIZE = 16 // dp
 internal fun ProjectGen(state: ProjectGenScreen.State, modifier: Modifier = Modifier) {
   if (state.showDoneDialog) {
     StatusDialog(
-      text = "Done! Don't forget to re-sync Android Studio!",
+      text = "Project generated successfully!",
+      confirmButtonText = "Quit and Sync",
       onQuit = { state.eventSink(ProjectGenScreen.Event.Quit) },
-      onDismiss = { state.eventSink(ProjectGenScreen.Event.Reset) },
+      onConfirm = { state.eventSink(ProjectGenScreen.Event.Sync) },
     )
   }
   if (state.showErrorDialog) {
     StatusDialog(
       text = "Failed to generate projects since project already exists",
+      confirmButtonText = "Reset",
       onQuit = { state.eventSink(ProjectGenScreen.Event.Quit) },
-      onDismiss = { state.eventSink(ProjectGenScreen.Event.Reset) },
+      onConfirm = { state.eventSink(ProjectGenScreen.Event.Reset) },
     )
   }
   val scrollState = rememberScrollState(0)
@@ -103,7 +105,6 @@ internal fun ProjectGen(state: ProjectGenScreen.State, modifier: Modifier = Modi
             }
             is TextElement -> {
               Column(Modifier.padding(start = (element.indentLevel * INDENT_SIZE).dp)) {
-                // TODO Add validation?
                 TextField(
                   element.value,
                   label = { Text(element.label) },
@@ -113,6 +114,10 @@ internal fun ProjectGen(state: ProjectGenScreen.State, modifier: Modifier = Modi
                       ?: VisualTransformation.None,
                   readOnly = element.readOnly,
                   enabled = element.enabled,
+                  singleLine = true,
+                  isError =
+                    element.value.isNotEmpty() &&
+                      !element.value.matches(Regex("[a-zA-Z]([A-Za-z0-9\\-_:.])*")),
                 )
                 element.description?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
               }
@@ -164,14 +169,19 @@ private fun PreviewFeature() {
 }
 
 @Composable
-private fun StatusDialog(text: String, onQuit: () -> Unit, onDismiss: () -> Unit) {
+private fun StatusDialog(
+  text: String,
+  confirmButtonText: String,
+  onQuit: () -> Unit,
+  onConfirm: () -> Unit,
+) {
   // No M3 AlertDialog in compose-jb yet
   // https://github.com/JetBrains/compose-multiplatform/issues/2037
   @Suppress("ComposeM2Api")
   (AlertDialog(
-    onDismissRequest = { onDismiss() },
-    confirmButton = { Button(onClick = { onQuit() }) { Text("Quit") } },
-    dismissButton = { Button(onClick = { onDismiss() }) { Text("Dismiss") } },
+    onDismissRequest = { onQuit() },
+    confirmButton = { Button(onClick = { onConfirm() }) { Text(confirmButtonText) } },
+    dismissButton = { Button(onClick = { onQuit() }) { Text("Quit") } },
     text = { Text(text) },
   ))
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenWindow.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenWindow.kt
@@ -32,7 +32,7 @@ import java.nio.file.Paths
 import javax.swing.Action
 import javax.swing.JComponent
 
-class ProjectGenWindow(private val currentProject: Project?, private val e: AnActionEvent) :
+class ProjectGenWindow(private val currentProject: Project?, private val event: AnActionEvent) :
   DialogWrapper(currentProject) {
   init {
     init()
@@ -65,7 +65,11 @@ class ProjectGenWindow(private val currentProject: Project?, private val e: AnAc
     val circuit = remember {
       Circuit.Builder()
         .addPresenterFactory { _, _, _ ->
-          ProjectGenPresenter(rootDir = rootDir, onDismissDialog = ::doOKAction, onSync = ::dismissDialogAndSync)
+          ProjectGenPresenter(
+            rootDir = rootDir,
+            onDismissDialog = ::doOKAction,
+            onSync = ::dismissDialogAndSync,
+          )
         }
         .addUiFactory { _, _ ->
           ui<ProjectGenScreen.State> { state, modifier -> ProjectGen(state, modifier) }
@@ -94,7 +98,7 @@ class ProjectGenWindow(private val currentProject: Project?, private val e: AnAc
     doOKAction()
     val am: ActionManager = ActionManager.getInstance()
     val sync: AnAction = am.getAction("Android.SyncProject")
-    sync.actionPerformed(e)
+    sync.actionPerformed(event)
   }
 
   private fun deleteProjectLock() {


### PR DESCRIPTION
 
When project got generated successfully, add an option to `Quit & Sync` that exits project gen dialog and does Gradle sync.
![image](https://github.com/slackhq/slack-gradle-plugin/assets/12748234/1880f157-cd03-4f69-abc0-08dd6e08dbf8)


https://github.com/slackhq/slack-gradle-plugin/assets/12748234/469c74b5-baa0-4133-be51-e4820a276b06

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.






  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->