### PR TITLE
Add property to override lint version

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -292,6 +292,13 @@ internal constructor(
     get() = booleanProperty("sgp.lint.ignoreTestSources", false)
 
   /**
+   * Flag to control which agp version should be used for lint. Optional. Value should be a version
+   * key in `libs.versions.toml`,
+   */
+  public val lintVersionOverride: String?
+    get() = optionalStringProperty("sgp.lint.agpVersion")
+
+  /**
    * Flag to indicate whether this project is a test library (such as test utils, test fixtures,
    * etc).
    */

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackVersions.kt
@@ -76,6 +76,8 @@ internal class SlackVersions(val catalog: VersionCatalog) {
   val robolectric: String?
     get() = getOptionalValue("robolectric").orElse(null)
 
+  fun lookupVersion(key: String) = getOptionalValue(key)
+
   val bundles = Bundles()
 
   inner class Bundles {

--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -145,6 +145,11 @@ internal object LintTasks {
     onProjectSkipped: (String, String) -> Unit,
   ) =
     androidExtension.finalizeDsl { extension ->
+      slackProperties.lintVersionOverride?.let {
+        val lintVersion = slackProperties.versions.lookupVersion(it)
+        extension.experimentalProperties["android.experimental.lint.version"] = lintVersion
+      }
+
       log("Applying ciLint to Android project")
 
       log(


### PR DESCRIPTION
This allows us to specify it programmatically and source our version catalogs rather than only statically in `gradle.properties`

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->