### PR TITLE
Fix mkdocs lists on the main page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -167,7 +167,6 @@ SGP expects there to be a `libs` version catalog.
 
 The following versions are required to be set the above catalog.
 Their docs can be found in `SlackVersions.kt`.
-- `jdk`
 
 For Android projects, some extra definitions need to be defined
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ The `slack.base` plugin offers common configuration for all projects implementin
 wide spectrum of Android, Kotlin, and Java configurations.
 
 This includes a whole host of things!
+
 - Common Android configuration (single variant libraries, disabling unused features, compose, etc).
 - Common Kotlin configuration (freeCompilerArgs, JVM target, etc).
 - Common Java configuration (toolchains, release versions, etc).
@@ -169,6 +170,7 @@ Their docs can be found in `SlackVersions.kt`.
 - `jdk`
 
 For Android projects, some extra definitions need to be defined
+
 - `libs.versions.toml` libraries
     - `google-coreLibraryDesugaring` - the core library desugaring libraries to use with L8.
 - `gradle.properties` properties
@@ -177,6 +179,7 @@ For Android projects, some extra definitions need to be defined
     - `slack.minSdkVersion`
 
 The following plugins are applied by default but can be disabled if you don't need them.
+
 - Gradle's test retry – `slack.auto-apply.test-retry`
     - By default, this uses the [Gradle test-retry plugin](https://github.com/gradle/test-retry-gradle-plugin), but can be configured to use the Gradle Enterprise plugin's implementation instead by setting the `slack.test.retry.pluginType` property to `GE`.
 - Spotless – `slack.auto-apply.spotless`


### PR DESCRIPTION
From main page: note the dashes, some of those are bullet points, some are descriptions of bullet points.

mkdocs's markdown doesn't like non-separate bullet lists.
Most of the project has new lines before lists, except these on the main page.

Example:
<img width="787" alt="image" src="https://github.com/slackhq/slack-gradle-plugin/assets/2906988/97b74d73-4a77-4568-86bb-58e5e226fd37">

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->