### PR TITLE
Fix Skate release notes format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -369,7 +369,7 @@ subprojects {
           pluginId.set(pluginDetails.pluginId)
           version.set(pluginDetails.version)
           pluginDescription.set(pluginDetails.description)
-          changeNotes.set(file("change-notes.md").readText())
+          changeNotes.set(file("change-notes.html").readText())
           sinceBuild.set(pluginDetails.sinceBuild)
           authentication.set(
             // Sip the username and token together to create an appropriate encoded auth header

--- a/skate-plugin/README.md
+++ b/skate-plugin/README.md
@@ -30,6 +30,6 @@ We're sending analytics for almost all Skate features to track user usage. To se
 3. Make call to `SkateTraceReporter` to send up the traces
 
 ## Releasing
-1. Add `change-notes.md` file under `skate-plugin/` and merge it to `main`
+1. Update `change-notes.html` file under `skate-plugin/` and merge it to `main`
 2. Run `publish-skate` Github Action.
 Behind the scene the action's running`./gradlew :skate-plugin:uploadPluginToArtifactory`

--- a/skate-plugin/change-notes.html
+++ b/skate-plugin/change-notes.html
@@ -1,13 +1,15 @@
 <![CDATA[
 <h2>0.7.3</h2>
 <ul>
-<li>Project Generator Improvements:<ul>
-<li>Fully migrated to Skate, directly accessible via <code>File-New-Slack Subproject</code>.</li>
-<li>New <code>circuit</code> option added to the UI.</li>
-<li>Added option to <code>Sync</code> with Studio upon successful project generation.</li>
-</ul>
-</li>
-<li>Code owner file parser now supports the new YAML format.</li>
-<li>Begin tracking IDE indexing time via tracing.</li>
+    <li>
+        Project Generator Improvements:
+        <ul>
+            <li>Fully migrated to Skate, directly accessible via <code>File-New-Slack Subproject</code>.</li>
+            <li>New <code>circuit</code> option added to the UI.</li>
+            <li>Added option to <code>Sync</code> with Studio upon successful project generation.</li>
+        </ul>
+    </li>
+    <li>Code owner file parser now supports the new YAML format.</li>
+    <li>Begin tracking IDE indexing time via tracing.</li>
 </ul>
 ]]>

--- a/skate-plugin/change-notes.html
+++ b/skate-plugin/change-notes.html
@@ -1,0 +1,13 @@
+<![CDATA[
+<h2>0.7.3</h2>
+<ul>
+<li>Project Generator Improvements:<ul>
+<li>Fully migrated to Skate, directly accessible via <code>File-New-Slack Subproject</code>.</li>
+<li>New <code>circuit</code> option added to the UI.</li>
+<li>Added option to <code>Sync</code> with Studio upon successful project generation.</li>
+</ul>
+</li>
+<li>Code owner file parser now supports the new YAML format.</li>
+<li>Begin tracking IDE indexing time via tracing.</li>
+</ul>
+]]>

--- a/skate-plugin/change-notes.md
+++ b/skate-plugin/change-notes.md
@@ -1,9 +1,0 @@
-0.7.2
------
-
-* Project Generator Improvements:
-  * Fully migrated to Skate, directly accessible via `File -> New -> Slack Subproject`.
-  * New `circuit` option added to the UI.
-  * Added option to `Sync` with Studio upon successful project generation.
-* Code owner file parser now supports the new YAML format.
-* Begin tracking IDE indexing time via tracing.


### PR DESCRIPTION
Fixed issue with release notes by switching it to HTML from Markdown


Before:
<img width="541" alt="image" src="https://github.com/slackhq/slack-gradle-plugin/assets/12748234/29375f1f-536d-49c7-96bb-e93a9c9b89de">


<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->