### PR TITLE
Fix codeowners file fetching issue

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerFileFetcher.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerFileFetcher.kt
@@ -31,16 +31,24 @@ interface CodeOwnerFileFetcher {
   fun getCodeOwnershipFile(): File?
 }
 
-class CodeOwnerFileFetcherImpl(private val project: Project) : CodeOwnerFileFetcher {
+class CodeOwnerFileFetcherImpl(
+  private val project: Project,
+  private val basePath: String = project.basePath ?: "",
+) : CodeOwnerFileFetcher {
 
   private val logger = logger<CodeOwnerFileFetcherImpl>()
 
   override fun getCodeOwnershipFile(): File? {
+    // get file path from settings if it's present
     val settings = project.service<SkatePluginSettings>()
-    val fs = LocalFileSystem.getInstance()
-    val path = Path.of(project.basePath ?: "", settings.codeOwnerFilePath ?: "")
-    logger.debug("getCodeOwnershipFile path location: $path")
-    return fs.findFileByNioFile(path)?.toNioPath()?.toFile()
+    val filePathSetting = settings.codeOwnerFilePath
+    // build full path and find file if file path setting is present
+    return filePathSetting?.let {
+      val fs = LocalFileSystem.getInstance()
+      val path = Path.of(basePath, filePathSetting)
+      logger.debug("getCodeOwnershipFile path location: $path")
+      fs.findFileByNioFile(path)?.toNioPath()?.toFile()
+    }
   }
 }
 

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerFileFetcherImplTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerFileFetcherImplTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.codeowners
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.slack.sgp.intellij.util.settings
+
+private const val TEST_OWNERSHIP_YAML_FILE = "src/test/resources/test-code-ownership.yaml"
+
+class CodeOwnerFileFetcherImplTest : BasePlatformTestCase() {
+
+  fun testGetCodeOwnershipFileSettingPresent() {
+    val underTest = CodeOwnerFileFetcherImpl(project, this.basePath)
+    project.settings().codeOwnerFilePath = TEST_OWNERSHIP_YAML_FILE
+    project.settings().isCodeOwnerEnabled = true
+    assertThat(underTest.getCodeOwnershipFile()).isNotNull()
+  }
+
+  fun testGetCodeOwnershipFileSettingNotPresent() {
+    val underTest = CodeOwnerFileFetcherImpl(project, this.basePath)
+    project.settings().codeOwnerFilePath = null
+    project.settings().isCodeOwnerEnabled = true
+    assertThat(underTest.getCodeOwnershipFile()).isNull()
+  }
+}


### PR DESCRIPTION
This PR fixes an issue when the code owner file setting is null or missing. Also added a test for this case.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->