### PR TITLE
Set change notes when publishing Skate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -369,7 +369,7 @@ subprojects {
           pluginId.set(pluginDetails.pluginId)
           version.set(pluginDetails.version)
           pluginDescription.set(pluginDetails.description)
-          //  changeNotes.set(file("change-notes.txt").readText())
+          changeNotes.set(file("change-notes.txt").readText())
           sinceBuild.set(pluginDetails.sinceBuild)
           authentication.set(
             // Sip the username and token together to create an appropriate encoded auth header

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -369,7 +369,7 @@ subprojects {
           pluginId.set(pluginDetails.pluginId)
           version.set(pluginDetails.version)
           pluginDescription.set(pluginDetails.description)
-          changeNotes.set(file("change-notes.txt").readText())
+          changeNotes.set(file("change-notes.md").readText())
           sinceBuild.set(pluginDetails.sinceBuild)
           authentication.set(
             // Sip the username and token together to create an appropriate encoded auth header

--- a/skate-plugin/README.md
+++ b/skate-plugin/README.md
@@ -29,7 +29,7 @@ We're sending analytics for almost all Skate features to track user usage. To se
 2. Use `SkateSpanBuilder` to create the span for event you want to track
 3. Make call to `SkateTraceReporter` to send up the traces
 
-## Publishing
-Run `publish-skate` Github Action to publish to the configured repository.
-
+## Releasing
+1. Add `change-notes.md` file under `skate-plugin/` and merge it to `main`
+2. Run `publish-skate` Github Action.
 Behind the scene the action's running`./gradlew :skate-plugin:uploadPluginToArtifactory`


### PR DESCRIPTION
Enable the code to set up change notes. Upon this change, planning to update the Github Action publish job to takes on a Release notes argument and write it to a `change-notes.md` file before running the publish task

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->