### PR TITLE
Remove Kover Workaround for `0.7.1`

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
+++ b/slack-plugin/src/main/kotlin/slack/unittest/UnitTests.kt
@@ -100,11 +100,7 @@ internal object UnitTests {
     if (
       slackProperties.ciUnitTestEnableKover && project.path != slackProperties.platformProjectPath
     ) {
-      project.afterEvaluate {
-        // Remove afterEvaluate
-        // after https://github.com/Kotlin/kotlinx-kover/issues/362 is fixed
-        project.pluginManager.apply("org.jetbrains.kotlinx.kover")
-      }
+      project.pluginManager.apply("org.jetbrains.kotlinx.kover")
     }
 
     val unitTestsPublisher: Publisher<SgpArtifact>? =


### PR DESCRIPTION
####
Description:
- I am working on updating our _kover_ version to `0.8.1` in the `slack-android-ng` repo and this workaround is no longer needed and actually fails the command if it's present.
- So removing this and will include this in a future release once the PR is merged to switch over in `slack-android-ng`
- The original issue is now fixed and merged: https://github.com/Kotlin/kotlinx-kover/issues/362