### PR TITLE
Fix compose compiler update warning

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/compose/ComposeUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/compose/ComposeUtil.kt
@@ -17,7 +17,6 @@ package slack.gradle.compose
 
 import org.gradle.api.Project
 import org.jetbrains.compose.ComposeExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import slack.gradle.SlackProperties

--- a/slack-plugin/src/main/kotlin/slack/gradle/compose/ComposeUtil.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/compose/ComposeUtil.kt
@@ -78,13 +78,6 @@ internal fun Project.configureComposeCompiler(
         logger.debug(
           "Configuring compose compiler args in ${project.path}:${this@configureKotlinCompilationTask.name}"
         )
-        if (this is KotlinJvmCompilerOptions) {
-          freeCompilerArgs.addAll(
-            "-Xskip-prerelease-check",
-            "-P",
-            "$COMPOSE_COMPILER_OPTION_PREFIX:suppressKotlinVersionCompatibilityCheck=$kotlinVersion",
-          )
-        }
       }
     }
   } else {


### PR DESCRIPTION
When update compose compiler plugin to 1.5.14, we're running into this error:
```
w:  `suppressKotlinVersionCompatibilityCheck` is set to the same version of Kotlin that the Compose Compiler was already expecting (Kotlin 1.9.24), and thus has no effect and should be removed.
```
PR removes the `suppressKotlinVersionCompatibilityCheck` to fix the warning. I tested by building the app locally
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->