### PR TITLE
Update codeowners to support new config format

### DIFF
--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
@@ -19,7 +19,6 @@ import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import com.intellij.openapi.diagnostic.logger
 import com.slack.sgp.intellij.codeowners.model.CodeOwnersFile
-import com.slack.sgp.intellij.codeowners.model.Path
 import java.io.File
 import java.io.FileNotFoundException
 import kotlin.text.Charsets.UTF_8

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
@@ -43,7 +43,7 @@ class CodeOwnerRepository(codeOwnerFileFetcher: CodeOwnerFileFetcher) {
         val codeOwnershipLineMap =
           codeOwnershipFile
             .readLines()
-            .mapIndexed { index, line -> line.trimStart(' ', '-') to index }
+            .mapIndexed { index, line -> line.trimStart(' ', '-').replace("path: ", "") to index }
             .toMap()
 
         // Marshal yaml

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepository.kt
@@ -19,6 +19,7 @@ import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import com.intellij.openapi.diagnostic.logger
 import com.slack.sgp.intellij.codeowners.model.CodeOwnersFile
+import com.slack.sgp.intellij.codeowners.model.Path
 import java.io.File
 import java.io.FileNotFoundException
 import kotlin.text.Charsets.UTF_8
@@ -56,7 +57,7 @@ class CodeOwnerRepository(codeOwnerFileFetcher: CodeOwnerFileFetcher) {
             .map { codeOwner ->
               codeOwner.paths.map { path ->
                 // Lookup line in ownership file (0 if not found) and construct CodeOwnerInfo
-                CodeOwnerInfo(codeOwner.name, path, codeOwnershipLineMap[path] ?: 0)
+                CodeOwnerInfo(codeOwner.name, path.path, codeOwnershipLineMap[path.path] ?: 0)
               }
             }
             .flatten()

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
@@ -15,46 +15,70 @@
  */
 package com.slack.sgp.intellij.codeowners.model
 
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import com.charleskorn.kaml.YamlInput
+import com.charleskorn.kaml.YamlMap
+import com.charleskorn.kaml.YamlScalar
+import kotlinx.serialization.*
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 
-object PathDeserializer : KSerializer<Path> {
-    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Path") {
-        element("path", String.serializer().descriptor)
-        element("notify", Boolean.serializer().descriptor)
+object StringOrObjectSerializer : KSerializer<Path> {
+    private val stringDescriptor = String.serializer().descriptor
+    private val objectDescriptor = buildClassSerialDescriptor("Path") {
+        element<String>("path")
+        element<Boolean>("notify", isOptional = true)
     }
 
-    @OptIn(ExperimentalSerializationApi::class)
+    @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
+    override val descriptor: SerialDescriptor = buildSerialDescriptor(
+        StringOrObjectSerializer::class.java.name,
+        SerialKind.CONTEXTUAL
+    ) {
+        element("object", objectDescriptor)
+        element("string", stringDescriptor)
+    }
+
     override fun deserialize(decoder: Decoder): Path {
-        return decoder.decodeStructure(descriptor) {
-            var path = ""
-            var notify = true
+        val tree = decoder.beginStructure(descriptor) as YamlInput
+        val result = when (tree.node) {
+            is YamlScalar -> beginAndDecodeString(tree)
+            is YamlMap -> beginAndDecodeObject(tree)
+            else -> error("Unexpected type, path should be string or map")
+        }
+        return result
+    }
+
+    private fun beginAndDecodeString(decoder: YamlInput): Path {
+        val input = decoder.beginStructure(stringDescriptor) as YamlInput
+        val path = input.decodeString().also { decoder.endStructure(descriptor) }
+        return Path(path, true)
+    }
+
+    private fun beginAndDecodeObject(decoder: YamlInput): Path {
+        var path = ""
+        var notify = true
+        decoder.decodeStructure(objectDescriptor) {
             while (true) {
-                when (val index = decodeElementIndex(descriptor)) {
-                    0 -> path = decodeStringElement(descriptor, 0)
-                    1 -> notify = decodeBooleanElement(descriptor, 1)
+                when (val index = decodeElementIndex(objectDescriptor)) {
+                    0 -> path = decodeStringElement(objectDescriptor, 0)
+                    1 -> notify = decodeBooleanElement(objectDescriptor, 1)
                     CompositeDecoder.DECODE_DONE -> break
                     else -> error("Unexpected index: $index")
                 }
             }
-            Path(path, notify)
         }
+        return Path(path, notify)
     }
 
-    @OptIn(ExperimentalSerializationApi::class)
     override fun serialize(encoder: Encoder, value: Path) {
-        encoder.encodeStructure(descriptor) {
-            encodeStringElement(descriptor, 0, value.path)
-        }
+        TODO("Not yet implemented")
     }
+
 }
 
-@Serializable(with = PathDeserializer::class)
+@Serializable
 data class Path(val path: String, val notify: Boolean?)
 
 @Serializable
-data class CodeOwner(val name: String, val paths: List<@Serializable(with = PathDeserializer::class)Path>)
+data class CodeOwner(val name: String, val paths: List<@Serializable(with = StringOrObjectSerializer::class) Path>)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
@@ -15,70 +15,7 @@
  */
 package com.slack.sgp.intellij.codeowners.model
 
-import com.charleskorn.kaml.YamlInput
-import com.charleskorn.kaml.YamlMap
-import com.charleskorn.kaml.YamlScalar
-import kotlinx.serialization.*
-import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.descriptors.*
-import kotlinx.serialization.encoding.*
-
-object StringOrObjectSerializer : KSerializer<Path> {
-    private val stringDescriptor = String.serializer().descriptor
-    private val objectDescriptor = buildClassSerialDescriptor("Path") {
-        element<String>("path")
-        element<Boolean>("notify", isOptional = true)
-    }
-
-    @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
-    override val descriptor: SerialDescriptor = buildSerialDescriptor(
-        StringOrObjectSerializer::class.java.name,
-        SerialKind.CONTEXTUAL
-    ) {
-        element("object", objectDescriptor)
-        element("string", stringDescriptor)
-    }
-
-    override fun deserialize(decoder: Decoder): Path {
-        val tree = decoder.beginStructure(descriptor) as YamlInput
-        val result = when (tree.node) {
-            is YamlScalar -> beginAndDecodeString(tree)
-            is YamlMap -> beginAndDecodeObject(tree)
-            else -> error("Unexpected type, path should be string or map")
-        }
-        return result
-    }
-
-    private fun beginAndDecodeString(decoder: YamlInput): Path {
-        val input = decoder.beginStructure(stringDescriptor) as YamlInput
-        val path = input.decodeString().also { decoder.endStructure(descriptor) }
-        return Path(path, true)
-    }
-
-    private fun beginAndDecodeObject(decoder: YamlInput): Path {
-        var path = ""
-        var notify = true
-        decoder.decodeStructure(objectDescriptor) {
-            while (true) {
-                when (val index = decodeElementIndex(objectDescriptor)) {
-                    0 -> path = decodeStringElement(objectDescriptor, 0)
-                    1 -> notify = decodeBooleanElement(objectDescriptor, 1)
-                    CompositeDecoder.DECODE_DONE -> break
-                    else -> error("Unexpected index: $index")
-                }
-            }
-        }
-        return Path(path, notify)
-    }
-
-    override fun serialize(encoder: Encoder, value: Path) {
-        TODO("Not yet implemented")
-    }
-
-}
-
-@Serializable
-data class Path(val path: String, val notify: Boolean?)
+import kotlinx.serialization.Serializable
 
 @Serializable
 data class CodeOwner(val name: String, val paths: List<@Serializable(with = StringOrObjectSerializer::class) Path>)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
@@ -17,4 +17,6 @@ package com.slack.sgp.intellij.codeowners.model
 
 import kotlinx.serialization.Serializable
 
-@Serializable data class CodeOwner(val name: String, val paths: List<String>)
+@Serializable data class CodeOwner(val name: String, @Serializable val paths: List<Path>)
+
+@Serializable data class Path(val path: String)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
@@ -18,4 +18,7 @@ package com.slack.sgp.intellij.codeowners.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CodeOwner(val name: String, val paths: List<@Serializable(with = PathObjectSerializer::class) Path>)
+data class CodeOwner(
+  val name: String,
+  val paths: List<@Serializable(with = PathObjectSerializer::class) Path>,
+)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/CodeOwner.kt
@@ -18,4 +18,4 @@ package com.slack.sgp.intellij.codeowners.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CodeOwner(val name: String, val paths: List<@Serializable(with = StringOrObjectSerializer::class) Path>)
+data class CodeOwner(val name: String, val paths: List<@Serializable(with = PathObjectSerializer::class) Path>)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/Path.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/Path.kt
@@ -1,6 +1,20 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.slack.sgp.intellij.codeowners.model
 
 import kotlinx.serialization.Serializable
 
-@Serializable
-data class Path(val path: String, val notify: Boolean?)
+@Serializable data class Path(val path: String, val notify: Boolean?)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/Path.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/Path.kt
@@ -1,0 +1,6 @@
+package com.slack.sgp.intellij.codeowners.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Path(val path: String, val notify: Boolean?)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/PathObjectSerializer.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/PathObjectSerializer.kt
@@ -13,7 +13,19 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.decodeStructure
 
-object StringOrObjectSerializer : KSerializer<Path> {
+/**
+ * A "path" in the config = can be of two types:
+ * Scalar: - my/path/something.kt
+ * Map: - path: my/other/path/something.kt
+ *      - notify: false
+ *
+ * This serializer handles both variations and returns an object of type Path like so:
+ * For a Scalar: Path("my/path/something.kt" notify=true)
+ * For a Map: Path("my/path/something.kt" notify)
+ *
+ * Note: We do not need a serializer at the moment.
+ */
+object PathObjectSerializer : KSerializer<Path> {
     private val stringDescriptor = String.serializer().descriptor
     private val objectDescriptor = buildClassSerialDescriptor("Path") {
         element<String>("path")
@@ -22,7 +34,7 @@ object StringOrObjectSerializer : KSerializer<Path> {
 
     @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
     override val descriptor: SerialDescriptor = buildSerialDescriptor(
-        StringOrObjectSerializer::class.java.name,
+        PathObjectSerializer::class.java.name,
         SerialKind.CONTEXTUAL
     ) {
         element("object", objectDescriptor)

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/PathObjectSerializer.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/PathObjectSerializer.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.slack.sgp.intellij.codeowners.model
 
 import com.charleskorn.kaml.YamlInput
@@ -14,67 +29,64 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.decodeStructure
 
 /**
- * A "path" in the config = can be of two types:
- * Scalar: - my/path/something.kt
- * Map: - path: my/other/path/something.kt
- *      - notify: false
+ * A "path" in the config = can be of two types: Scalar: - my/path/something.kt Map: - path:
+ * my/other/path/something.kt
+ * - notify: false
  *
- * This serializer handles both variations and returns an object of type Path like so:
- * For a Scalar: Path("my/path/something.kt" notify=true)
- * For a Map: Path("my/path/something.kt" notify)
+ * This serializer handles both variations and returns an object of type Path like so: For a Scalar:
+ * Path("my/path/something.kt" notify=true) For a Map: Path("my/path/something.kt" notify)
  *
  * Note: We do not need a serializer at the moment.
  */
 object PathObjectSerializer : KSerializer<Path> {
-    private val stringDescriptor = String.serializer().descriptor
-    private val objectDescriptor = buildClassSerialDescriptor("Path") {
-        element<String>("path")
-        element<Boolean>("notify", isOptional = true)
+  private val stringDescriptor = String.serializer().descriptor
+  private val objectDescriptor =
+    buildClassSerialDescriptor("Path") {
+      element<String>("path")
+      element<Boolean>("notify", isOptional = true)
     }
 
-    @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
-    override val descriptor: SerialDescriptor = buildSerialDescriptor(
-        PathObjectSerializer::class.java.name,
-        SerialKind.CONTEXTUAL
-    ) {
-        element("object", objectDescriptor)
-        element("string", stringDescriptor)
+  @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
+  override val descriptor: SerialDescriptor =
+    buildSerialDescriptor(PathObjectSerializer::class.java.name, SerialKind.CONTEXTUAL) {
+      element("object", objectDescriptor)
+      element("string", stringDescriptor)
     }
 
-    override fun deserialize(decoder: Decoder): Path {
-        val tree = decoder.beginStructure(descriptor) as YamlInput
-        val result = when (tree.node) {
-            is YamlScalar -> beginAndDecodeString(tree)
-            is YamlMap -> beginAndDecodeObject(tree)
-            else -> error("Unexpected type, path should be string or map")
+  override fun deserialize(decoder: Decoder): Path {
+    val tree = decoder.beginStructure(descriptor) as YamlInput
+    val result =
+      when (tree.node) {
+        is YamlScalar -> beginAndDecodeString(tree)
+        is YamlMap -> beginAndDecodeObject(tree)
+        else -> error("Unexpected type, path should be string or map")
+      }
+    return result
+  }
+
+  private fun beginAndDecodeString(decoder: YamlInput): Path {
+    val input = decoder.beginStructure(stringDescriptor) as YamlInput
+    val path = input.decodeString().also { decoder.endStructure(descriptor) }
+    return Path(path, true)
+  }
+
+  private fun beginAndDecodeObject(decoder: YamlInput): Path {
+    var path = ""
+    var notify = true
+    decoder.decodeStructure(objectDescriptor) {
+      while (true) {
+        when (val index = decodeElementIndex(objectDescriptor)) {
+          0 -> path = decodeStringElement(objectDescriptor, 0)
+          1 -> notify = decodeBooleanElement(objectDescriptor, 1)
+          CompositeDecoder.DECODE_DONE -> break
+          else -> error("Unexpected index: $index")
         }
-        return result
+      }
     }
+    return Path(path, notify)
+  }
 
-    private fun beginAndDecodeString(decoder: YamlInput): Path {
-        val input = decoder.beginStructure(stringDescriptor) as YamlInput
-        val path = input.decodeString().also { decoder.endStructure(descriptor) }
-        return Path(path, true)
-    }
-
-    private fun beginAndDecodeObject(decoder: YamlInput): Path {
-        var path = ""
-        var notify = true
-        decoder.decodeStructure(objectDescriptor) {
-            while (true) {
-                when (val index = decodeElementIndex(objectDescriptor)) {
-                    0 -> path = decodeStringElement(objectDescriptor, 0)
-                    1 -> notify = decodeBooleanElement(objectDescriptor, 1)
-                    CompositeDecoder.DECODE_DONE -> break
-                    else -> error("Unexpected index: $index")
-                }
-            }
-        }
-        return Path(path, notify)
-    }
-
-    override fun serialize(encoder: Encoder, value: Path) {
-        TODO("Not yet implemented")
-    }
-
+  override fun serialize(encoder: Encoder, value: Path) {
+    TODO("Not yet implemented")
+  }
 }

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/StringOrObjectSerializer.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/codeowners/model/StringOrObjectSerializer.kt
@@ -1,0 +1,68 @@
+package com.slack.sgp.intellij.codeowners.model
+
+import com.charleskorn.kaml.YamlInput
+import com.charleskorn.kaml.YamlMap
+import com.charleskorn.kaml.YamlScalar
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+
+object StringOrObjectSerializer : KSerializer<Path> {
+    private val stringDescriptor = String.serializer().descriptor
+    private val objectDescriptor = buildClassSerialDescriptor("Path") {
+        element<String>("path")
+        element<Boolean>("notify", isOptional = true)
+    }
+
+    @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
+    override val descriptor: SerialDescriptor = buildSerialDescriptor(
+        StringOrObjectSerializer::class.java.name,
+        SerialKind.CONTEXTUAL
+    ) {
+        element("object", objectDescriptor)
+        element("string", stringDescriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): Path {
+        val tree = decoder.beginStructure(descriptor) as YamlInput
+        val result = when (tree.node) {
+            is YamlScalar -> beginAndDecodeString(tree)
+            is YamlMap -> beginAndDecodeObject(tree)
+            else -> error("Unexpected type, path should be string or map")
+        }
+        return result
+    }
+
+    private fun beginAndDecodeString(decoder: YamlInput): Path {
+        val input = decoder.beginStructure(stringDescriptor) as YamlInput
+        val path = input.decodeString().also { decoder.endStructure(descriptor) }
+        return Path(path, true)
+    }
+
+    private fun beginAndDecodeObject(decoder: YamlInput): Path {
+        var path = ""
+        var notify = true
+        decoder.decodeStructure(objectDescriptor) {
+            while (true) {
+                when (val index = decodeElementIndex(objectDescriptor)) {
+                    0 -> path = decodeStringElement(objectDescriptor, 0)
+                    1 -> notify = decodeBooleanElement(objectDescriptor, 1)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index: $index")
+                }
+            }
+        }
+        return Path(path, notify)
+    }
+
+    override fun serialize(encoder: Encoder, value: Path) {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepositoryTest.kt
+++ b/skate-plugin/src/test/kotlin/com/slack/sgp/intellij/codeowners/CodeOwnerRepositoryTest.kt
@@ -40,7 +40,7 @@ class CodeOwnerRepositoryTest : BasePlatformTestCase() {
     val result = underTest.getCodeOwnership("app/folder2/subfolder/foo.kt")
     assertThat(result.size).isEqualTo(1)
     assertThat(result[0].packagePattern).isEqualTo(FOLDER_2_PATTERN)
-    assertThat(result[0].codeOwnerLineNumber).isEqualTo(14)
+    assertThat(result[0].codeOwnerLineNumber).isEqualTo(15)
     assertThat(result[0].team).isEqualTo(TEAM_1)
   }
 
@@ -49,10 +49,10 @@ class CodeOwnerRepositoryTest : BasePlatformTestCase() {
     val result = underTest.getCodeOwnership("app/folder3/subfolder/foo.kt")
     assertThat(result.size).isEqualTo(2)
     assertThat(result[0].packagePattern).isEqualTo(FOLDER_3_GRANULAR_PATTERN)
-    assertThat(result[0].codeOwnerLineNumber).isEqualTo(15)
+    assertThat(result[0].codeOwnerLineNumber).isEqualTo(16)
     assertThat(result[0].team).isEqualTo(TEAM_1)
     assertThat(result[1].packagePattern).isEqualTo(FOLDER_3_PATTERN)
-    assertThat(result[1].codeOwnerLineNumber).isEqualTo(19)
+    assertThat(result[1].codeOwnerLineNumber).isEqualTo(20)
     assertThat(result[1].team).isEqualTo(TEAM_2)
   }
 

--- a/skate-plugin/src/test/resources/test-code-ownership.yaml
+++ b/skate-plugin/src/test/resources/test-code-ownership.yaml
@@ -11,12 +11,12 @@ included_extensions:
 ownership:
   - name: Team 1
     paths:
-      - path: app/folder1/.*
-        notify: false
+      - app/folder1/.*
+      - app/folder5/.*
       - app/folder2/.*
-      - path: app/folder3/subfolder/.*
+      - app/folder3/subfolder/.*
     bogusProp: Foo
   - name: Team 2
     paths:
-      - path: app/folder3/.*
+      - app/folder3/.*
     bogusProp: Bar

--- a/skate-plugin/src/test/resources/test-code-ownership.yaml
+++ b/skate-plugin/src/test/resources/test-code-ownership.yaml
@@ -11,8 +11,8 @@ included_extensions:
 ownership:
   - name: Team 1
     paths:
-      - app/folder1/.*
-      - app/folder5/.*
+      - path: app/folder1/.*
+        notify: false
       - app/folder2/.*
       - app/folder3/subfolder/.*
     bogusProp: Foo

--- a/skate-plugin/src/test/resources/test-code-ownership.yaml
+++ b/skate-plugin/src/test/resources/test-code-ownership.yaml
@@ -13,7 +13,7 @@ ownership:
     paths:
       - path: app/folder1/.*
         notify: false
-      - path: app/folder2/.*
+      - app/folder2/.*
       - path: app/folder3/subfolder/.*
     bogusProp: Foo
   - name: Team 2

--- a/skate-plugin/src/test/resources/test-code-ownership.yaml
+++ b/skate-plugin/src/test/resources/test-code-ownership.yaml
@@ -11,11 +11,11 @@ included_extensions:
 ownership:
   - name: Team 1
     paths:
-      - app/folder1/.*
-      - app/folder2/.*
-      - app/folder3/subfolder/.*
+      - path: app/folder1/.*
+      - path: app/folder2/.*
+      - path: app/folder3/subfolder/.*
     bogusProp: Foo
   - name: Team 2
     paths:
-      - app/folder3/.*
+      - path: app/folder3/.*
     bogusProp: Bar

--- a/skate-plugin/src/test/resources/test-code-ownership.yaml
+++ b/skate-plugin/src/test/resources/test-code-ownership.yaml
@@ -12,6 +12,7 @@ ownership:
   - name: Team 1
     paths:
       - path: app/folder1/.*
+        notify: false
       - path: app/folder2/.*
       - path: app/folder3/subfolder/.*
     bogusProp: Foo


### PR DESCRIPTION
The `path` objects for the config are changing, this PR introduces support for the new format.

Currently `paths` looks as follows:
```
    paths:
      - app/folder1/.*
      - app/folder2/.*
      - app/folder3/subfolder/.*
```

We are adding a new `notify` flag which means that a `path` can be either a string (i.e. previous format) or an object (new format:
```
    paths:
      - path: app/folder1/.*
        notify: false
      - app/folder2/.*
      - app/folder3/subfolder/.*
```

This PR introduces a custom deserializer and a Path object to be able to handle the above. The changes are backwards compatible so old configs will still work as usual.

Testing:
- The relevant tests were updated to cover the new config
- I was able to confirm with a local build of SKATE that the new format (and the old format) are working okay