### PR TITLE
Fix configuration cache when setting module name

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/StandardProjectConfigurations.kt
@@ -943,8 +943,7 @@ internal class StandardProjectConfigurations(
 
             // Set the module name to a dashified version of the project path to ensure uniqueness
             // in created .kotlin_module files
-            val pathProvider = project.provider { project.path.replace(":", "-") }
-            moduleName.set(pathProvider)
+            moduleName.set(project.path.replace(":", "-"))
           }
         }
       }


### PR DESCRIPTION
We can't have a provider that captures the enclosing project, so let's just set it directly.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->