### PR TITLE
Switch to Compose-based markdown rendering solution

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ kotlin = "1.9.23"
 kotlinPoet = "1.16.0"
 ksp = "1.9.23-1.0.20"
 ktfmt = "0.47"
+markdown = "0.14.0"
 mavenPublish = "0.28.0"
 moshi = "1.15.1"
 moshix = "0.25.1"
@@ -68,6 +69,7 @@ circuit-foundation = { module = "com.slack.circuit:circuit-foundation", version.
 commonsText = "org.apache.commons:commons-text:1.12.0"
 composeLints = "com.slack.lint.compose:compose-lint-checks:1.3.1"
 compose-compilerJb = { module = "org.jetbrains.compose.compiler:compiler", version.ref = "compose-jb-compiler" }
+compose-markdown = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdown" }
 coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "coroutines" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,7 @@ kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet"}
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
 jewel-bridge232 = { module = "org.jetbrains.jewel:jewel-ide-laf-bridge-232", version.ref = "jewel" }
+jewel-standalone = { module = "org.jetbrains.jewel:jewel-int-ui-standalone", version = "0.15.2" }
 jgrapht = "org.jgrapht:jgrapht-core:1.5.2"
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -188,6 +188,7 @@ include(
   ":sgp-common",
   ":skate-plugin",
   ":skate-plugin:artifactory-authenticator",
+  ":skate-plugin:compose-playground",
   ":skate-plugin:project-gen",
   ":slack-plugin",
   ":tracing",

--- a/skate-plugin/compose-playground/build.gradle.kts
+++ b/skate-plugin/compose-playground/build.gradle.kts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.jetbrains.compose.ComposeExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+
+plugins {
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.compose)
+  alias(libs.plugins.lint)
+}
+
+kotlin {
+  jvm()
+
+  sourceSets {
+    jvmMain {
+      dependencies {
+        implementation(compose.animation)
+        implementation(compose.desktop.common)
+        implementation(compose.desktop.linux_arm64)
+        implementation(compose.desktop.linux_x64)
+        implementation(compose.desktop.macos_arm64)
+        implementation(compose.desktop.macos_x64)
+        implementation(compose.desktop.windows_x64)
+        implementation(compose.foundation)
+        implementation(compose.material)
+        implementation(compose.material3)
+        implementation(compose.ui)
+        implementation(libs.circuit.foundation)
+        implementation(libs.compose.markdown)
+        implementation(libs.jewel.standalone)
+        implementation(libs.kotlin.poet)
+        implementation(libs.markdown)
+        implementation(projects.skatePlugin.projectGen)
+      }
+    }
+  }
+}
+
+configure<ComposeExtension> {
+  val kotlinVersion = libs.versions.kotlin.get()
+  // Flag to disable Compose's kotlin version check because they're often behind
+  // Or ahead
+  // Or if they're the same, do nothing
+  // It's basically just very noisy.
+  kotlinCompilerPlugin.set(libs.compose.compilerJb.map { it.toString() })
+  val suppressComposeKotlinVersion = kotlinVersion != libs.versions.compose.jb.kotlinVersion.get()
+  if (suppressComposeKotlinVersion) {
+    kotlinCompilerPluginArgs.add("suppressKotlinVersionCompatibilityCheck=$kotlinVersion")
+  }
+}
+
+// Tell lint to only resolve the jvm attrs for our compose deps
+configurations
+  .named { it.endsWith("ForLint") }
+  .configureEach { attributes { attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm) } }
+
+dependencies { lintChecks(libs.composeLints) }

--- a/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
+++ b/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package slack.tooling.compose.playground
 
 import androidx.compose.foundation.background
@@ -31,9 +46,9 @@ fun main() = singleWindowApplication {
 private const val MARKDOWN =
   """
   # Markdown Playground
-  
+
   ---
-  
+
   # This is an H1
 
   ## This is an H2
@@ -45,40 +60,40 @@ private const val MARKDOWN =
   ##### This is an H5
 
   ###### This is an H6
-  
+
   This is a paragraph with some *italic* and **bold** text.
-  
+
   This is a paragraph with some `inline code`.
-  
+
   This is a paragraph with a [link](https://www.jetbrains.com/).
-  
+
   This is a code block:
   ```kotlin
   fun main() {
     println("Hello, world!")
   }
   ```
-  
+
   > This is a block quote.
-  
+
   This is a divider
-  
+
   ---
-  
+
   The above was supposed to be a divider.
-  
+
   ~~This is strikethrough~~
-  
+
   This is an ordered list:
   1. Item 1
   2. Item 2
   3. Item 3
-  
+
   This is an unordered list with dashes:
   - Item 1
   - Item 2
   - Item 3
-  
+
   This is an unordered list with asterisks:
   * Item 1
   * Item 2

--- a/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
+++ b/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
@@ -83,7 +83,7 @@ private const val MARKDOWN =
   The above was supposed to be a divider.
 
   ~~This is strikethrough with two tildes~~
-  
+
   ~This is strikethrough~
 
   This is an ordered list:

--- a/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
+++ b/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
@@ -1,0 +1,86 @@
+package slack.tooling.compose.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.singleWindowApplication
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.Text
+import slack.tooling.markdown.ui.MarkdownContent
+
+fun main() = singleWindowApplication {
+  var isDark by remember { mutableStateOf(false) }
+  IntUiTheme(isDark) {
+    Column(Modifier.background(JewelTheme.globalColors.paneBackground)) {
+      DefaultButton(modifier = Modifier.padding(16.dp), onClick = { isDark = !isDark }) {
+        Text("Toggle dark mode")
+      }
+      MarkdownContent { MARKDOWN }
+    }
+  }
+}
+
+private const val MARKDOWN =
+  """
+  # Markdown Playground
+  
+  ---
+  
+  # This is an H1
+
+  ## This is an H2
+
+  ### This is an H3
+
+  #### This is an H4
+
+  ##### This is an H5
+
+  ###### This is an H6
+  
+  This is a paragraph with some *italic* and **bold** text.
+  
+  This is a paragraph with some `inline code`.
+  
+  This is a paragraph with a [link](https://www.jetbrains.com/).
+  
+  This is a code block:
+  ```kotlin
+  fun main() {
+    println("Hello, world!")
+  }
+  ```
+  
+  > This is a block quote.
+  
+  This is a divider
+  
+  ---
+  
+  The above was supposed to be a divider.
+  
+  ~~This is strikethrough~~
+  
+  This is an ordered list:
+  1. Item 1
+  2. Item 2
+  3. Item 3
+  
+  This is an unordered list with dashes:
+  - Item 1
+  - Item 2
+  - Item 3
+  
+  This is an unordered list with asterisks:
+  * Item 1
+  * Item 2
+  * Item 3
+"""

--- a/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
+++ b/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
@@ -82,7 +82,9 @@ private const val MARKDOWN =
 
   The above was supposed to be a divider.
 
-  ~~This is strikethrough~~
+  ~~This is strikethrough with two tildes~~
+  
+  ~This is strikethrough~
 
   This is an ordered list:
   1. Item 1

--- a/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/ProjectGenPlayground.kt
+++ b/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/ProjectGenPlayground.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package slack.tooling.compose.playground
 
 import androidx.compose.foundation.background

--- a/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/ProjectGenPlayground.kt
+++ b/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/ProjectGenPlayground.kt
@@ -1,0 +1,42 @@
+package slack.tooling.compose.playground
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.singleWindowApplication
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
+import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.Text
+import slack.tooling.projectgen.ProjectGenUi
+import slack.tooling.projectgen.ProjectGenUi.ProjectGenApp
+
+fun main() = singleWindowApplication {
+  var isDark by remember { mutableStateOf(false) }
+  IntUiTheme(isDark) {
+    Column(Modifier.background(JewelTheme.globalColors.paneBackground)) {
+      DefaultButton(modifier = Modifier.padding(16.dp), onClick = { isDark = !isDark }) {
+        Text("Toggle dark mode")
+      }
+      ProjectGenApp(
+        rootDir = "rootDir",
+        events =
+          object : ProjectGenUi.Events {
+            override fun doOKAction() {
+              println("doOKAction")
+            }
+
+            override fun dismissDialogAndSync() {
+              println("dismissDialogAndSync")
+            }
+          },
+      )
+    }
+  }
+}

--- a/skate-plugin/project-gen/build.gradle.kts
+++ b/skate-plugin/project-gen/build.gradle.kts
@@ -41,8 +41,10 @@ kotlin {
         implementation(compose.material3)
         implementation(compose.ui)
         implementation(libs.circuit.foundation)
+        implementation(libs.compose.markdown)
         implementation(libs.jewel.bridge232)
         implementation(libs.kotlin.poet)
+        implementation(libs.markdown)
       }
     }
   }

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposePanel
@@ -39,13 +40,14 @@ import javax.swing.JComponent
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Typography
 import org.jetbrains.jewel.ui.component.Typography.labelTextSize
-import org.jetbrains.jewel.ui.component.plus
+import org.jetbrains.jewel.ui.component.minus
 import slack.tooling.projectgen.SlackDesktopTheme
 
 object MarkdownPanel {
   fun createPanel(computeMarkdown: suspend () -> String): JComponent {
     return ComposePanel().apply {
       // Necessary to avoid an NPE in JPanel
+      // This is just a minimum
       preferredSize = Dimension(400, 600)
       setContent {
         SlackDesktopTheme {
@@ -92,9 +94,9 @@ private fun jewelMarkdownColor(
   text: Color = JewelTheme.defaultTextStyle.color,
   codeText: Color = JewelTheme.defaultTextStyle.color,
   linkText: Color = text,
-  codeBackground: Color = JewelTheme.globalColors.paneBackground.copy(alpha = 0.1f),
+  codeBackground: Color = rememberCodeBackground(JewelTheme.globalColors.paneBackground),
   inlineCodeBackground: Color = codeBackground,
-  dividerColor: Color = JewelTheme.globalColors.outlines.focused,
+  dividerColor: Color = JewelTheme.globalColors.borders.normal,
 ): MarkdownColors =
   DefaultMarkdownColors(
     text = text,
@@ -106,16 +108,55 @@ private fun jewelMarkdownColor(
   )
 
 @Composable
+private fun rememberCodeBackground(color: Color, percentage: Float = 30f): Color {
+  val newColor =
+    remember(color, percentage) {
+      val factor = 1 - percentage / 100
+      Color(
+        red = (color.red * factor).coerceIn(0f, 1f),
+        green = (color.green * factor).coerceIn(0f, 1f),
+        blue = (color.blue * factor).coerceIn(0f, 1f),
+        alpha = color.alpha,
+      )
+    }
+  return newColor
+}
+
+@Composable
 private fun jewelMarkdownTypography(
-  h1: TextStyle = Typography.h0TextStyle(),
-  h2: TextStyle = Typography.h1TextStyle(),
-  h3: TextStyle = Typography.h2TextStyle(),
-  h4: TextStyle = Typography.h3TextStyle(),
-  h5: TextStyle = Typography.h4TextStyle(),
+  text: TextStyle = JewelTheme.defaultTextStyle,
+  code: TextStyle =
+    JewelTheme.defaultTextStyle.copy(
+      fontSize = labelTextSize() - 2.sp,
+      fontFamily = FontFamily.Monospace,
+    ),
+  h1: TextStyle =
+    JewelTheme.defaultTextStyle.copy(fontSize = labelTextSize() * 2, fontWeight = FontWeight.Bold),
+  h2: TextStyle =
+    JewelTheme.defaultTextStyle.copy(
+      fontSize = labelTextSize() * 1.5,
+      fontWeight = FontWeight.Bold,
+    ),
+  h3: TextStyle =
+    JewelTheme.defaultTextStyle.copy(
+      fontSize = labelTextSize() * 1.25,
+      fontWeight = FontWeight.Medium,
+    ),
+  h4: TextStyle =
+    JewelTheme.defaultTextStyle.copy(
+      fontSize = labelTextSize() * 1.1,
+      fontWeight = FontWeight.Normal,
+    ),
+  h5: TextStyle =
+    JewelTheme.defaultTextStyle.copy(
+      fontSize = labelTextSize() * 1.05,
+      fontWeight = FontWeight.Normal,
+    ),
   h6: TextStyle =
-    JewelTheme.defaultTextStyle.copy(fontSize = labelTextSize(), fontWeight = FontWeight.Bold),
-  text: TextStyle = JewelTheme.defaultTextStyle.copy(fontSize = labelTextSize() + 2.sp),
-  code: TextStyle = JewelTheme.defaultTextStyle.copy(fontFamily = FontFamily.Monospace),
+    JewelTheme.defaultTextStyle.copy(
+      fontSize = labelTextSize() * 0.95,
+      fontWeight = FontWeight.Normal,
+    ),
   quote: TextStyle = JewelTheme.defaultTextStyle.plus(SpanStyle(fontStyle = FontStyle.Italic)),
   paragraph: TextStyle = text,
   ordered: TextStyle = text,

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package slack.tooling.markdown.ui
 
 import androidx.compose.foundation.VerticalScrollbar

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
@@ -67,13 +67,13 @@ object MarkdownPanel {
       // Necessary to avoid an NPE in JPanel
       // This is just a minimum
       preferredSize = Dimension(400, 600)
-      setContent { SlackDesktopTheme { MarkdownContent(computeMarkdown) } }
+      setContent { SlackDesktopTheme { MarkdownContent(computeMarkdown = computeMarkdown) } }
     }
   }
 }
 
 @Composable
-fun MarkdownContent(computeMarkdown: suspend () -> String) {
+fun MarkdownContent(modifier: Modifier = Modifier, computeMarkdown: suspend () -> String) {
   CompositionLocalProvider(
     LocalMarkdownColors provides jewelMarkdownColor(),
     LocalMarkdownTypography provides jewelMarkdownTypography(),
@@ -81,7 +81,7 @@ fun MarkdownContent(computeMarkdown: suspend () -> String) {
     val markdown by produceState<String?>(null) { value = computeMarkdown() }
     if (markdown == null) {
       Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
       ) {
@@ -90,7 +90,7 @@ fun MarkdownContent(computeMarkdown: suspend () -> String) {
       }
     } else {
       val stateVertical = rememberScrollState(0)
-      Box(Modifier.fillMaxSize()) {
+      Box(modifier.fillMaxSize()) {
         Box(Modifier.fillMaxSize().verticalScroll(stateVertical).padding(16.dp)) {
           Markdown(
             markdown!!,

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
@@ -1,0 +1,139 @@
+package slack.tooling.markdown.ui
+
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mikepenz.markdown.compose.LocalMarkdownColors
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
+import com.mikepenz.markdown.compose.Markdown
+import com.mikepenz.markdown.model.DefaultMarkdownColors
+import com.mikepenz.markdown.model.DefaultMarkdownTypography
+import com.mikepenz.markdown.model.MarkdownColors
+import com.mikepenz.markdown.model.MarkdownTypography
+import java.awt.Dimension
+import javax.swing.JComponent
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Typography
+import org.jetbrains.jewel.ui.component.Typography.labelTextSize
+import org.jetbrains.jewel.ui.component.plus
+import slack.tooling.projectgen.SlackDesktopTheme
+
+object MarkdownPanel {
+  fun createPanel(computeMarkdown: suspend () -> String): JComponent {
+    return ComposePanel().apply {
+      // Necessary to avoid an NPE in JPanel
+      preferredSize = Dimension(400, 600)
+      setContent {
+        SlackDesktopTheme {
+          CompositionLocalProvider(
+            LocalMarkdownColors provides jewelMarkdownColor(),
+            LocalMarkdownTypography provides jewelMarkdownTypography(),
+          ) {
+            val markdown by produceState<String?>(null) { value = computeMarkdown() }
+            if (markdown == null) {
+              Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+              ) {
+                CircularProgressIndicator()
+                Text("Loading…", style = Typography.h0TextStyle())
+              }
+            } else {
+              val stateVertical = rememberScrollState(0)
+              Box(Modifier.fillMaxSize()) {
+                Box(Modifier.fillMaxSize().verticalScroll(stateVertical).padding(16.dp)) {
+                  Markdown(
+                    markdown!!,
+                    colors = LocalMarkdownColors.current,
+                    typography = LocalMarkdownTypography.current,
+                  )
+                }
+
+                VerticalScrollbar(
+                  modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+                  adapter = rememberScrollbarAdapter(stateVertical),
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun jewelMarkdownColor(
+  text: Color = JewelTheme.defaultTextStyle.color,
+  codeText: Color = JewelTheme.defaultTextStyle.color,
+  linkText: Color = text,
+  codeBackground: Color = JewelTheme.globalColors.paneBackground.copy(alpha = 0.1f),
+  inlineCodeBackground: Color = codeBackground,
+  dividerColor: Color = JewelTheme.globalColors.outlines.focused,
+): MarkdownColors =
+  DefaultMarkdownColors(
+    text = text,
+    codeText = codeText,
+    linkText = linkText,
+    codeBackground = codeBackground,
+    inlineCodeBackground = inlineCodeBackground,
+    dividerColor = dividerColor,
+  )
+
+@Composable
+private fun jewelMarkdownTypography(
+  h1: TextStyle = Typography.h0TextStyle(),
+  h2: TextStyle = Typography.h1TextStyle(),
+  h3: TextStyle = Typography.h2TextStyle(),
+  h4: TextStyle = Typography.h3TextStyle(),
+  h5: TextStyle = Typography.h4TextStyle(),
+  h6: TextStyle =
+    JewelTheme.defaultTextStyle.copy(fontSize = labelTextSize(), fontWeight = FontWeight.Bold),
+  text: TextStyle = JewelTheme.defaultTextStyle.copy(fontSize = labelTextSize() + 2.sp),
+  code: TextStyle = JewelTheme.defaultTextStyle.copy(fontFamily = FontFamily.Monospace),
+  quote: TextStyle = JewelTheme.defaultTextStyle.plus(SpanStyle(fontStyle = FontStyle.Italic)),
+  paragraph: TextStyle = text,
+  ordered: TextStyle = text,
+  bullet: TextStyle = text,
+  list: TextStyle = text,
+): MarkdownTypography =
+  DefaultMarkdownTypography(
+    h1 = h1,
+    h2 = h2,
+    h3 = h3,
+    h4 = h4,
+    h5 = h5,
+    h6 = h6,
+    text = text,
+    quote = quote,
+    code = code,
+    paragraph = paragraph,
+    ordered = ordered,
+    bullet = bullet,
+    list = list,
+  )

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
@@ -112,8 +112,7 @@ fun MarkdownContent(modifier: Modifier = Modifier, computeMarkdown: suspend () -
 private fun jewelMarkdownColor(
   text: Color = JewelTheme.defaultTextStyle.color.takeOrElse { JewelTheme.contentColor },
   linkText: Color = JewelTheme.linkColor,
-  // TODO https://github.com/mikepenz/multiplatform-markdown-renderer/issues/131
-  dividerColor: Color = JewelTheme.globalColors.outlines.focused,
+  dividerColor: Color = JewelTheme.globalColors.borders.normal,
 ): MarkdownColors {
   // TODO https://github.com/mikepenz/multiplatform-markdown-renderer/issues/130
   val (codeText, codeBackground, _, inlineCodeBackground) =

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/ProjectGenUi.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/ProjectGenUi.kt
@@ -71,18 +71,12 @@ object ProjectGenUi {
   fun createPanel(rootDir: String, width: Int, height: Int, events: Events): JComponent {
     return ComposePanel().apply {
       setBounds(0, 0, width, height)
-      setContent {
-        ProjectGenApp(rootDir, events) { content -> SlackDesktopTheme(content = content) }
-      }
+      setContent { SlackDesktopTheme { ProjectGenApp(rootDir, events) } }
     }
   }
 
   @Composable
-  internal fun ProjectGenApp(
-    rootDir: String,
-    events: Events,
-    render: @Composable (content: @Composable () -> Unit) -> Unit,
-  ) {
+  fun ProjectGenApp(rootDir: String, events: Events) {
     val circuit = remember {
       Circuit.Builder()
         .addPresenterFactory { _, _, _ ->
@@ -97,7 +91,7 @@ object ProjectGenUi {
         }
         .build()
     }
-    render { CircuitContent(ProjectGenScreen, circuit = circuit) }
+    CircuitContent(ProjectGenScreen, circuit = circuit)
   }
 }
 

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/SkateService.kt
@@ -18,7 +18,6 @@ package com.slack.sgp.intellij
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowManager
@@ -63,12 +62,8 @@ class SkateProjectServiceImpl(private val project: Project) : SkateProjectServic
           stripeTitle = Supplier { "What's New in Slack!" }
           anchor = ToolWindowAnchor.RIGHT
         }
-      // The Disposable is necessary to prevent a substantial memory leak while working with
-      // MarkdownJCEFHtmlPanel
-      val parentDisposable = Disposer.newDisposable()
 
-      WhatsNewPanelFactory()
-        .createToolWindowContent(toolWindow, project, parsedChangelog, parentDisposable)
+      WhatsNewPanelFactory().createToolWindowContent(toolWindow, project, parsedChangelog)
 
       toolWindow.show()
     }


### PR DESCRIPTION
This uses a multiplatform compose markdown renderer for markdown rendering, offering a nicer UI for the whatsnew panel since Studio doesn't seem likely to ever support JCEF.

In the process of this, I also made a playground project where we can test compose UIs like this and project gen without needing to run a whole IDE flow to test, to make it easier to iterate. Now it's as easy as just running the `main` functions in those files.

There are still some features missing from the markdown library like strikethrough, dividers, tables, etc, but the maintainer is responsive and I've been filing issues. This builds a best-effort bridge theme based off of Jewel. In the future we may also consider their in-development impl.

| Light | Dark |
| ----- | ---- |
| <img width="820" alt="Screenshot 2024-04-25 at 2 23 59 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/1361086/50bc7b86-eeec-459d-8b7a-23da4269743f"> | <img width="820" alt="Screenshot 2024-04-25 at 2 24 01 PM" src="https://github.com/slackhq/slack-gradle-plugin/assets/1361086/bfba03b7-2da8-47b9-a8c3-bb7666dae285"> |


<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->