### PR TITLE
Add circuit to project gen option

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenPresenter.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/ProjectGenPresenter.kt
@@ -104,6 +104,8 @@ internal class ProjectGenPresenter(
       indentLevel = 1,
     )
 
+  private val circuit = CheckboxElement(false, name = "Circuit", hint = "Enables Circuit")
+
   private val compose = CheckboxElement(false, name = "Compose", hint = "Enables Jetpack Compose.")
 
   private val uiElements =
@@ -123,6 +125,7 @@ internal class ProjectGenPresenter(
       dagger,
       daggerRuntimeOnly,
       compose,
+      circuit,
     )
 
   @Composable
@@ -176,6 +179,7 @@ internal class ProjectGenPresenter(
     daggerRuntimeOnly.reset()
     robolectric.reset()
     compose.reset()
+    circuit.reset()
   }
 
   private fun generate() {
@@ -201,6 +205,7 @@ internal class ProjectGenPresenter(
       robolectric = robolectric.isChecked,
       compose = compose.isChecked,
       androidTest = androidTest.isChecked,
+      circuit = circuit.isChecked,
     )
   }
 
@@ -217,6 +222,7 @@ internal class ProjectGenPresenter(
     robolectric: Boolean,
     compose: Boolean,
     androidTest: Boolean,
+    circuit: Boolean,
   ) {
     val features = mutableListOf<Feature>()
     val androidLibraryEnabled =
@@ -243,6 +249,10 @@ internal class ProjectGenPresenter(
 
     if (robolectric) {
       features += RobolectricFeature
+    }
+
+    if (circuit) {
+      features += CircuitFeature
     }
 
     val buildFile = BuildFile(emptyList())

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/models.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/projectgen/models.kt
@@ -289,6 +289,12 @@ internal object ComposeFeature : Feature, SlackFeatureVisitor {
   }
 }
 
+internal object CircuitFeature : Feature, SlackFeatureVisitor {
+  override fun writeToSlackFeatures(builder: FileSpec.Builder) {
+    builder.addStatement("circuit()")
+  }
+}
+
 internal class ReadMeFile {
   fun writeTo(projectDir: File) {
     val projectName = projectDir.name


### PR DESCRIPTION
Add `circuit` option to project gen. Once selected, project gen will add circuit set up to new module BUILD file:
```
  features {
    circuit()
  }
```

Screenshot:
<img width="583" alt="image" src="https://github.com/slackhq/slack-gradle-plugin/assets/12748234/2068bdac-ca0e-4620-a255-ec9ce1cfa63a">



<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->