### PR TITLE
Skate AI Initial Chat User Text Field and Window

### DIFF
--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatPanel.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatPanel.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.tooling.aibot
+
+import androidx.compose.ui.awt.ComposePanel
+import java.awt.Dimension
+import javax.swing.JComponent
+import slack.tooling.projectgen.SlackDesktopTheme
+
+object ChatPanel {
+  fun createPanel(): JComponent {
+    return ComposePanel().apply {
+      preferredSize = Dimension(400, 600)
+      setContent { SlackDesktopTheme { ChatWindow() } }
+    }
+  }
+}

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
@@ -115,5 +115,5 @@ fun ConversationField(modifier: Modifier = Modifier) {
 }
 
 fun Modifier.enabled(enabled: Boolean): Modifier {
-  return this.then(if (enabled) Modifier else Modifier.alpha(0.5f))
+  return this.then(if (enabled) Modifier.alpha(1.0f) else Modifier.alpha(0.38f))
 }

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
@@ -61,6 +61,8 @@ fun ConversationField(modifier: Modifier = Modifier) {
     horizontalArrangement = Arrangement.Center,
     verticalAlignment = Alignment.Bottom,
   ) {
+    // user text input. enter sends the message and clears text
+    // shift + enter adds a new line and expands the text field
     TextArea(
       value = textValue,
       onValueChange = { newText -> textValue = newText },
@@ -84,7 +86,6 @@ fun ConversationField(modifier: Modifier = Modifier) {
                 true
               }
             }
-
             else -> false
           }
         },
@@ -93,8 +94,9 @@ fun ConversationField(modifier: Modifier = Modifier) {
       maxLines = Int.MAX_VALUE,
     )
     Column(Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
+      // button will be disabled if there is no text
       IconButton(
-        modifier = Modifier.padding(4.dp).contentAlpha(isTextNotEmpty),
+        modifier = Modifier.padding(4.dp).enabled(isTextNotEmpty),
         onClick = {
           if (isTextNotEmpty) {
             textValue = TextFieldValue()
@@ -112,6 +114,6 @@ fun ConversationField(modifier: Modifier = Modifier) {
   }
 }
 
-fun Modifier.contentAlpha(enabled: Boolean): Modifier {
+fun Modifier.enabled(enabled: Boolean): Modifier {
   return this.then(if (enabled) Modifier else Modifier.alpha(0.5f))
 }

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
@@ -16,17 +16,7 @@
 package slack.tooling.aibot
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -67,9 +57,9 @@ fun ConversationField(modifier: Modifier = Modifier) {
   var textValue by remember { mutableStateOf(TextFieldValue()) }
   val isTextNotEmpty = textValue.text.isNotBlank()
   Row(
-    modifier.fillMaxWidth().height(IntrinsicSize.Min).padding(4.dp),
+    modifier.padding(4.dp).height(IntrinsicSize.Min).padding(4.dp),
     horizontalArrangement = Arrangement.Center,
-    verticalAlignment = Alignment.CenterVertically,
+    verticalAlignment = Alignment.Bottom,
   ) {
     TextArea(
       value = textValue,
@@ -94,6 +84,7 @@ fun ConversationField(modifier: Modifier = Modifier) {
                 true
               }
             }
+
             else -> false
           }
         },
@@ -102,32 +93,25 @@ fun ConversationField(modifier: Modifier = Modifier) {
       maxLines = Int.MAX_VALUE,
     )
     Column(Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
-      Row(verticalAlignment = Alignment.CenterVertically) {
-        IconButton(
-          modifier = Modifier.padding(4.dp).fadeWhenDisabled(isTextNotEmpty),
-          onClick = {
-            if (isTextNotEmpty) {
-              textValue = TextFieldValue()
-            }
-          },
-          enabled = isTextNotEmpty,
-        ) {
-          Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-          ) {
-            Icon(
-              painter = painterResource("/drawable/send.svg"),
-              contentDescription = "Send",
-              modifier = Modifier.size(20.dp),
-            )
+      IconButton(
+        modifier = Modifier.padding(4.dp).contentAlpha(isTextNotEmpty),
+        onClick = {
+          if (isTextNotEmpty) {
+            textValue = TextFieldValue()
           }
-        }
+        },
+        enabled = isTextNotEmpty,
+      ) {
+        Icon(
+          painter = painterResource("/drawable/send.svg"),
+          contentDescription = "Send",
+          modifier = Modifier.size(20.dp),
+        )
       }
     }
   }
 }
 
-fun Modifier.fadeWhenDisabled(enabled: Boolean): Modifier {
+fun Modifier.contentAlpha(enabled: Boolean): Modifier {
   return this.then(if (enabled) Modifier else Modifier.alpha(0.5f))
 }

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
@@ -16,13 +16,41 @@
 package slack.tooling.aibot
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.key.*
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
 import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.TextArea
 
 @Composable
 fun ChatWindow(modifier: Modifier = Modifier) {
@@ -36,5 +64,70 @@ fun ChatWindow(modifier: Modifier = Modifier) {
 
 @Composable
 fun ConversationField(modifier: Modifier = Modifier) {
-  Text("hello world", modifier.padding(8.dp))
+  var textValue by remember { mutableStateOf(TextFieldValue()) }
+  val isTextNotEmpty = textValue.text.isNotBlank()
+  Row(
+    modifier.fillMaxWidth().height(IntrinsicSize.Min).padding(4.dp),
+    horizontalArrangement = Arrangement.Center,
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    TextArea(
+      value = textValue,
+      onValueChange = { newText -> textValue = newText },
+      modifier =
+        Modifier.weight(1f).padding(4.dp).heightIn(min = 56.dp).onPreviewKeyEvent { event ->
+          when {
+            (event.key == Key.Enter || event.key == Key.NumPadEnter) &&
+              event.type == KeyEventType.KeyDown -> {
+              if (event.isShiftPressed) {
+                val newText =
+                  textValue.text.replaceRange(
+                    textValue.selection.start,
+                    textValue.selection.end,
+                    "\n",
+                  )
+                val newSelection = TextRange(textValue.selection.start + 1)
+                textValue = TextFieldValue(newText, newSelection)
+                true
+              } else {
+                textValue = TextFieldValue("")
+                true
+              }
+            }
+            else -> false
+          }
+        },
+      placeholder = { Text("Start your conversation") },
+      keyboardActions = KeyboardActions.Default,
+      maxLines = Int.MAX_VALUE,
+    )
+    Column(Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        IconButton(
+          modifier = Modifier.padding(4.dp).fadeWhenDisabled(isTextNotEmpty),
+          onClick = {
+            if (isTextNotEmpty) {
+              textValue = TextFieldValue()
+            }
+          },
+          enabled = isTextNotEmpty,
+        ) {
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+          ) {
+            Icon(
+              painter = painterResource("/drawable/send.svg"),
+              contentDescription = "Send",
+              modifier = Modifier.size(20.dp),
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+fun Modifier.fadeWhenDisabled(enabled: Boolean): Modifier {
+  return this.then(if (enabled) Modifier else Modifier.alpha(0.5f))
 }

--- a/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
+++ b/skate-plugin/project-gen/src/jvmMain/kotlin/slack/tooling/aibot/ChatWindow.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.tooling.aibot
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.*
+import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Text
+
+@Composable
+fun ChatWindow(modifier: Modifier = Modifier) {
+  Column(
+    modifier = Modifier.fillMaxSize().background(JewelTheme.globalColors.paneBackground),
+    verticalArrangement = Arrangement.Bottom,
+  ) {
+    ConversationField(modifier)
+  }
+}
+
+@Composable
+fun ConversationField(modifier: Modifier = Modifier) {
+  Text("hello world", modifier.padding(8.dp))
+}

--- a/skate-plugin/project-gen/src/jvmMain/resources/drawable/send.svg
+++ b/skate-plugin/project-gen/src/jvmMain/resources/drawable/send.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.5 8H3.5L2.5 14.5L14.5 8L2.5 1.5L3.192 6" stroke="#6C707E" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/aibot/ChatBotToolWindow.kt
+++ b/skate-plugin/src/main/kotlin/com/slack/sgp/intellij/aibot/ChatBotToolWindow.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.slack.sgp.intellij.aibot
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.content.ContentFactory
+import javax.swing.JComponent
+import slack.tooling.aibot.ChatPanel
+
+class ChatBotToolWindow : ToolWindowFactory {
+  override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+    val contentFactory = ContentFactory.getInstance()
+    val content = contentFactory.createContent(createComposePanel(), "", false)
+    toolWindow.contentManager.addContent(content)
+  }
+
+  private fun createComposePanel(): JComponent {
+    return ChatPanel.createPanel()
+  }
+}

--- a/skate-plugin/src/main/resources/META-INF/plugin.xml
+++ b/skate-plugin/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,7 @@
         <externalAnnotator language="kotlin" implementationClass="com.slack.sgp.intellij.featureflags.FeatureFlagAnnotator"/>
         <projectIndexingActivityHistoryListener implementation="com.slack.sgp.intellij.idemetrics.IndexingListener"/>
         <postStartupActivity implementation="com.slack.sgp.intellij.PostStartupActivityExtension"/>
+        <toolWindow factoryClass="com.slack.sgp.intellij.aibot.ChatBotToolWindow" id="DevXPAI" anchor="right" canCloseContents="true" secondary="false" icon="AllIcons.Actions.Lightning" />
     </extensions>
 
     <projectListeners>


### PR DESCRIPTION
This is a continuation of #927, but because of the Jewel update in #937, I ended up running into some hiccups with transitioning the project and migrating to a different version of intellij gradle platform plugin. We reverted it back in #947 and this PR reflects the changes that are compatible with the old Jewel version (which is back on main). 

I have included the functionality for user input, where send button clears text, enter clears text, and shift + enter adds new lines. Users can also add multiple lines. I also added a function where the send button is faded and unselectable until there is text input. In future PRs, I will add the chat conversation as well, and this is just a start.

https://github.com/user-attachments/assets/94971a43-476e-4d67-924c-e012c633bc3c

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->