### PR TITLE
Incorporate lint into the project

### DIFF
--- a/agp-handlers/agp-handler-82/build.gradle.kts
+++ b/agp-handlers/agp-handler-82/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
   alias(libs.plugins.ksp)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.buildConfig)
+  alias(libs.plugins.lint)
 }
 
 buildConfig {
@@ -31,6 +32,8 @@ buildConfig {
 
 dependencies {
   ksp(libs.autoService.ksp)
+
+  lintChecks(libs.gradleLints)
 
   api(projects.agpHandlers.agpHandlerApi)
 

--- a/agp-handlers/agp-handler-82/lint-baseline.xml
+++ b/agp-handlers/agp-handler-82/lint-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.4.0-alpha11" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.4.0-alpha11">
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.SdkLocator"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/agphandler/v82/AgpHandler82.kt"
+            line="19"
+            column="1"/>
+    </issue>
+
+</issues>

--- a/agp-handlers/agp-handler-83/build.gradle.kts
+++ b/agp-handlers/agp-handler-83/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
   alias(libs.plugins.ksp)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.buildConfig)
+  alias(libs.plugins.lint)
 }
 
 buildConfig {
@@ -31,6 +32,8 @@ buildConfig {
 
 dependencies {
   ksp(libs.autoService.ksp)
+
+  lintChecks(libs.gradleLints)
 
   api(projects.agpHandlers.agpHandlerApi)
 

--- a/agp-handlers/agp-handler-83/lint-baseline.xml
+++ b/agp-handlers/agp-handler-83/lint-baseline.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.4.0-alpha11" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.4.0-alpha11">
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.SdkLocationSourceSet"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/agphandler/v83/AgpHandler83.kt"
+            line="19"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.SdkLocator"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/agphandler/v83/AgpHandler83.kt"
+            line="20"
+            column="1"/>
+    </issue>
+
+</issues>

--- a/agp-handlers/agp-handler-api/build.gradle.kts
+++ b/agp-handlers/agp-handler-api/build.gradle.kts
@@ -16,9 +16,11 @@
 plugins {
   kotlin("jvm")
   alias(libs.plugins.mavenPublish)
+  alias(libs.plugins.lint)
 }
 
 dependencies {
+  lintChecks(libs.gradleLints)
   implementation(libs.guava)
 
   compileOnly(gradleApi())

--- a/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/VersionNumber.kt
+++ b/agp-handlers/agp-handler-api/src/main/kotlin/slack/gradle/agp/VersionNumber.kt
@@ -181,8 +181,8 @@ private constructor(
 
   private class DefaultScheme : AbstractScheme(3) {
     override fun format(versionNumber: VersionNumber): String {
-      return String.format(
-        VERSION_TEMPLATE,
+      return VERSION_TEMPLATE.format(
+        Locale.US,
         versionNumber.major,
         versionNumber.minor,
         versionNumber.micro,
@@ -197,8 +197,8 @@ private constructor(
 
   private class SchemeWithPatchVersion : AbstractScheme(4) {
     override fun format(versionNumber: VersionNumber): String {
-      return String.format(
-        VERSION_TEMPLATE,
+      return VERSION_TEMPLATE.format(
+        Locale.US,
         versionNumber.major,
         versionNumber.minor,
         versionNumber.micro,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ plugins {
   alias(libs.plugins.intellij) apply false
   alias(libs.plugins.pluginUploader) apply false
   alias(libs.plugins.buildConfig) apply false
+  alias(libs.plugins.lint) apply false
 }
 
 configure<DetektExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.android.build.api.dsl.Lint
 import com.diffplug.gradle.spotless.KotlinExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.github.gmazzo.buildconfig.BuildConfigExtension
@@ -381,6 +382,15 @@ subprojects {
         }
       }
     }
+  }
+
+  pluginManager.withPlugin("com.android.lint") {
+    configure<Lint> {
+      lintConfig = rootProject.layout.projectDirectory.file("config/lint/lint.xml").asFile
+      baseline = project.layout.projectDirectory.file("lint-baseline.xml").asFile
+    }
+    project.dependencies.add("lintChecks", libs.slackLints.checks)
+    project.dependencies.add("implementation", libs.slackLints.annotations)
   }
 }
 

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!--
+    We often apply lint rules globally, which sometimes includes IDs not detected in individual
+    projects
+    -->
+    <issue id="UnknownIssueId" severity="ignore"/>
+
+    <!--
+    We don't want to run lint over generated sources because generated code is able to guarantee
+    us a certain degree of correctness. This means we're allowing it to hardcode some things we
+    know are correct, like Butter Knife view IDs rather than fully qualified "R.id.blah".
+    -->
+    <issue id="all">
+        <ignore path="build" />
+    </issue>
+
+<!--    <issue id="ComposeCompositionLocalUsage">-->
+<!--        <option name="allowed-composition-locals"-->
+<!--                value="LocalComposeDarkModeHelper,LocalImageLoader,LocalSKImageLoader,LocalSlackColors,LocalTypography,LocalTraceContext,LocalSKPalettes,LocalSKColorSet,LocalSKThemeColorSet,LocalSKUserThemeEmitter,LocalSlackCompositionLocalsState" />-->
+<!--    </issue>-->
+
+    <issue id="ComposeNamingUppercase,ComposeNamingLowercase">
+        <option name="allowed-composable-function-names" value=".*Presenter"/>
+    </issue>
+
+    <!-- We've migrated to M3, so lint against M2 API use -->
+    <issue id="ComposeM2Api" severity="error" />
+
+    <!-- Serializable is ok in this repo -->
+    <issue id="SerializableUsage" severity="ignore" />
+
+    <!-- This is just for health score and not tracked in this repo -->
+    <issue id="DeprecatedCall" severity="ignore" />
+
+    <!-- These lint checks network requests and is never up-to-date! -->
+    <issue id="GradleDependency,NewerVersionAvailable" severity="ignore" />
+</lint>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,15 @@ org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 
+# Ironically, this property itself is also experimental, so we have to suppress it too.
+android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,\
+  android.experimental.lint.missingBaselineIsEmptyBaseline,\
+  android.experimental.lint.version
+
+# Force use of the latest android lint version
+android.experimental.lint.version=8.4.0-alpha11
+android.experimental.lint.missingBaselineIsEmptyBaseline=true
+
 # New Kotlin IC flags
 kotlin.compiler.suppressExperimentalICOptimizationsWarning=true
 kotlin.compiler.keepIncrementalCompilationCachesInMemory=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,11 +58,13 @@ autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.1.0"
 bugsnag = "com.bugsnag:bugsnag:3.7.1"
 clikt = "com.github.ajalt.clikt:clikt:4.2.2"
 commonsText = "org.apache.commons:commons-text:1.11.0"
+composeLints = "com.slack.lint.compose:compose-lint-checks:1.3.1"
 circuit = { module = "com.slack.circuit:circuit-foundation", version.ref = "circuit"}
 coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "coroutines" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
 detekt = { module = "io.gitlab.arturbosch.detekt:detekt-core", version.ref = "detekt" }
+gradleLints = "androidx.lint:lint-gradle:1.0.0-alpha01"
 gradlePlugins-anvil = { module = "com.squareup.anvil:gradle-plugin", version.ref = "anvil" }
 gradlePlugins-bugsnag = { module = "com.bugsnag:bugsnag-android-gradle-plugin", version.ref = "bugsnagGradle" }
 gradlePlugins-compose = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-jb" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ mavenPublish = "0.27.0"
 moshi = "1.15.1"
 moshix = "0.25.1"
 nullawayGradle = "1.3.0"
-okhttp = "5.0.0-alpha.10"
+okhttp = "5.0.0-alpha.12"
 okio = "3.8.0"
 retrofit = "2.9.0"
 sortDependencies = "0.6"
@@ -31,7 +31,7 @@ wire = "4.9.3"
 
 [plugins]
 bestPracticesPlugin = { id = "com.autonomousapps.plugin-best-practices-plugin", version = "0.10" }
-buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.0.0" }
+buildConfig = { id = "com.github.gmazzo.buildconfig", version = "5.3.5" }
 compose = { id = "org.jetbrains.compose", version = "1.5.12"}
 dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependencyAnalysisPlugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
@@ -71,7 +71,7 @@ gradlePlugins-compose = { module = "org.jetbrains.compose:compose-gradle-plugin"
 gradlePlugins-dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysisPlugin" }
 gradlePlugins-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradlePlugins-doctor = "com.osacky.doctor:doctor-plugin:0.9.1"
-gradlePlugins-enterprise = "com.gradle:gradle-enterprise-gradle-plugin:3.12.2"
+gradlePlugins-enterprise = "com.gradle:gradle-enterprise-gradle-plugin:3.16.2"
 gradlePlugins-errorProne = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version.ref = "errorproneGradle" }
 gradlePlugins-graphAssert = "com.jraska.module.graph.assertion:plugin:2.3.1"
 gradlePlugins-kgp = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -81,7 +81,7 @@ gradlePlugins-moshix = { module = "dev.zacsweers.moshix:moshi-gradle-plugin", ve
 gradlePlugins-napt = "com.sergei-lapin.napt:gradle:1.16"
 gradlePlugins-nullaway = { module = "net.ltgt.gradle:gradle-nullaway-plugin", version.ref = "nullawayGradle" }
 gradlePlugins-redacted = "dev.zacsweers.redacted:redacted-compiler-plugin-gradle:1.7.1"
-gradlePlugins-retry = "org.gradle:test-retry-gradle-plugin:1.4.0"
+gradlePlugins-retry = "org.gradle:test-retry-gradle-plugin:1.5.8"
 gradlePlugins-sortDependencies = { module = "com.squareup:sort-dependencies-gradle-plugin", version.ref = "sortDependencies" }
 gradlePlugins-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 gradlePlugins-sqldelight = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ nullawayGradle = "1.3.0"
 okhttp = "5.0.0-alpha.12"
 okio = "3.8.0"
 retrofit = "2.9.0"
+slack-lint = "0.7.0"
 sortDependencies = "0.6"
 spotless = "6.25.0"
 sqldelight = "2.0.1"
@@ -108,4 +109,6 @@ oshi = "com.github.oshi:oshi-core:6.4.13"
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-converters-wire = { module = "com.squareup.retrofit2:converter-wire", version.ref = "retrofit" }
 rxjava = "io.reactivex.rxjava3:rxjava:3.1.8"
+slackLints-checks = { module = "com.slack.lint:slack-lint-checks", version.ref = "slack-lint" }
+slackLints-annotations = { module = "com.slack.lint:slack-lint-annotations", version.ref = "slack-lint" }
 truth = "com.google.truth:truth:1.4.1"

--- a/sgp-common/build.gradle.kts
+++ b/sgp-common/build.gradle.kts
@@ -16,6 +16,7 @@
 plugins {
   kotlin("jvm")
   alias(libs.plugins.mavenPublish)
+  alias(libs.plugins.lint)
 }
 
 dependencies {

--- a/skate-plugin/build.gradle.kts
+++ b/skate-plugin/build.gradle.kts
@@ -25,11 +25,15 @@ plugins {
   alias(libs.plugins.pluginUploader)
   alias(libs.plugins.buildConfig)
   alias(libs.plugins.compose)
+  alias(libs.plugins.lint)
 }
 
 group = "com.slack.intellij"
 
-repositories { mavenCentral() }
+repositories {
+  mavenCentral()
+  google()
+}
 
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
@@ -93,6 +97,7 @@ buildConfig {
 }
 
 dependencies {
+  lintChecks(libs.composeLints)
   implementation(compose.animation)
   implementation(compose.desktop.currentOs)
   implementation(compose.foundation)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenWindow.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenWindow.kt
@@ -16,6 +16,7 @@
 package com.slack.sgp.intellij.projectgen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.awt.ComposePanel
 import com.intellij.openapi.actionSystem.ActionManager
@@ -32,6 +33,7 @@ import java.nio.file.Paths
 import javax.swing.Action
 import javax.swing.JComponent
 
+@Stable
 class ProjectGenWindow(private val currentProject: Project?, private val event: AnActionEvent) :
   DialogWrapper(currentProject) {
   init {
@@ -42,12 +44,12 @@ class ProjectGenWindow(private val currentProject: Project?, private val event: 
   override fun createCenterPanel(): JComponent {
     return ComposePanel().apply {
       setBounds(0, 0, 600, 800)
-      setContent { dialogContent() }
+      setContent { DialogContent() }
     }
   }
 
   @Composable
-  fun dialogContent() {
+  fun DialogContent() {
     val rootDir = remember {
       val path =
         currentProject?.basePath

--- a/skippy/build.gradle.kts
+++ b/skippy/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
   kotlin("jvm")
   alias(libs.plugins.moshix)
   alias(libs.plugins.mavenPublish)
+  alias(libs.plugins.lint)
 }
 
 dependencies {

--- a/slack-plugin/build.gradle.kts
+++ b/slack-plugin/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
   alias(libs.plugins.bestPracticesPlugin)
   alias(libs.plugins.moshix)
   alias(libs.plugins.buildConfig)
+  alias(libs.plugins.lint)
 }
 
 gradlePlugin {
@@ -66,6 +67,7 @@ dependencies.constraints {
 }
 
 dependencies {
+  lintChecks(libs.gradleLints)
   api(platform(libs.okhttp.bom))
   api(libs.okhttp)
   // Better I/O

--- a/slack-plugin/lint-baseline.xml
+++ b/slack-plugin/lint-baseline.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.4.0-alpha11" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.4.0-alpha11">
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.publishing.AndroidArtifacts"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/tasks/BaseDependencyCheckTask.kt"
+            line="18"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.publishing.AndroidArtifacts.ArtifactType"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/tasks/BaseDependencyCheckTask.kt"
+            line="19"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.dsl.BuildType"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/GradleExt.kt"
+            line="22"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/lint/LintTasks.kt"
+            line="23"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.lint.LintModelWriterTask"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/lint/LintTasks.kt"
+            line="24"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.lint.VariantInputs"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/lint/LintTasks.kt"
+            line="25"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.dsl.BaseAppModuleExtension"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt"
+            line="26"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.dsl.BuildType"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt"
+            line="27"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="ExceptionMessage"
+        message="Please specify a lazyMessage param for check"
+        errorLine1="    check(logs.isNotEmpty())"
+        errorLine2="    ~~~~~">
+        <location
+            file="src/main/kotlin/slack/gradle/util/ThermalsWatcher.kt"
+            line="216"
+            column="5"/>
+    </issue>
+
+</issues>

--- a/slack-plugin/src/main/kotlin/slack/gradle/tasks/ProgressResponseBody.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/tasks/ProgressResponseBody.kt
@@ -15,6 +15,7 @@
  */
 package slack.gradle.tasks
 
+import java.util.Locale
 import okhttp3.Interceptor
 import okhttp3.ResponseBody
 import okio.Buffer
@@ -27,7 +28,7 @@ import org.gradle.internal.logging.progress.ProgressLogger
 private const val ONE_MEGABYTE_IN_BYTES: Double = (1L * 1024L * 1024L).toDouble()
 
 private val Long.mb: String
-  get() = String.format("%.2f", this / ONE_MEGABYTE_IN_BYTES)
+  get() = "%.2f".format(Locale.US, this / ONE_MEGABYTE_IN_BYTES)
 
 internal class ProgressResponseBody
 internal constructor(

--- a/slack-plugin/src/main/kotlin/slack/gradle/util/ThermalsWatcher.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/util/ThermalsWatcher.kt
@@ -260,7 +260,7 @@ public data class ThermalsData(public val logs: List<ThermLog>) : Thermals() {
 
 @JsonClass(generateAdapter = true)
 public data class ThermLog(
-  public val timestamp: LocalDateTime,
+  @Suppress("MoshiUsageNonMoshiClassPlatform") public val timestamp: LocalDateTime,
   public val schedulerLimit: Int,
   public val availableCpus: Int,
   public val speedLimit: Int,
@@ -354,8 +354,8 @@ internal class AppleSiliconThermals(
         return null
       }
     // Raw value in this case is 0-4, which we use as the ordinal of our enums for convenience
-    return if (rawValue in 0..ThermalState.values().size) {
-      ThermalState.values()[rawValue]
+    return if (rawValue in 0..ThermalState.entries.size) {
+      ThermalState.entries[rawValue]
     } else {
       null
     }

--- a/slack-plugin/src/test/kotlin/slack/gradle/util/ThermlogParserTest.kt
+++ b/slack-plugin/src/test/kotlin/slack/gradle/util/ThermlogParserTest.kt
@@ -20,6 +20,7 @@ import java.time.LocalDateTime
 import org.junit.Assert.fail
 import org.junit.Test
 
+@Suppress("ExceptionMessage")
 class ThermlogParserTest {
 
   @Test

--- a/tracing/build.gradle.kts
+++ b/tracing/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
   kotlin("jvm")
   alias(libs.plugins.wire)
   alias(libs.plugins.mavenPublish)
+  alias(libs.plugins.lint)
 }
 
 wire {

--- a/tracing/lint-baseline.xml
+++ b/tracing/lint-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.4.0-alpha11" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.4.0-alpha11">
+
+    <issue
+        id="RetrofitUsage"
+        message="Retrofit endpoints should return something other than Unit/void."
+        errorLine1="  @POST suspend fun sendTrace(@Url url: String, @Body spans: ListOfSpans)"
+        errorLine2="                    ~~~~~~~~~">
+        <location
+            file="src/main/kotlin/com/slack/sgp/tracing/api/TracingService.kt"
+            line="25"
+            column="21"/>
+    </issue>
+
+</issues>


### PR DESCRIPTION
This starts running lint checks on the project, including our common compose and slack lints along with a set of gradle lints that google started publishing recently.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->