### PR TITLE
Turn off xml report generation for lint task

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/lint/LintTasks.kt
@@ -273,7 +273,7 @@ internal object LintTasks {
       checkTestSources = slackProperties.lintCheckTestSources
 
       textReport = true
-      xmlReport = true
+      xmlReport = false
       htmlReport = true
       sarifReport = true
 


### PR DESCRIPTION
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->
#### Description:
- Turning off the `XML` report generation for the Lint task since we don't currently use the XML reports for anything