### PR TITLE
Add new flag + logic to relocate project build directories

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackBasePlugin.kt
@@ -42,6 +42,15 @@ internal class SlackBasePlugin @Inject constructor(private val buildFeatures: Bu
   override fun apply(target: Project) {
     val slackProperties = SlackProperties(target)
 
+    if (slackProperties.relocateBuildDir && !target.isSyncing) {
+      // <root-dir>/../<root-dir-name>-out/<project's relative path>
+      val rootDir = target.rootDir
+      val rootDirName = rootDir.name
+      target.layout.buildDirectory.set(
+        rootDir.resolve("../$rootDirName-out/${target.projectDir.toRelativeString(rootDir)}")
+      )
+    }
+
     if (!target.isRootProject) {
       val versionCatalog =
         target.getVersionsCatalogOrNull() ?: error("SGP requires use of version catalogs!")

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -478,6 +478,22 @@ internal constructor(
   public val buildToolsVersionOverride: String? =
     optionalStringProperty("sgp.android.buildToolsVersionOverride")
 
+  /**
+   * Performance optimization to relocate the entire project build directory to a location outside
+   * the IDE's view. This prevents the IDE from tracking these files and improves IDE performance.
+   */
+  public val relocateBuildDir: Boolean = betaFeature("sgp.perf.relocateBuildDir")
+
+  /** Opt-in for beta SGP features. */
+  public val enableBetaFeatures: Boolean = booleanProperty("sgp.beta", defaultValue = false)
+
+  /**
+   * Shorthand helper for checking features that are in beta or falling back to their specific flag.
+   */
+  private fun betaFeature(key: String): Boolean {
+    return enableBetaFeatures || booleanProperty(key, defaultValue = false)
+  }
+
   /* Controls for auto-applied plugins. */
   public val autoApplyTestRetry: Boolean
     get() = booleanProperty("slack.auto-apply.test-retry", defaultValue = true)


### PR DESCRIPTION
We were tipped off by our friends at another company that this helps with IDE performance immensely by completely preventing the IDE from indexing build dirs (which tend to be littered with tons of intermediate files, even if untracked). We want to experiment with this flag and see if it improves things for us too.

We might have some plugins that still hardcode lookups to `build` dirs, but we can iterate from here.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->