### PR TITLE
Disable YAML strict-mode marshalling for codeowner widget

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
@@ -16,6 +16,7 @@
 package com.slack.sgp.intellij.codeowners
 
 import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlConfiguration
 import com.intellij.openapi.diagnostic.logger
 import com.slack.sgp.intellij.codeowners.model.CodeOwnersFile
 import java.io.File
@@ -78,6 +79,7 @@ class CodeOwnerRepository(codeOwnerFileFetcher: CodeOwnerFileFetcher) {
 
   private fun marshalCodeOwnershipYaml(file: File): CodeOwnersFile {
     val fileContents = file.readText(charset = UTF_8)
-    return Yaml.default.decodeFromString(CodeOwnersFile.serializer(), fileContents)
+    return Yaml(configuration = YamlConfiguration(strictMode = false))
+      .decodeFromString(CodeOwnersFile.serializer(), fileContents)
   }
 }

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepositoryTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepositoryTest.kt
@@ -52,7 +52,7 @@ class CodeOwnerRepositoryTest : BasePlatformTestCase() {
     assertThat(result[0].codeOwnerLineNumber).isEqualTo(15)
     assertThat(result[0].team).isEqualTo(TEAM_1)
     assertThat(result[1].packagePattern).isEqualTo(FOLDER_3_PATTERN)
-    assertThat(result[1].codeOwnerLineNumber).isEqualTo(18)
+    assertThat(result[1].codeOwnerLineNumber).isEqualTo(19)
     assertThat(result[1].team).isEqualTo(TEAM_2)
   }
 

--- a/skate-plugin/src/test/resources/test-code-ownership.yaml
+++ b/skate-plugin/src/test/resources/test-code-ownership.yaml
@@ -14,6 +14,8 @@ ownership:
       - app/folder1/.*
       - app/folder2/.*
       - app/folder3/subfolder/.*
+    bogusProp: Foo
   - name: Team 2
     paths:
       - app/folder3/.*
+    bogusProp: Bar


### PR DESCRIPTION
Adding new properties to our code owners file format shouldn't break marshalling - this PR disables YAML strict mode.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->