### PR TITLE
Add workaround for source information in KGP/AGP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- Add workaround for KGP not applying `sourceInformation` compose options in android projects and default it to true.
+
 0.19.4
 ------
 

--- a/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/SlackProperties.kt
@@ -176,6 +176,31 @@ internal constructor(
       }
 
   /**
+   * Use a workaround for compose-compiler's `includeInformation` option on android projects.
+   *
+   * On android projects, the compose compiler gradle plugin annoyingly no-ops
+   * https://issuetracker.google.com/issues/362780328#comment4
+   */
+  public val composeUseIncludeInformationWorkaround: Boolean
+    get() =
+      resolver.booleanValue("sgp.compose.useIncludeInformationWorkaround", defaultValue = true)
+
+  /**
+   * By default, Compose on android only enables source information in debug variants. This is a bit
+   * silly in large projects because we generally make all libraries single-variant as "release",
+   * and can result in libraries not having source information. Instead, we rely on R8 to strip out
+   * this information in release builds as needed.
+   *
+   * @see <a href="https://issuetracker.google.com/issues/362780328">Upstream issue</a>
+   */
+  public val composeIncludeSourceInformationEverywhereByDefault: Boolean
+    get() =
+      resolver.booleanValue(
+        "sgp.compose.includeSourceInformationEverywhereByDefault",
+        defaultValue = true,
+      )
+
+  /**
    * When this property is present, the "internalRelease" build variant will have an application id
    * of "com.Slack.prototype", instead of "com.Slack.internal".
    *


### PR DESCRIPTION
See the docs on the two new properties for why we're doing this

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->