### PR TITLE
Update jewel to 0.23.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ dokka = "1.9.20"
 errorproneGradle = "3.0.1"
 jdk = "22"
 jvmTarget = "17"
-jewel = "0.15.2.2"
+jewel = "0.23.0"
 jna = "5.14.0"
 kaml = "0.61.0"
 kotlin = "2.0.20"
@@ -104,8 +104,8 @@ kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin
 kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
-jewel-bridge232 = { module = "org.jetbrains.jewel:jewel-ide-laf-bridge-232", version.ref = "jewel" }
-jewel-standalone = { module = "org.jetbrains.jewel:jewel-int-ui-standalone", version = "0.15.2" }
+jewel-bridge = { module = "org.jetbrains.jewel:jewel-ide-laf-bridge-241", version.ref = "jewel" }
+jewel-standalone = { module = "org.jetbrains.jewel:jewel-int-ui-standalone-241", version.ref = "jewel" }
 jgrapht = "org.jgrapht:jgrapht-core:1.5.2"
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,8 @@ agpAlpha = "8.5.2"
 anvil = "2.5.0-beta11"
 bugsnagGradle = "8.1.0"
 circuit = "0.23.1"
-compose-jb = "1.6.11"
+compose-jb = "1.7.0-alpha03"
+compose-jb-stable = "1.6.11"
 coroutines = "1.8.1"
 dependencyAnalysisPlugin = "1.33.0"
 detekt = "1.23.6"
@@ -77,7 +78,7 @@ develocity-agent-adapters = "com.gradle:develocity-gradle-plugin-adapters:1.0.3"
 gradleLints = "androidx.lint:lint-gradle:1.0.0-alpha01"
 gradlePlugins-anvil = { module = "com.squareup.anvil:gradle-plugin", version.ref = "anvil" }
 gradlePlugins-bugsnag = { module = "com.bugsnag:bugsnag-android-gradle-plugin", version.ref = "bugsnagGradle" }
-gradlePlugins-compose = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-jb" }
+gradlePlugins-compose = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-jb-stable" }
 gradlePlugins-composeCompiler = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 gradlePlugins-dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysisPlugin" }
 gradlePlugins-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }

--- a/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
+++ b/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/MarkdownPlayground.kt
@@ -34,7 +34,7 @@ import slack.tooling.markdown.ui.MarkdownContent
 fun main() = singleWindowApplication {
   var isDark by remember { mutableStateOf(false) }
   IntUiTheme(isDark) {
-    Column(Modifier.background(JewelTheme.globalColors.paneBackground)) {
+    Column(Modifier.background(JewelTheme.globalColors.panelBackground)) {
       DefaultButton(modifier = Modifier.padding(16.dp), onClick = { isDark = !isDark }) {
         Text("Toggle dark mode")
       }

--- a/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/ProjectGenPlayground.kt
+++ b/skate-plugin/compose-playground/src/jvmMain/kotlin/slack/tooling/compose/playground/ProjectGenPlayground.kt
@@ -35,7 +35,7 @@ import slack.tooling.projectgen.ProjectGenUi.ProjectGenApp
 fun main() = singleWindowApplication {
   var isDark by remember { mutableStateOf(false) }
   IntUiTheme(isDark) {
-    Column(Modifier.background(JewelTheme.globalColors.paneBackground)) {
+    Column(Modifier.background(JewelTheme.globalColors.panelBackground)) {
       DefaultButton(modifier = Modifier.padding(16.dp), onClick = { isDark = !isDark }) {
         Text("Toggle dark mode")
       }

--- a/skate-plugin/project-gen/build.gradle.kts
+++ b/skate-plugin/project-gen/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
         implementation(compose.ui)
         implementation(libs.circuit.foundation)
         implementation(libs.compose.markdown)
-        implementation(libs.jewel.bridge232)
+        implementation(libs.jewel.bridge)
         implementation(libs.kotlin.poet)
         implementation(libs.markdown)
       }

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/markdown/ui/MarkdownPanel.kt
@@ -131,7 +131,7 @@ private fun jewelMarkdownColor(
   dividerColor: Color = JewelTheme.globalColors.borders.normal,
 ): MarkdownColors {
   val (codeText, codeBackground, inlineCodeText, inlineCodeBackground) =
-    rememberCodeBackground(JewelTheme.globalColors.paneBackground, text)
+    rememberCodeBackground(JewelTheme.globalColors.panelBackground, text)
   return DefaultMarkdownColors(
     text = text,
     codeText = codeText,

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/PrefixTransformation.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/PrefixTransformation.kt
@@ -17,9 +17,10 @@ package slack.tooling.projectgen
 
 import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.insert
 
 class PrefixTransformation(private val prefix: String) : OutputTransformation {
   override fun TextFieldBuffer.transformOutput() {
-    prefix + originalText
+    insert(0, prefix)
   }
 }

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/PrefixTransformation.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/PrefixTransformation.kt
@@ -15,33 +15,11 @@
  */
 package slack.tooling.projectgen
 
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.input.OffsetMapping
-import androidx.compose.ui.text.input.TransformedText
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
 
-class PrefixTransformation(val prefix: String) : VisualTransformation {
-  override fun filter(text: AnnotatedString): TransformedText {
-    return prefixFilter(text, prefix)
+class PrefixTransformation(private val prefix: String) : OutputTransformation {
+  override fun TextFieldBuffer.transformOutput() {
+    prefix + originalText
   }
-}
-
-private fun prefixFilter(number: AnnotatedString, prefix: String): TransformedText {
-
-  val out = prefix + number.text
-  val prefixOffset = prefix.length
-
-  val numberOffsetTranslator =
-    object : OffsetMapping {
-      override fun originalToTransformed(offset: Int): Int {
-        return offset + prefixOffset
-      }
-
-      override fun transformedToOriginal(offset: Int): Int {
-        if (offset <= prefixOffset - 1) return prefixOffset
-        return offset - prefixOffset
-      }
-    }
-
-  return TransformedText(AnnotatedString(out), numberOffsetTranslator)
 }

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/ProjectGenPresenter.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/ProjectGenPresenter.kt
@@ -187,7 +187,8 @@ internal class ProjectGenPresenter(
             add("view-binding")
           }
         },
-      androidResourcePrefix = androidResourcePrefix.value.takeIf { androidResources.isChecked },
+      androidResourcePrefix =
+        androidResourcePrefix.value.text.takeIf { androidResources.isChecked },
       dagger = dagger.isChecked,
       daggerFeatures =
         buildSet {
@@ -209,7 +210,7 @@ internal class ProjectGenPresenter(
     packageName: String,
     android: Boolean,
     androidFeatures: Set<String>,
-    androidResourcePrefix: String?,
+    androidResourcePrefix: CharSequence?,
     dagger: Boolean,
     daggerFeatures: Set<String>,
     robolectric: Boolean,

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/ProjectGenUi.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/ProjectGenUi.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposePanel
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -118,7 +117,7 @@ internal fun ProjectGen(state: ProjectGenScreen.State, modifier: Modifier = Modi
     )
   }
 
-  Box(modifier.fillMaxSize().background(JewelTheme.globalColors.paneBackground)) {
+  Box(modifier.fillMaxSize().background(JewelTheme.globalColors.panelBackground)) {
     val listState = rememberLazyListState()
     Column(Modifier.padding(16.dp)) {
       LazyColumn(
@@ -133,7 +132,7 @@ internal fun ProjectGen(state: ProjectGenScreen.State, modifier: Modifier = Modi
               Divider(Orientation.Horizontal)
             }
             is SectionElement -> {
-              Column(Modifier.animateItemPlacement()) {
+              Column(Modifier.animateItem()) {
                 Text(element.title, style = Typography.h1TextStyle())
                 Text(element.description)
               }
@@ -143,27 +142,23 @@ internal fun ProjectGen(state: ProjectGenScreen.State, modifier: Modifier = Modi
                 element.name,
                 element.hint,
                 element.isChecked,
-                modifier = Modifier.animateItemPlacement(),
+                modifier = Modifier.animateItem(),
                 indent = (element.indentLevel * INDENT_SIZE).dp,
                 onEnabledChange = { element.isChecked = it },
               )
             }
             is TextElement -> {
               Column(
-                Modifier.padding(start = (element.indentLevel * INDENT_SIZE).dp)
-                  .animateItemPlacement()
+                Modifier.padding(start = (element.indentLevel * INDENT_SIZE).dp).animateItem()
               ) {
                 Text(text = element.label, style = Typography.h4TextStyle())
                 Spacer(Modifier.height(4.dp))
                 TextField(
-                  value = element.value,
-                  onValueChange = { newValue -> element.value = newValue },
+                  state = element.value,
                   modifier = Modifier.fillMaxWidth(),
                   readOnly = element.readOnly,
                   enabled = element.enabled,
-                  visualTransformation =
-                    element.prefixTransformation?.let(::PrefixTransformation)
-                      ?: VisualTransformation.None,
+                  outputTransformation = element.prefixTransformation?.let(::PrefixTransformation),
                   outline = if (element.isValid) Outline.None else Outline.Error,
                 )
                 element.description?.let {
@@ -177,7 +172,7 @@ internal fun ProjectGen(state: ProjectGenScreen.State, modifier: Modifier = Modi
       }
       Divider(Orientation.Horizontal)
       Box(
-        Modifier.background(JewelTheme.globalColors.paneBackground)
+        Modifier.background(JewelTheme.globalColors.panelBackground)
           .fillMaxWidth()
           .padding(top = 16.dp, start = 16.dp, end = 16.dp),
         contentAlignment = Alignment.CenterEnd,
@@ -239,7 +234,7 @@ private fun StatusDialog(
     Box(
       Modifier.width(600.dp)
         .height(100.dp)
-        .background(JewelTheme.globalColors.paneBackground)
+        .background(JewelTheme.globalColors.panelBackground)
         .border(1.5.dp, JewelTheme.globalColors.borders.disabled, RoundedCornerShape(8.dp))
     ) {
       Column(

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/UiElement.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/UiElement.kt
@@ -15,6 +15,7 @@
  */
 package slack.tooling.projectgen
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
@@ -68,17 +69,17 @@ internal class TextElement(
   private val dependentElements: List<CheckboxElement> = emptyList(),
   val validationRegex: Regex? = null,
 ) : UiElement {
-  var value by mutableStateOf(initialValue)
+  val value = TextFieldState(initialValue)
 
   val enabled by derivedStateOf { !readOnly && dependentElements.all { it.isChecked } }
 
   val isValid by derivedStateOf {
-    validationRegex?.let { value.isNotBlank() && value.matches(it) } != false
+    validationRegex?.let { value.text.isNotBlank() && value.text.matches(it) } != false
   }
 
   override fun reset() {
-    value = initialValue
     isVisible = initialVisibility
+    value.edit { replace(0, length, initialValue) }
   }
 
   override var isVisible: Boolean by mutableStateOf(initialVisibility)

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/models.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/projectgen/models.kt
@@ -186,7 +186,7 @@ internal interface DependenciesVisitor {
 }
 
 internal data class AndroidLibraryFeature(
-  val resourcesPrefix: String?,
+  val resourcesPrefix: CharSequence?,
   val viewBindingEnabled: Boolean,
   val androidTest: Boolean,
   val packageName: String,


### PR DESCRIPTION
The latest stable Android Studio is now based on intellij 2024.1, so we can move up to a newer Jewel version. This also moves Skate to use the latest compose-multiplatform alphas (but still only compiles SGP against the latest stable gradle plugin).

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->