### PR TITLE
Update -Werror behavior in kotlin and disallow in tests by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 **Unreleased**
 --------------
 
+- Change `slack.allowWarnings` property to `sgp.kotlin.allowWarnings`.
+- Disallow warnings in Kotlin test compilations by default, add `sgp.kotlin.allowWarningsInTests` property to opt-out.
+
 0.19.3
 ------
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/GradleExt.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/GradleExt.kt
@@ -35,6 +35,7 @@ import org.gradle.api.plugins.PluginManager
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.reflect.TypeOf
 import org.gradle.api.tasks.TaskContainer
@@ -282,3 +283,6 @@ internal inline fun <reified T : Task> TaskContainer.registerOrConfigure(
     in names -> named(taskName) as TaskProvider<T>
     else -> register(taskName, T::class.java)
   }.apply { configure { configureAction() } }
+
+/** Returns a provider that is the inverse of this. */
+internal fun Provider<Boolean>.not(): Provider<Boolean> = map { !it }

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -199,9 +199,13 @@ internal constructor(
   public val robolectricIVersion: Int
     get() = intProperty("slack.robolectricIVersion")
 
-  /** Opt out for -Werror, should only be used for prototype projects. */
-  public val allowWarnings: Boolean
-    get() = booleanProperty("slack.allowWarnings")
+  /** Opt out for -Werror. */
+  public val allowWarnings: Provider<Boolean>
+    get() = resolver.booleanProvider("sgp.kotlin.allowWarnings", defaultValue = false)
+
+  /** Opt out for -Werror in tests. */
+  public val allowWarningsInTests: Provider<Boolean>
+    get() = resolver.booleanProvider("sgp.kotlin.allowWarningsInTests", defaultValue = false)
 
   /**
    * Anvil generator projects that should always be included when Anvil is enabled.

--- a/slack-plugin/src/main/kotlin/slack/gradle/kgp/KgpTasks.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/kgp/KgpTasks.kt
@@ -37,8 +37,10 @@ import slack.gradle.SlackTools
 import slack.gradle.asProvider
 import slack.gradle.configure
 import slack.gradle.lint.DetektTasks
+import slack.gradle.not
 import slack.gradle.onFirst
 import slack.gradle.util.configureKotlinCompilationTask
+import slack.gradle.util.setDisallowChanges
 
 /** Common configuration for Kotlin projects. */
 internal object KgpTasks {
@@ -179,11 +181,10 @@ internal object KgpTasks {
             slackProperties.kotlinLanguageVersionOverride.map(KotlinVersion::fromVersion)
           )
         }
-        if (
-          !slackProperties.allowWarnings &&
-            !this@configureKotlinCompilationTask.name.contains("test", ignoreCase = true)
-        ) {
-          allWarningsAsErrors.set(true)
+        if (this@configureKotlinCompilationTask.name.contains("test", ignoreCase = true)) {
+          allWarningsAsErrors.setDisallowChanges(slackProperties.allowWarningsInTests.not())
+        } else {
+          allWarningsAsErrors.setDisallowChanges(slackProperties.allowWarnings.not())
         }
         freeCompilerArgs.addAll(slackProperties.kotlinFreeArgs)
 


### PR DESCRIPTION
Never realized we didn't allow this in tests, this refreshes the logic for this area a bit and adds a test control.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->