### PR TITLE
Add a kapt language version override

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -19,6 +19,7 @@ import java.io.File
 import java.util.Locale
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import slack.gradle.anvil.AnvilMode
 import slack.gradle.artifacts.SgpArtifact
 import slack.gradle.util.PropertyResolver
@@ -616,6 +617,13 @@ internal constructor(
     get() =
       resolver.stringValue("sgp.anvil.mode", defaultValue = AnvilMode.K1_EMBEDDED.name).let {
         AnvilMode.valueOf(it.uppercase(Locale.US))
+      }
+
+  /** Overrides the kotlin language version if present. */
+  public val kaptLanguageVersion: Provider<KotlinVersion>
+    get() =
+      resolver.optionalStringProvider("sgp.kapt.languageVersion").map {
+        KotlinVersion.fromVersion(it)
       }
 
   /** Defines a required vendor for JDK toolchains. */


### PR DESCRIPTION
This allows us to force it to a lower version if needed for K2 testing

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->